### PR TITLE
Add Prettier formatting support for interface mixes

### DIFF
--- a/common/changes/@cadl-lang/compiler/format-interface-mixes_2021-11-02-10-06.json
+++ b/common/changes/@cadl-lang/compiler/format-interface-mixes_2021-11-02-10-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add Prettier formatting support for interface mixes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -433,15 +433,19 @@ export function printInterfaceStatement(
   options: CadlPrettierOptions,
   print: PrettierChildPrint
 ) {
+  const node = path.getValue();
   const id = path.call(print, "id");
   const { decorators } = printDecorators(path, options, print, { tryInline: false });
   const generic = printTemplateParameters(path, options, print, "templateParameters");
+  const mixes =
+    node.mixes.length > 0 ? concat(["mixes ", join(", ", path.map(print, "mixes")), " "]) : "";
   return concat([
     decorators,
     "interface ",
     id,
     generic,
     " ",
+    mixes,
     printInterfaceMembers(path, options, print),
   ]);
 }

--- a/packages/compiler/test/formatter/scenarios/inputs/interface.cadl
+++ b/packages/compiler/test/formatter/scenarios/inputs/interface.cadl
@@ -6,3 +6,15 @@ Foo {
   string,
   y (x: int32, y: int32): int32
 }
+
+interface Bar    mixes
+ResourceOperations<BarResource> {
+  blerp(n: int32): string;
+}
+
+interface Baz mixes ResourceRead<BarResource>,
+
+ResourceCreate<BarResource>,     ResourceDelete<BarResource>
+  {
+  glorp(n: int32): string;
+}

--- a/packages/compiler/test/formatter/scenarios/outputs/interface.cadl
+++ b/packages/compiler/test/formatter/scenarios/outputs/interface.cadl
@@ -2,3 +2,11 @@ interface Foo {
   x(n: int32): string;
   y(x: int32, y: int32): int32;
 }
+
+interface Bar mixes ResourceOperations<BarResource> {
+  blerp(n: int32): string;
+}
+
+interface Baz mixes ResourceRead<BarResource>, ResourceCreate<BarResource>, ResourceDelete<BarResource> {
+  glorp(n: int32): string;
+}


### PR DESCRIPTION
I noticed that the formatter was deleting the `mixes` list for interfaces so I added support for this syntax element.