### PR TITLE
Configure cadl-server path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -89,5 +89,6 @@
     "CADL_VERBOSE_TEST_OUTPUT": "true",
     "NODE_OPTIONS": "--stack-trace-limit=50"
   },
-  "testExplorer.errorDecoration": false
+  "testExplorer.errorDecoration": false,
+  "cadl.cadl-server.path": "${workspaceRoot}/packages/samples/node_modules/.bin/cadl-server"
 }


### PR DESCRIPTION
I neglected to port a change in cadl-azure to cadl. This will resolve this error when working on cadl in isolation:


![image](https://user-images.githubusercontent.com/75470/140166555-6882ea26-0044-493d-90d3-749f2c0a32c6.png)

