### PR TITLE
Add --import parameter to generate sample output using any emitter

### DIFF
--- a/common/changes/@cadl-lang/compiler/import-argument_2021-11-04-14-41.json
+++ b/common/changes/@cadl-lang/compiler/import-argument_2021-11-04-14-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add new --import CLI parameter to add a global import via the command line",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/cli.ts
+++ b/packages/compiler/core/cli.ts
@@ -53,6 +53,12 @@ async function main() {
             default: false,
             describe: "Don't load the Cadl standard library.",
           })
+          .option("import", {
+            type: "array",
+            string: true,
+            describe:
+              "Additional imports to include.  This parameter can be used multiple times to add more imports.",
+          })
           .option("watch", {
             type: "boolean",
             default: false,
@@ -225,6 +231,7 @@ async function getCompilerOptions(args: {
   "output-path": string;
   nostdlib?: boolean;
   option?: string[];
+  import?: string[];
   watch?: boolean;
   "diagnostic-level": string;
 }): Promise<CompilerOptions> {
@@ -248,6 +255,7 @@ async function getCompilerOptions(args: {
     outputPath,
     swaggerOutputFile: resolve(args["output-path"], "openapi.json"),
     nostdlib: args["nostdlib"],
+    additionalImports: args["import"],
     watchForChanges: args["watch"],
     diagnosticLevel: args["diagnostic-level"] as any,
   };

--- a/packages/compiler/core/options.ts
+++ b/packages/compiler/core/options.ts
@@ -6,6 +6,7 @@ export interface CompilerOptions {
   swaggerOutputFile?: string;
   nostdlib?: boolean;
   noEmit?: boolean;
+  additionalImports?: string[];
   watchForChanges?: boolean;
   serviceCodePath?: string;
   diagnosticLevel?: LogLevel;

--- a/packages/compiler/core/program.ts
+++ b/packages/compiler/core/program.ts
@@ -97,6 +97,13 @@ export async function createProgram(
     await loadStandardLibrary(program);
   }
 
+  // Load additional imports prior to compilation
+  if (options.additionalImports) {
+    const importScript = options.additionalImports.map((i) => `import "${i}";`).join("\n");
+    const sourceFile = createSourceFile(importScript, `__additional_imports`);
+    await loadCadlScript(sourceFile);
+  }
+
   await loadMain(mainFile, options);
 
   const checker = (program.checker = createChecker(program));

--- a/packages/samples/documentation/docs.cadl
+++ b/packages/samples/documentation/docs.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 @resource("/foo")
 @doc("Things to do with foo")

--- a/packages/samples/grpc-kiosk-example/kiosk.cadl
+++ b/packages/samples/grpc-kiosk-example/kiosk.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 @resource("/v1")
 @tag("Display")

--- a/packages/samples/grpc-library-example/library.cadl
+++ b/packages/samples/grpc-library-example/library.cadl
@@ -4,7 +4,6 @@
 
 // package google.example.library.v1;
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 @doc(
   """

--- a/packages/samples/mutation/mutation.cadl
+++ b/packages/samples/mutation/mutation.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 import "./decorators.js";
 import "./common.cadl";

--- a/packages/samples/nested/nested.cadl
+++ b/packages/samples/nested/nested.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 namespace Root {
   @resource("/sub/a")

--- a/packages/samples/nullable/nullable.cadl
+++ b/packages/samples/nullable/nullable.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 model HasNullables {
   str: string;

--- a/packages/samples/optional/optional.cadl
+++ b/packages/samples/optional/optional.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 model HasOptional {
   optionalNoDefault?: string;

--- a/packages/samples/param-decorators/param-decorators.cadl
+++ b/packages/samples/param-decorators/param-decorators.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 @serviceTitle("Parameter Decorators")
 namespace Cadl.Samples;

--- a/packages/samples/petstore/petstore.cadl
+++ b/packages/samples/petstore/petstore.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 import "./decorators.js";
 
 @serviceTitle("Pet Store Service")

--- a/packages/samples/scripts/regen-samples.js
+++ b/packages/samples/scripts/regen-samples.js
@@ -38,6 +38,7 @@ function main() {
       "compile",
       inputPath,
       `--output-path=${outputPath}`,
+      `--import=@cadl-lang/openapi3`,
       `--debug`,
     ]);
   }

--- a/packages/samples/tags/tagged-operations.cadl
+++ b/packages/samples/tags/tagged-operations.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 @resource("/foo")
 @tag("foo")

--- a/packages/samples/testserver/body-boolean/body-boolean.cadl
+++ b/packages/samples/testserver/body-boolean/body-boolean.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 @doc("Error")
 model Error {

--- a/packages/samples/testserver/body-time/body-time.cadl
+++ b/packages/samples/testserver/body-time/body-time.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 @doc("Error")
 model Error {

--- a/packages/samples/testserver/media-types/media-types.cadl
+++ b/packages/samples/testserver/media-types/media-types.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 @doc("Uri or local path to source data.")
 model SourcePath {

--- a/packages/samples/testserver/multiple-inheritance/multiple-inheritance.cadl
+++ b/packages/samples/testserver/multiple-inheritance/multiple-inheritance.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 model Pet {
   name: string;

--- a/packages/samples/visibility/visibility.cadl
+++ b/packages/samples/visibility/visibility.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 model Person {
   @visibility("read") id: string;


### PR DESCRIPTION
This change does the following:

- Adds a new `--import` parameter which enables one to import a particular library into the program before the main Cadl file gets loaded.  This means that any decorators and emitters pulled in by the library will be available to the compilation
- Updates all existing samples to remove direct import of `@cadl-lang/openapi3`
- Updates `regen-samples.js` to use the `--import=@cadl-lang/openapi3` parameter to pull in the OpenAPI 3 emitter