### PR TITLE
VSCode server path use compiler path instead of bin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -90,5 +90,5 @@
     "NODE_OPTIONS": "--stack-trace-limit=50"
   },
   "testExplorer.errorDecoration": false,
-  "cadl.cadl-server.path": "${workspaceRoot}/packages/samples/node_modules/.bin/cadl-server"
+  "cadl.cadl-server.path": "${workspaceRoot}/packages/compiler"
 }

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ using the preview.
 
 ## Packages
 
-| Name                                        | Changelog                    | Latest                                                     |
-| ------------------------------------------- | ---------------------------- | ---------------------------------------------------------- |
-| Core functionality                          |
-| [@cadl-lang/compiler][cadl_src]             | [Changelog][cadl_chg]        | ![](https://img.shields.io/npm/v/@cadl-lang/compiler)      |
-| Cadl Libraries                              |
-| [@cadl-lang/rest][rest_src]                 | [Changelog][rest_chg]        | ![](https://img.shields.io/npm/v/@cadl-lang/rest)          |
-| [@cadl-lang/openapi3][openapi3_src]         | [Changelog][openapi3_chg]    | ![](https://img.shields.io/npm/v/@cadl-lang/openapi3)      |
-| Cadl Tools                                  |
-| [cadl-vs][cadl-vs_src]                      | [Changelog][cadl-vs_chg]     | ![](https://img.shields.io/npm/v/@azure-tools/cadl-vs)     |
-| [cadl-vscode][cadl-vscode_src]              | [Changelog][cadl-vscode_chg] | ![](https://img.shields.io/npm/v/cadl-vscode)              |
+| Name                                | Changelog                    | Latest                                                 |
+| ----------------------------------- | ---------------------------- | ------------------------------------------------------ |
+| Core functionality                  |
+| [@cadl-lang/compiler][cadl_src]     | [Changelog][cadl_chg]        | ![](https://img.shields.io/npm/v/@cadl-lang/compiler)  |
+| Cadl Libraries                      |
+| [@cadl-lang/rest][rest_src]         | [Changelog][rest_chg]        | ![](https://img.shields.io/npm/v/@cadl-lang/rest)      |
+| [@cadl-lang/openapi3][openapi3_src] | [Changelog][openapi3_chg]    | ![](https://img.shields.io/npm/v/@cadl-lang/openapi3)  |
+| Cadl Tools                          |
+| [cadl-vs][cadl-vs_src]              | [Changelog][cadl-vs_chg]     | ![](https://img.shields.io/npm/v/@azure-tools/cadl-vs) |
+| [cadl-vscode][cadl-vscode_src]      | [Changelog][cadl-vscode_chg] | ![](https://img.shields.io/npm/v/cadl-vscode)          |
 
 [cadl_src]: packages/compiler
 [cadl_chg]: packages/compiler/CHANGELOG.md
@@ -72,7 +72,6 @@ using the preview.
 
    This will compile the Cadl files in the project folder into one output file: `.\cadl-output\openapi.json`.
 
-
 ## Usage
 
 See full usage documentation by typing:
@@ -86,6 +85,7 @@ cadl --help
 Here is a very small Cadl example that uses the `@cadl-lang/openapi3` library to generate OpenAPI 3.0 from Cadl.
 
 #### sample.cadl
+
 ```
 import "@cadl-lang/rest";
 import "@cadl-lang/openapi3";
@@ -98,6 +98,7 @@ namespace Example {
 ```
 
 You can compile it to OpenAPI 3.0 by using the following command:
+
 ```
 cadl compile sample.cadl
 ```
@@ -106,7 +107,6 @@ Once it compiles, you can find the emitted OpenAPI document in `./cadl-output/op
 
 You can also pass in a directory instead of a file to `cadl compile`. That's
 equivalent to passing `main.cadl` in that directory.
-
 
 ### Formatting Cadl files
 
@@ -130,7 +130,7 @@ This will download and install the latest VS Code extension. Use `cadl code unin
 If `cadl-server` cannot be found on PATH by VS Code in your setup, you can
 configure its location in VS Code settings. Search for "Cadl" in File ->
 Preferences -> Settings, and adjust `cadl.cadl-server.path` accordingly. You may
-need to restart VS Code after changing this.
+need to restart VS Code after changing this. This should be the path to the `@cadl-lang/compiler` package. (e.g. `./node_modules/@cadl-lang/compiler`)
 
 You can also configure a project to use a local npm install of
 `@cadl-lang/compiler`. See [local-cadl sample](packages/samples/local-cadl).

--- a/common/changes/cadl-vscode/feature-cadl-server-path-node_2021-11-04-23-01.json
+++ b/common/changes/cadl-vscode/feature-cadl-server-path-node_2021-11-04-23-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vscode",
+      "comment": "**Change** `cadl.cadl-server.path` should point to the `@cadl-lang/compiler` package instead of `cadl-server` binary.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "cadl-vscode"
+}

--- a/packages/cadl-vscode/rollup.config.js
+++ b/packages/cadl-vscode/rollup.config.js
@@ -10,7 +10,7 @@ export default {
     sourcemap: true,
     exports: "default",
   },
-  external: ["vscode"],
+  external: ["fs/promises", "vscode"],
   plugins: [resolve({ preferBuiltins: true }), commonjs()],
   onwarn: (warning, warn) => {
     if (warning.code === "CIRCULAR_DEPENDENCY") {

--- a/packages/cadl-vscode/src/extension.ts
+++ b/packages/cadl-vscode/src/extension.ts
@@ -1,3 +1,4 @@
+import { stat } from "fs/promises";
 import { join } from "path";
 import { ExtensionContext, workspace } from "vscode";
 import {
@@ -9,8 +10,8 @@ import {
 
 let client: LanguageClient | undefined;
 
-export function activate(context: ExtensionContext) {
-  const exe = resolveCadlServer(context);
+export async function activate(context: ExtensionContext) {
+  const exe = await resolveCadlServer(context);
   const options: LanguageClientOptions = {
     synchronize: {
       fileEvents: [
@@ -30,7 +31,7 @@ export function activate(context: ExtensionContext) {
   client.start();
 }
 
-function resolveCadlServer(context: ExtensionContext): Executable {
+async function resolveCadlServer(context: ExtensionContext): Promise<Executable> {
   const nodeOptions = process.env.CADL_SERVER_NODE_OPTIONS;
   const args = ["--stdio"];
   // In development mode (F5 launch from source), resolve to locally built server.js.
@@ -42,23 +43,18 @@ function resolveCadlServer(context: ExtensionContext): Executable {
     return { command: "node", args: [...options, script, ...args] };
   }
 
-  // In production, first try VS Code configuration, which allows a global machine
-  // location that is not on PATH, or a workspace-specific installation.
-  let serverPath = workspace.getConfiguration().get("cadl.cadl-server.path") as string;
-  if (serverPath && typeof serverPath !== "string") {
-    throw new Error("VS Code configuration option 'cadl.cadl-server.path' must be a string");
-  }
-
-  if (serverPath?.includes("${workspaceRoot}")) {
-    const workspaceRoot = workspace.workspaceFolders?.[0]?.uri?.fsPath ?? "";
-    serverPath = serverPath.replace("${workspaceRoot}", workspaceRoot);
-  }
-
   let options: ExecutableOptions | undefined;
   if (nodeOptions) {
     options = {
       env: { ...process.env, NODE_OPTIONS: nodeOptions },
     };
+  }
+
+  // In production, first try VS Code configuration, which allows a global machine
+  // location that is not on PATH, or a workspace-specific installation.
+  let serverPath = workspace.getConfiguration().get("cadl.cadl-server.path") as string;
+  if (serverPath && typeof serverPath !== "string") {
+    throw new Error("VS Code configuration option 'cadl.cadl-server.path' must be a string");
   }
 
   // Default to cadl-server on PATH, which would come from `npm install -g
@@ -68,11 +64,35 @@ function resolveCadlServer(context: ExtensionContext): Executable {
     return { command: executable, args, options };
   }
 
+  if (serverPath.includes("${workspaceRoot}")) {
+    const workspaceRoot = workspace.workspaceFolders?.[0]?.uri?.fsPath ?? "";
+    serverPath = serverPath.replace("${workspaceRoot}", workspaceRoot);
+  }
+
   if (!serverPath.endsWith(".js")) {
-    serverPath = join(serverPath, "cmd/cadl-server.js");
+    // Allow path to cadl-server.cmd to be passed.
+    if (await isFile(serverPath)) {
+      const command =
+        process.platform === "win32" && !serverPath.endsWith(".cmd")
+          ? `${serverPath}.cmd`
+          : "cadl-server";
+
+      return { command, args, options };
+    } else {
+      serverPath = join(serverPath, "cmd/cadl-server.js");
+    }
   }
 
   return { command: "node", args: [serverPath, ...args], options };
+}
+
+async function isFile(path: string) {
+  try {
+    const stats = await stat(path);
+    return stats.isFile();
+  } catch {
+    return false;
+  }
 }
 
 export async function deactivate() {

--- a/packages/samples/local-cadl/.vscode/settings.json
+++ b/packages/samples/local-cadl/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cadl.cadl-server.path": "${workspaceRoot}/node_modules/.bin/cadl-server"
+  "cadl.cadl-server.path": "${workspaceRoot}/packages/compiler"
 }


### PR DESCRIPTION
fix #40

Simplify redefining where to load `cadl-server` from. This should just be the path to the `@cadl-lang/compiler` package.
This is more similar to how typescript customize its path