### PR TITLE
Refactor verbForEndpoint to rest library

### DIFF
--- a/common/changes/@cadl-lang/openapi3/minor-refactor_2021-11-07-14-07.json
+++ b/common/changes/@cadl-lang/openapi3/minor-refactor_2021-11-07-14-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Refactor verbForEndpoint to rest library",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/minor-refactor_2021-11-07-14-07.json
+++ b/common/changes/@cadl-lang/rest/minor-refactor_2021-11-07-14-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Refactor verbForEndpoint to rest library",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -35,8 +35,8 @@ import {
   getServiceNamespaceString,
   getServiceTitle,
   getServiceVersion,
-  HttpVerb,
   isBody,
+  verbForEndpoint,
 } from "@cadl-lang/rest";
 import * as path from "path";
 import { reportDiagnostic } from "./lib.js";
@@ -314,25 +314,6 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     }
 
     return [verb, pathSegments, routePath];
-  }
-
-  function verbForEndpoint(name: string): HttpVerb | undefined {
-    switch (name) {
-      case "list":
-        return "get";
-      case "create":
-        return "post";
-      case "read":
-        return "get";
-      case "update":
-        return "patch";
-      case "delete":
-        return "delete";
-      case "deleteAll":
-        return "delete";
-    }
-
-    return undefined;
   }
 
   function emitEndpoint(resource: NamespaceType, op: OperationType) {

--- a/packages/rest/src/rest.ts
+++ b/packages/rest/src/rest.ts
@@ -216,6 +216,25 @@ export function getOperationRoute(program: Program, entity: Type): OperationRout
   return program.stateMap(operationRoutesKey).get(entity);
 }
 
+export function verbForEndpoint(name: string): HttpVerb | undefined {
+  switch (name) {
+    case "list":
+      return "get";
+    case "create":
+      return "post";
+    case "read":
+      return "get";
+    case "update":
+      return "patch";
+    case "delete":
+      return "delete";
+    case "deleteAll":
+      return "delete";
+  }
+
+  return undefined;
+}
+
 export function $get(program: Program, entity: Type, subPath?: string) {
   setOperationRoute(program, entity, {
     verb: "get",


### PR DESCRIPTION
This PR is a simple refactor that moves the `verbForEndpoint` method into the rest library, since there is nothing openapi3 specific about this mapping. 