### PR TITLE
Feature: Added `--check` option to cadl format

### DIFF
--- a/common/changes/@cadl-lang/compiler/feature-format-check_2021-11-08-17-46.json
+++ b/common/changes/@cadl-lang/compiler/feature-format-check_2021-11-08-17-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Added** `--check` option to `cadl format` command to verify files are formatted",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/formatter.ts
+++ b/packages/compiler/core/formatter.ts
@@ -15,6 +15,21 @@ export async function formatCadl(code: string, prettierConfig?: prettier.Options
 }
 
 /**
+ * Check the given is correctly formatted.
+ * @returns true if code is formatted correctly.
+ */
+export async function checkFormatCadl(
+  code: string,
+  prettierConfig?: prettier.Options
+): Promise<boolean> {
+  return prettier.check(code, {
+    ...prettierConfig,
+    parser: "cadl",
+    plugins: [cadlPrettierPlugin],
+  });
+}
+
+/**
  * Format all the Cadl files.
  * @param patterns List of wildcard pattern searching for Cadl files.
  */
@@ -34,11 +49,48 @@ export async function formatCadlFiles(patterns: string[], { debug }: { debug?: b
   }
 }
 
+/**
+ * Find all the unformatted files.
+ * @returns list of files not formatted.
+ */
+export async function findUnformattedCadlFiles(
+  patterns: string[],
+  { debug }: { debug?: boolean }
+): Promise<string[]> {
+  const files = await findFiles(patterns);
+  const unformatted = [];
+  for (const file of files) {
+    try {
+      if (!(await checkFormatCadlFile(file))) {
+        unformatted.push(file);
+      }
+    } catch (e) {
+      if (e instanceof PrettierParserError) {
+        const details = debug ? e.message : "";
+        console.error(`File '${file}' failed to fromat. ${details}`);
+      } else {
+        throw e;
+      }
+    }
+  }
+  return unformatted;
+}
+
 export async function formatCadlFile(filename: string) {
   const content = await readFile(filename);
   const prettierConfig = await prettier.resolveConfig(filename);
   const formattedContent = await formatCadl(content.toString(), prettierConfig ?? {});
   await writeFile(filename, formattedContent);
+}
+
+/**
+ * Check the given cadl file is correctly formatted.
+ * @returns true if code is formatted correctly.
+ */
+export async function checkFormatCadlFile(filename: string): Promise<boolean> {
+  const content = await readFile(filename);
+  const prettierConfig = await prettier.resolveConfig(filename);
+  return await checkFormatCadl(content.toString(), prettierConfig ?? {});
 }
 
 async function findFilesFromPattern(pattern: string): Promise<string[]> {

--- a/packages/compiler/core/formatter.ts
+++ b/packages/compiler/core/formatter.ts
@@ -68,6 +68,7 @@ export async function findUnformattedCadlFiles(
       if (e instanceof PrettierParserError) {
         const details = debug ? e.message : "";
         console.error(`File '${file}' failed to fromat. ${details}`);
+        unformatted.push(file);
       } else {
         throw e;
       }


### PR DESCRIPTION
Added `--check` option similar to `rust fmt --check` to add some option for user to validate files are formatted without having to use `prettier` directly.

Realized we were missing this and to ensure cadl user can make sure they code is formatted, I believe this is required.


Example running `cadl format **/*.cadl --check` in  this repo: 
![image](https://user-images.githubusercontent.com/1031227/140792868-545a803b-6797-4af8-9185-018256b871dc.png)
