### PR TITLE
Feature: Duration model

### DIFF
--- a/common/changes/@cadl-lang/compiler/feature-duration_2021-11-09-19-41.json
+++ b/common/changes/@cadl-lang/compiler/feature-duration_2021-11-09-19-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Added** `duration` intrinsic type",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi3/feature-duration_2021-11-09-19-41.json
+++ b/common/changes/@cadl-lang/openapi3/feature-duration_2021-11-09-19-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "**Added** Support for duration type",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -74,6 +74,7 @@ export type IntrinsicModelName =
   | "plainDate"
   | "plainTime"
   | "zonedDateTime"
+  | "duration"
   | "boolean"
   | "null";
 

--- a/packages/compiler/lib/lib.cadl
+++ b/packages/compiler/lib/lib.cadl
@@ -60,6 +60,9 @@ model plainTime {}
 model zonedDateTime {}
 
 @intrinsic
+model duration {}
+
+@intrinsic
 model boolean {}
 
 @intrinsic

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1121,6 +1121,8 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
             return { type: "string", format: "date-time" };
           case "plainTime":
             return { type: "string", format: "time" };
+          case "duration":
+            return { type: "string", format: "duration" };
           case "Map":
             // We assert on valType because Map types always have a type
             const valType = cadlType.properties.get("v");

--- a/packages/openapi3/test/test-openapi-output.ts
+++ b/packages/openapi3/test/test-openapi-output.ts
@@ -394,6 +394,7 @@ describe("openapi3: primitives", () => {
     ["plainDate", { type: "string", format: "date" }],
     ["zonedDateTime", { type: "string", format: "date-time" }],
     ["plainTime", { type: "string", format: "time" }],
+    ["duration", { type: "string", format: "duration" }],
     ["bytes", { type: "string", format: "byte" }],
   ];
 


### PR DESCRIPTION
fix #48

Added `duration` intrinsic type and update openapi3 emitter to emit `type: string, format: duration` for it.