### PR TITLE
Make init package.json private to remove warning for missing fields

### DIFF
--- a/common/changes/@cadl-lang/compiler/tweak-init-private-package_2021-11-10-17-30.json
+++ b/common/changes/@cadl-lang/compiler/tweak-init-private-package_2021-11-10-17-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "`cadl init` generate `package.json` with `private: true`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/init/init.ts
+++ b/packages/compiler/init/init.ts
@@ -206,6 +206,7 @@ async function writePackageJson(host: CompilerHost, config: ScaffoldingConfig) {
   const packageJson = {
     name: config.name,
     dependencies,
+    private: true,
   };
 
   return host.writeFile(


### PR DESCRIPTION
fix https://github.com/Azure/cadl-azure/issues/777
![image](https://user-images.githubusercontent.com/1031227/141163252-4ad7015d-3793-4107-a918-4fb80f388b74.png)
