### PR TITLE
Feature: `cadl install` command

### DIFF
--- a/common/changes/@cadl-lang/compiler/feature-cadl-install_2021-11-10-18-25.json
+++ b/common/changes/@cadl-lang/compiler/feature-cadl-install_2021-11-10-18-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Added** `cadl install` command which shell out to `npm install`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/cli.ts
+++ b/packages/compiler/core/cli.ts
@@ -12,6 +12,7 @@ import { compile, Program } from "../core/program.js";
 import { initCadlProject } from "../init/index.js";
 import { compilerAssert, dumpError, logDiagnostics } from "./diagnostics.js";
 import { findUnformattedCadlFiles, formatCadlFiles } from "./formatter.js";
+import { installCadlDependencies } from "./install.js";
 import { Diagnostic } from "./types.js";
 import { cadlVersion, NodeHost } from "./util.js";
 
@@ -160,6 +161,12 @@ async function main() {
           type: "string",
         }),
       (args) => initCadlProject(NodeHost, process.cwd(), args.templatesUrl)
+    )
+    .command(
+      "install",
+      "Install cadl dependencies",
+      () => {},
+      () => installCadlDependencies(process.cwd())
     )
     .command(
       "info",

--- a/packages/compiler/core/install.ts
+++ b/packages/compiler/core/install.ts
@@ -1,0 +1,34 @@
+import { spawn } from "child_process";
+
+interface SpawnError {
+  errno: number;
+  code: "ENOENT";
+  sysCall: string;
+  path: string;
+  spawnArgs: string[];
+}
+
+export async function installCadlDependencies(directory: string): Promise<void> {
+  const cmd = process.platform === "win32" ? "npm.cmd" : "npm";
+  const child = spawn(cmd, ["install"], {
+    stdio: "inherit",
+    cwd: directory,
+    env: process.env,
+  });
+
+  return new Promise(() => {
+    child.on("error", (error: SpawnError) => {
+      if (error.code === "ENOENT") {
+        console.error(
+          "Cannot find `npm` executable. Make sure to have npm installed in your path."
+        );
+      } else {
+        console.error("Error", error);
+      }
+      process.exit(error.errno);
+    });
+    child.on("exit", (exitCode) => {
+      process.exit(exitCode ?? -1);
+    });
+  });
+}


### PR DESCRIPTION
Doing this as this would let us create a `docker` image with no other dependency on the user side.

Other thing that could be nice is producing a cadl executable which is self contained but then we would need to have npm as a dependency to the compiler.

Adds a new `cadl install` command which just simply shell out to `npm install` and pass through the stdio.

Example: success:
![image](https://user-images.githubusercontent.com/1031227/141172324-18cfacf6-6bdf-465c-82b5-3869a8b6d6f4.png)

Example: Failure to find `npm`:
![image](https://user-images.githubusercontent.com/1031227/141172265-52b7aa8a-4d24-414b-88f8-e8b85972d3f3.png)
