### PR TITLE
Feature: docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+**/node_modules
+**/dist
+
+# Rush files
+common/temp/**
+package-deps.json
+
+# tsc incremental build files
+**/*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ using the preview.
 
 ## Getting Started
 
+### Using Docker
+
+[See docker documentation](./docs/docker.md)
+
+### Using Node & Npm
+
 1. Install [Node.js 14 LTS](https://nodejs.org/en/download/) and ensure you are able to run the `npm` command in a command prompt:
 
    ```

--- a/common/changes/tmlanguage-generator/feature-docker_2021-11-10-23-04.json
+++ b/common/changes/tmlanguage-generator/feature-docker_2021-11-10-23-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "tmlanguage-generator",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "tmlanguage-generator"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3032,10 +3032,11 @@ packages:
       '@types/plist': 3.0.2
       onigasm: 2.2.5
       plist: 3.0.4
+      typescript: 4.4.4
     dev: false
     name: '@rush-temp/tmlanguage-generator'
     resolution:
-      integrity: sha512-WM1WhCLQw/RzuttQrS7QutOHooQHzcxlNAI8Jv5FUgaPmH7OGl7G3m/dH8KcWE4vSQRteEKlCNqeHU8w1z152w==
+      integrity: sha512-knw/L+Bae0ugyw0PdTcsoHMPZIAuAz07xX0LuxYb3mcXklWfh3ubNBGuNnn94abkOXM5yd6fiWgwtgpwowPREg==
       tarball: file:projects/tmlanguage-generator.tgz
     version: 0.0.0
 specifiers:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:16-alpine3.12
+
+RUN npm install -g npm
+
+RUN npm install -g @cadl-lang/compiler
+
+ENTRYPOINT [ "cadl" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,25 @@
+# --------------------------------
+#  Build compiler
+# --------------------------------
+FROM node:16-alpine3.12 as builder
+
+COPY . /app
+
+WORKDIR /app
+RUN npm install -g @microsoft/rush
+RUN rush install
+RUN rush rebuild
+
+WORKDIR /app/packages/compiler
+RUN npm pack
+
+# --------------------------------
+#  Setup final image
+# --------------------------------
 FROM node:16-alpine3.12
 
-RUN npm install -g npm
+COPY --from=builder /app/packages/compiler/*.tgz /tmp/compiler.tgz
 
-RUN npm install -g @cadl-lang/compiler
+RUN npm install -g /tmp/compiler.tgz && rm /tmp/compiler.tgz
 
 ENTRYPOINT [ "cadl" ]

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,36 @@
+# Use cadl via docker
+
+Image: `azsdkengsys.azurecr.io/cadl`
+
+Tags:
+
+- Lastest from master: `alpine`, `latest`
+
+## Usage
+
+```bash
+docker run \
+  -v "${pwd}:/wd" --workdir="/wd" \
+  -t azsdkengsys.azurecr.io/cadl \
+  # ... cadl args ...
+```
+
+**For usage in powershell replace `\` with `` ` ``**
+
+### Install dependencies
+
+```bash
+docker run -v "${pwd}:/wd" --workdir="/wd"  -t azsdkengsys.azurecr.io/cadl install
+```
+
+### Compile
+
+```bash
+docker run -v "${pwd}:/wd" --workdir="/wd"  -t azsdkengsys.azurecr.io/cadl compile .
+```
+
+### Init a new project
+
+```bash
+docker run -v "${pwd}:/wd" --workdir="/wd"  -t azsdkengsys.azurecr.io/cadl init
+```

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -43,10 +43,12 @@ jobs:
       - task: Docker@1
         displayName: "Build and test with Docker"
         inputs:
+          command: "Build an image"
+          imageName: cadl-test
+      - task: Docker@1
+        displayName: "Build and test with Docker"
+        inputs:
           azureContainerRegistry: azuresdkimages.azurecr.io
           azureSubscriptionEndpoint: "Azure SDK ACR"
           command: "Run an image"
           imageName: cadl-test
-          qualifyImageName: true
-          runInBackground: false
-          volumes: "$(System.DefaultWorkingDirectory):/data"

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -56,5 +56,5 @@ jobs:
             .
         displayName: "Build"
 
-      - script: docker push $(imageName)
+      - script: docker push $(imageName) --all-tags
         displayName: "Push"

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -4,31 +4,49 @@ trigger:
   - main
 pr: none
 
-pool:
-  vmImage: windows-2019
+jobs:
+  # - job: npm
+  #   displayName: Npm publish
+  #   pool:
+  #     vmImage: windows-2019
+  #   steps:
+  #     - task: NodeTool@0
+  #       inputs:
+  #         versionSpec: 14.x
+  #       displayName: Install Node.js
 
-steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: 14.x
-    displayName: Install Node.js
+  #     - script: echo '##vso[task.setvariable variable=CADL_VS_CI_BUILD;]true'
+  #       displayName: Enable official Visual Studio extension build
 
-  - script: echo '##vso[task.setvariable variable=CADL_VS_CI_BUILD;]true'
-    displayName: Enable official Visual Studio extension build
+  #     - script: node common/scripts/install-run-rush.js install
+  #       displayName: Install JavaScript Dependencies
 
-  - script: node common/scripts/install-run-rush.js install
-    displayName: Install JavaScript Dependencies
+  #     - script: node packages/cadl-vs/scripts/build.js --restore
+  #       displayName: Restore .NET Dependencies
 
-  - script: node packages/cadl-vs/scripts/build.js --restore
-    displayName: Restore .NET Dependencies
+  #     - script: node common/scripts/install-run-rush.js rebuild --verbose
+  #       displayName: Build
 
-  - script: node common/scripts/install-run-rush.js rebuild --verbose
-    displayName: Build
+  #     - script: node common/scripts/install-run-rush.js test-official
+  #       displayName: Test
 
-  - script: node common/scripts/install-run-rush.js test-official
-    displayName: Test
+  #     - script: |
+  #         set NPM_AUTH_TOKEN=$(azure-sdk-npm-token)
+  #         node common/scripts/install-run-rush.js publish --publish --include-all --set-access-level public
+  #       displayName: Release
 
-  - script: |
-      set NPM_AUTH_TOKEN=$(azure-sdk-npm-token)
-      node common/scripts/install-run-rush.js publish --publish --include-all --set-access-level public
-    displayName: Release
+  - job: docker
+    displayName: docker
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      - task: Docker@1
+        displayName: "Build and test with Docker"
+        inputs:
+          azureContainerRegistry: azuresdkimages.azurecr.io
+          azureSubscriptionEndpoint: "Azure SDK ACR"
+          command: "Run an image"
+          imageName: cadl-test
+          qualifyImageName: true
+          runInBackground: false
+          volumes: "$(System.DefaultWorkingDirectory):/data"

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -41,12 +41,16 @@ jobs:
       vmImage: ubuntu-latest
     steps:
       - task: Docker@1
-        displayName: "Build and test with Docker"
+        displayName: "Build"
         inputs:
           command: "Build an image"
           imageName: cadl-test
+          dockerFile: ./docker/Dockerfile
+          includeLatestTag: true
+          buildContext: "."
+
       - task: Docker@1
-        displayName: "Build and test with Docker"
+        displayName: "Push"
         inputs:
           azureContainerRegistry: azuresdkimages.azurecr.io
           azureSubscriptionEndpoint: "Azure SDK ACR"

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -36,23 +36,21 @@ jobs:
   #       displayName: Release
 
   - job: docker
-    displayName: docker
+    displayName: Docker build and publish
+    variables:
+      imageName: "azsdkengsys.azurecr.io/cadl"
     pool:
       vmImage: ubuntu-latest
     steps:
       - task: Docker@1
-        displayName: "Build"
+        displayName: login
         inputs:
-          command: "Build an image"
-          imageName: cadl-test
-          dockerFile: ./docker/Dockerfile
-          includeLatestTag: true
-          buildContext: "."
+          azureSubscriptionEndpoint: "AzureSDKEngKeyVault Secrets"
+          azureContainerRegistry: azsdkengsys.azurecr.io
+          command: login
 
-      - task: Docker@1
+      - script: docker build -f ./docker/Dockerfile -t $(imageName) -t $(imageName):alpine .
+        displayName: "Build"
+
+      - script: docker push $(imageName) $(imageName):alpine
         displayName: "Push"
-        inputs:
-          azureContainerRegistry: azuresdkimages.azurecr.io
-          azureSubscriptionEndpoint: "Azure SDK ACR"
-          command: "Run an image"
-          imageName: cadl-test

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -49,8 +49,11 @@ jobs:
           azureContainerRegistry: azsdkengsys.azurecr.io
           command: login
 
-      - script: docker build -f ./docker/Dockerfile -t $(imageName) -t $(imageName):alpine .
+      - script: docker build -f ./docker/Dockerfile \
+          -t $(imageName):latest \
+          -t $(imageName):alpine \
+          .
         displayName: "Build"
 
-      - script: docker push $(imageName) $(imageName):alpine
+      - script: docker push $(imageName)
         displayName: "Push"

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -5,35 +5,35 @@ trigger:
 pr: none
 
 jobs:
-  # - job: npm
-  #   displayName: Npm publish
-  #   pool:
-  #     vmImage: windows-2019
-  #   steps:
-  #     - task: NodeTool@0
-  #       inputs:
-  #         versionSpec: 14.x
-  #       displayName: Install Node.js
+  - job: npm
+    displayName: Npm publish
+    pool:
+      vmImage: windows-2019
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: 14.x
+        displayName: Install Node.js
 
-  #     - script: echo '##vso[task.setvariable variable=CADL_VS_CI_BUILD;]true'
-  #       displayName: Enable official Visual Studio extension build
+      - script: echo '##vso[task.setvariable variable=CADL_VS_CI_BUILD;]true'
+        displayName: Enable official Visual Studio extension build
 
-  #     - script: node common/scripts/install-run-rush.js install
-  #       displayName: Install JavaScript Dependencies
+      - script: node common/scripts/install-run-rush.js install
+        displayName: Install JavaScript Dependencies
 
-  #     - script: node packages/cadl-vs/scripts/build.js --restore
-  #       displayName: Restore .NET Dependencies
+      - script: node packages/cadl-vs/scripts/build.js --restore
+        displayName: Restore .NET Dependencies
 
-  #     - script: node common/scripts/install-run-rush.js rebuild --verbose
-  #       displayName: Build
+      - script: node common/scripts/install-run-rush.js rebuild --verbose
+        displayName: Build
 
-  #     - script: node common/scripts/install-run-rush.js test-official
-  #       displayName: Test
+      - script: node common/scripts/install-run-rush.js test-official
+        displayName: Test
 
-  #     - script: |
-  #         set NPM_AUTH_TOKEN=$(azure-sdk-npm-token)
-  #         node common/scripts/install-run-rush.js publish --publish --include-all --set-access-level public
-  #       displayName: Release
+      - script: |
+          set NPM_AUTH_TOKEN=$(azure-sdk-npm-token)
+          node common/scripts/install-run-rush.js publish --publish --include-all --set-access-level public
+        displayName: Release
 
   - job: docker
     displayName: Docker build and publish

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -49,10 +49,11 @@ jobs:
           azureContainerRegistry: azsdkengsys.azurecr.io
           command: login
 
-      - script: docker build -f ./docker/Dockerfile \
-          -t $(imageName):latest \
-          -t $(imageName):alpine \
-          .
+      - script: |
+          docker build -f ./docker/Dockerfile \
+            -t $(imageName):latest \
+            -t $(imageName):alpine \
+            .
         displayName: "Build"
 
       - script: docker push $(imageName)

--- a/packages/tmlanguage-generator/package.json
+++ b/packages/tmlanguage-generator/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@types/node": "~14.0.27",
-    "@types/plist": "~3.0.2"
+    "@types/plist": "~3.0.2",
+    "typescript": "~4.4.4"
   }
 }


### PR DESCRIPTION
Add support for running cadl via docker


- Always build the code in the image(Will be a requirement for MCR I believe)
- Use multi-stage pipeline to only have the bare minimum in the final image(Builder step)
- Publish 2 tags: `alpine` and `latest` both pointing to the same image(latest changes).
- [Documentation](https://github.com/microsoft/cadl/blob/2aebba60e86ab45a1cff9dc0a715121e3d9997b2/docs/docker.md)

Follow up: 
- Produce specific version tags so user can pin to a specific version.
   - `latest` and `alpine-latest` would always point to either the latest release
   - `current` would point to the latest change from master(what is currently `latest` and `alpine` doing)