### PR TITLE
Fix: Log Warning count

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-log-warnings-count_2021-11-15-16-47.json
+++ b/common/changes/@cadl-lang/compiler/fix-log-warnings-count_2021-11-15-16-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Fix** Logging of warning counts, showing error count",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/cli.ts
+++ b/packages/compiler/core/cli.ts
@@ -260,11 +260,7 @@ function logDiagnosticCount(diagnostics: readonly Diagnostic[]) {
   const warningCount = diagnostics.filter((x) => x.severity === "warning").length;
 
   const addSuffix = (count: number, suffix: string) =>
-    count > 1
-      ? `${errorCount} ${suffix}s`
-      : errorCount === 1
-      ? `${errorCount} ${suffix}`
-      : undefined;
+    count > 1 ? `${count} ${suffix}s` : count === 1 ? `${count} ${suffix}` : undefined;
   const errorText = addSuffix(errorCount, "error");
   const warningText = addSuffix(warningCount, "warning");
 


### PR DESCRIPTION
fix #61
Warning count was showing the error count.

Not sure however how `Found .` is happening. There shouldn't be anything but `warning` and `error` in the diagnostics list and I can't seem to repro locally.
NVM: that fix actually fixed it too. It was the case where there was only 1 warning then it was also comparing with the error count and so not displaying anything for warnings. 