### PR TITLE
Fix issues introduced by PR #34

### DIFF
--- a/common/changes/@cadl-lang/rest/rest-fixes_2021-11-16-12-19.json
+++ b/common/changes/@cadl-lang/rest/rest-fixes_2021-11-16-12-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add documentation strings to models and operations",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/lib/http.cadl
+++ b/packages/rest/lib/http.cadl
@@ -2,44 +2,81 @@ import "../dist/http.js";
 
 namespace Cadl.Http;
 
+@doc("The request has succeeded.")
 model OkResponse<T> {
-  @header statusCode: 200;
-  @body body: T;
+  @doc("The status code.")
+  @header
+  statusCode: 200;
+
+  @doc("The reponse body.")
+  @body
+  body: T;
 }
 
+@doc("The Location header.")
 model LocationHeader {
-  @header location: string;
+  @doc(
+    "The Location header contains the URL where the status of the long running operation can be checked."
+  )
+  @header
+  location: string;
 }
 
+@doc("The request has succeeded and a new resource has been created as a result.")
 model CreatedResponse {
-  @header statusCode: 201;
+  @doc("The status code.")
+  @header
+  statusCode: 201;
 }
 
+@doc("The request has been received but not yet acted upon.")
 model AcceptedResponse {
-  @header statusCode: 202;
+  @doc("The status code.")
+  @header
+  statusCode: 202;
 }
 
+@doc("There is no content to send for this request, but the headers may be useful. ")
 model NoContentResponse {
-  @header statusCode: 204;
+  @doc("The status code.")
+  @header
+  statusCode: 204;
 }
 
+@doc(
+  "The URL of the requested resource has been changed permanently. The new URL is given in the response."
+)
 model MovedResponse {
-  @header statusCode: 301;
+  @doc("The status code.")
+  @header
+  statusCode: 301;
   ... LocationHeader;
 }
 
+@doc("This is used for caching purposes.")
 model NotModifiedResponse {
-  @header statusCode: 304;
+  @doc("The status code.")
+  @header
+  statusCode: 304;
 }
 
+@doc("The server could not understand the request due to invalid syntax.")
 model UnauthorizedResponse {
-  @header statusCode: 401;
+  @doc("The status code.")
+  @header
+  statusCode: 401;
 }
 
+@doc("The server can not find the requested resource.")
 model NotFoundResponse {
-  @header statusCode: 404;
+  @doc("The status code.")
+  @header
+  statusCode: 404;
 }
 
+@doc("This response is sent when a request conflicts with the current state of the server.")
 model ConflictResponse {
-  @header statusCode: 409;
+  @doc("The status code.")
+  @header
+  statusCode: 409;
 }

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -5,25 +5,33 @@ namespace Cadl.Rest.Resource;
 
 @doc("The default error response for resource operations.")
 model ResourceError {
+  @doc("The error code.")
   code: int32;
+
+  @doc("The error message.")
   message: string;
 }
 
+@doc("Dynamically gathers keys of the model type T.")
 @copyResourceKeyParameters
 model KeysOf<T> {}
 
+@doc("Dynamically gathers parent keys of the model type T.")
 @copyResourceKeyParameters("parent")
 model ParentKeysOf<T> {}
 
+@doc("Represents operation parameters for resource TResource.")
 model ResourceParameters<TResource> {
   ...KeysOf<TResource>;
 }
 
+@doc("Represents collection operation parameters for resource TResource.")
 model ResourceCollectionParameters<TResource> {
   ...ParentKeysOf<TResource>;
 }
 
 interface ResourceRead<TResource, TError> {
+  @doc("Gets an instance of the resource.")
   @read(TResource)
   Get(...ResourceParameters<TResource>): TResource | TError;
 }
@@ -35,6 +43,7 @@ model ResourceCreatedResponse<T> {
 }
 
 interface ResourceCreate<TResource, TError> {
+  @doc("Creates a new instance of the resource.")
   @create(TResource)
   Create(
     ...ResourceParameters<TResource>,
@@ -43,6 +52,7 @@ interface ResourceCreate<TResource, TError> {
 }
 
 interface ResourceUpdate<TResource, TError> {
+  @doc("Updates an existing instance of the resource.")
   @update(TResource)
   Update(
     ...ResourceParameters<TResource>,
@@ -52,10 +62,13 @@ interface ResourceUpdate<TResource, TError> {
 
 @doc("Resource deleted successfully.")
 model ResourceDeletedResponse {
-  @Cadl.Http.header statusCode: 200;
+  @doc("The status code.")
+  @Cadl.Http.header
+  statusCode: 200;
 }
 
 interface ResourceDelete<TResource, TError> {
+  @doc("Deletes an existing instance of the resource.")
   @delete(TResource)
   Delete(...ResourceParameters<TResource>): ResourceDeletedResponse | TError;
 }
@@ -70,6 +83,7 @@ model Page<T> {
 }
 
 interface ResourceList<TResource, TError> {
+  @doc("Lists all instances of the resource.")
   @list(TResource)
   List(...ResourceCollectionParameters<TResource>): Page<TResource> | TError;
 }

--- a/packages/samples/rest/petstore/petstore.cadl
+++ b/packages/samples/rest/petstore/petstore.cadl
@@ -1,5 +1,4 @@
 import "@cadl-lang/rest";
-import "@cadl-lang/openapi3";
 
 @serviceTitle("Pet Store Service")
 @serviceVersion("2021-03-25")

--- a/packages/samples/test/output/mutation/openapi.json
+++ b/packages/samples/test/output/mutation/openapi.json
@@ -29,7 +29,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/nested/openapi.json
+++ b/packages/samples/test/output/nested/openapi.json
@@ -12,7 +12,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/param-decorators/openapi.json
+++ b/packages/samples/test/output/param-decorators/openapi.json
@@ -33,7 +33,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -53,7 +53,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/petstore/openapi.json
+++ b/packages/samples/test/output/petstore/openapi.json
@@ -17,7 +17,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -50,7 +50,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -98,7 +98,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -124,7 +124,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -178,7 +178,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -9,6 +9,7 @@
     "/pets/{petId}": {
       "get": {
         "operationId": "Pets_Get",
+        "summary": "Gets an instance of the resource.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Pet.petId"
@@ -39,6 +40,7 @@
       },
       "patch": {
         "operationId": "Pets_Update",
+        "summary": "Updates an existing instance of the resource.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Pet.petId"
@@ -94,6 +96,7 @@
       },
       "delete": {
         "operationId": "Pets_Delete",
+        "summary": "Deletes an existing instance of the resource.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Pet.petId"
@@ -124,6 +127,7 @@
       },
       "post": {
         "operationId": "Pets_Create",
+        "summary": "Creates a new instance of the resource.",
         "parameters": [
           {
             "$ref": "#/components/parameters/Pet.petId"
@@ -175,6 +179,7 @@
     "/pets": {
       "get": {
         "operationId": "Pets_List",
+        "summary": "Lists all instances of the resource.",
         "parameters": [],
         "responses": {
           "200": {
@@ -203,6 +208,7 @@
     "/pets/{petId}/toys/{toyId}": {
       "get": {
         "operationId": "Toys_Get",
+        "summary": "Gets an instance of the resource.",
         "parameters": [
           {
             "$ref": "#/components/parameters/PetStore.Pet.petId"

--- a/packages/samples/test/output/testserver/body-boolean/openapi.json
+++ b/packages/samples/test/output/testserver/body-boolean/openapi.json
@@ -43,7 +43,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/body-time/openapi.json
+++ b/packages/samples/test/output/testserver/body-time/openapi.json
@@ -13,7 +13,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -41,7 +41,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/media-types/openapi.json
+++ b/packages/samples/test/output/testserver/media-types/openapi.json
@@ -13,7 +13,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -62,7 +62,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/multiple-inheritance/openapi.json
+++ b/packages/samples/test/output/testserver/multiple-inheritance/openapi.json
@@ -13,7 +13,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -40,7 +40,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -78,7 +78,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -105,7 +105,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -143,7 +143,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -170,7 +170,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -208,7 +208,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -235,7 +235,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -273,7 +273,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -300,7 +300,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
This change fixes a few issues I introduced via PR #34, mainly just the loss of some documentation strings that affected linting checks in the `cadl-rpaas` library and also ensuring that the `openapi3` emitter doesn't get used by default in the REST PetStore sample.