### PR TITLE
Fix syntax highlighting broken by markdown embedded highlighting

### DIFF
--- a/common/changes/cadl-vscode/main_2021-11-22-19-18.json
+++ b/common/changes/cadl-vscode/main_2021-11-22-19-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vscode",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "cadl-vscode"
+}

--- a/packages/cadl-vscode/package.json
+++ b/packages/cadl-vscode/package.json
@@ -45,6 +45,9 @@
           ".cadl"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "markdown-cadl"
       }
     ],
     "configuration": [
@@ -67,7 +70,7 @@
         "path": "./dist/cadl.tmLanguage"
       },
       {
-        "language": "cadl",
+        "language": "markdown-cadl",
         "scopeName": "markdown.cadl.codeblock",
         "path": "./markdown-cadl.json",
         "injectTo": [


### PR DESCRIPTION
Turns out the langauage IDs need to be distinct.