### PR TITLE
Fix wrong library import in rest init template

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-init-rest-api-wrong-import_2021-11-23-19-19.json
+++ b/common/changes/@cadl-lang/compiler/fix-init-rest-api-wrong-import_2021-11-23-19-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Fix** Wrong library import for the rest template",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/docs/writing-scaffolding-template.md
+++ b/docs/writing-scaffolding-template.md
@@ -41,7 +41,7 @@ You can add a list of cadl libraries to include. This will automatically add tho
   "rest": {
     "title": "Rest API",
     "description": "Create a new project representing a REST API",
-    "libraries": ["@cadl-lang/rest", "@cadl-lang/openapi"]
+    "libraries": ["@cadl-lang/rest", "@cadl-lang/openapi3"]
   }
 }
 ```

--- a/packages/compiler/init/init.ts
+++ b/packages/compiler/init/init.ts
@@ -113,7 +113,7 @@ const builtInTemplates: Record<string, InitTemplate> = {
   rest: {
     title: "Generic Rest API",
     description: "Create a project representing a generic Rest API",
-    libraries: ["@cadl-lang/rest", "@cadl-lang/openapi"],
+    libraries: ["@cadl-lang/rest", "@cadl-lang/openapi3"],
   },
 };
 


### PR DESCRIPTION
Was using "openapi" instead of "openapi3"