### PR TITLE
Generate anyOf or oneOf schemas for Cadl unions in openapi3

### DIFF
--- a/common/changes/@cadl-lang/compiler/openapi3-unions_2021-11-23-23-34.json
+++ b/common/changes/@cadl-lang/compiler/openapi3-unions_2021-11-23-23-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Improve getTypeName support for Unions and UnionVariants",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi3/openapi3-unions_2021-11-23-23-34.json
+++ b/common/changes/@cadl-lang/openapi3/openapi3-unions_2021-11-23-23-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Generate anyOf or oneOf schemas for Cadl unions in openapi3",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -277,7 +277,9 @@ export function createChecker(program: Program): Checker {
       case "Enum":
         return getEnumName(type);
       case "Union":
-        return type.options.map(getTypeName).join(" | ");
+        return type.name || type.options.map(getTypeName).join(" | ");
+      case "UnionVariant":
+        return getTypeName(type.type);
       case "Array":
         return getTypeName(type.elementType) + "[]";
       case "String":

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -6,6 +6,7 @@ const libDef = {
     "decorator-wrong-type": {
       severity: "error",
       messages: {
+        default: paramMessage`Cannot apply ${"decoratorName"} decorator to ${"entityKind"}`,
         modelsOperations: paramMessage`${"decoratorName"} decorator can only be applied to models and operation parameters.`,
       },
     },

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -29,6 +29,7 @@ import {
   Program,
   Type,
   UnionType,
+  UnionTypeVariant,
 } from "@cadl-lang/compiler";
 import { getInterfaceOperations, http, OperationDetails } from "@cadl-lang/rest";
 import * as path from "path";
@@ -56,11 +57,27 @@ export async function $onBuild(p: Program) {
 
 const operationIdsKey = Symbol();
 export function $operationId(program: Program, entity: Type, opId: string) {
+  if (entity.kind !== "Operation") {
+    reportDiagnostic(program, {
+      code: "decorator-wrong-type",
+      format: { decoratorName: "operationId", entityKind: entity.kind },
+      target: entity,
+    });
+    return;
+  }
   program.stateMap(operationIdsKey).set(entity, opId);
 }
 
 const pageableOperationsKey = Symbol();
 export function $pageable(program: Program, entity: Type, nextLinkName: string = "nextLink") {
+  if (entity.kind !== "Operation") {
+    reportDiagnostic(program, {
+      code: "decorator-wrong-type",
+      format: { decoratorName: "pageable", entityKind: entity.kind },
+      target: entity,
+    });
+    return;
+  }
   program.stateMap(pageableOperationsKey).set(entity, nextLinkName);
 }
 
@@ -85,6 +102,23 @@ export function $useRef(program: Program, entity: Type, refUrl: string): void {
 
 function getRef(program: Program, entity: Type): string | undefined {
   return program.stateMap(refTargetsKey).get(entity);
+}
+
+const oneOfKey = Symbol();
+export function $oneOf(program: Program, entity: Type) {
+  if (entity.kind !== "Union") {
+    reportDiagnostic(program, {
+      code: "decorator-wrong-type",
+      format: { decoratorName: "oneOf", entityKind: entity.kind },
+      target: entity,
+    });
+    return;
+  }
+  program.stateMap(oneOfKey).set(entity, true);
+}
+
+function getOneOf(program: Program, entity: Type): boolean {
+  return program.stateMap(oneOfKey).get(entity);
 }
 
 // NOTE: These functions aren't meant to be used directly as decorators but as a
@@ -831,6 +865,8 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       return getSchemaForModel(type);
     } else if (type.kind === "Union") {
       return getSchemaForUnion(type);
+    } else if (type.kind === "UnionVariant") {
+      return getSchemaForUnionVariant(type);
     } else if (type.kind === "Enum") {
       return getSchemaForEnum(type);
     }
@@ -898,29 +934,29 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       case "Model":
         type = "model";
         break;
+      case "UnionVariant":
+        type = "model";
+        break;
       default:
         reportUnsupportedUnion();
         return {};
     }
 
-    const values = [];
     if (type === "model") {
-      // Model unions can only ever be a model type with 'null'
       if (nonNullOptions.length === 1) {
         // Get the schema for the model type
         const schema: any = getSchemaForType(nonNullOptions[0]);
 
         return schema;
       } else {
-        reportDiagnostic(program, {
-          code: "union-unsupported",
-          messageId: "null",
-          target: union,
-        });
-        return {};
+        const variants = nonNullOptions.map((s) => getSchemaOrRef(s));
+        const ofType = getOneOf(program, union) ? "oneOf" : "anyOf";
+        const schema: any = { [ofType]: nonNullOptions.map((s) => getSchemaOrRef(s)) };
+        return schema;
       }
     }
 
+    const values = [];
     for (const option of nonNullOptions) {
       if (option.kind != kind) {
         reportUnsupportedUnion();
@@ -940,6 +976,11 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     function reportUnsupportedUnion() {
       reportDiagnostic(program, { code: "union-unsupported", target: union });
     }
+  }
+
+  function getSchemaForUnionVariant(variant: UnionTypeVariant) {
+    const schema: any = getSchemaForType(variant.type);
+    return schema;
   }
 
   function getSchemaForArray(array: ArrayType) {

--- a/packages/openapi3/test/test-openapi-output.ts
+++ b/packages/openapi3/test/test-openapi-output.ts
@@ -376,6 +376,198 @@ describe("openapi3: definitions", () => {
     strictEqual(diagnostics.length, 1);
     match(diagnostics[0].message, /Empty unions are not supported for OpenAPI v3/);
   });
+
+  it("defines request bodies as unions of models", async () => {
+    const openApi = await openApiFor(`
+      model Cat {
+        meow: int32;
+      }
+      model Dog {
+        bark: string;
+      }
+      @route("/")
+      namespace root {
+        op create(@body body: Cat | Dog): OkResponse<{}>;
+      }
+      `);
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    ok(openApi.components.schemas.Dog, "expected definition named Dog");
+    deepStrictEqual(openApi.paths["/"].post.requestBody.content["application/json"].schema, {
+      "x-cadl-name": "Cat | Dog",
+      anyOf: [{ $ref: "#/components/schemas/Cat" }, { $ref: "#/components/schemas/Dog" }],
+    });
+  });
+
+  it("defines request bodies as unions of model and non-model types", async () => {
+    const openApi = await openApiFor(`
+      model Cat {
+        meow: int32;
+      }
+      @route("/")
+      namespace root {
+        op create(@body body: Cat | string): OkResponse<{}>;
+      }
+      `);
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    deepStrictEqual(openApi.paths["/"].post.requestBody.content["application/json"].schema, {
+      "x-cadl-name": "Cat | Cadl.string",
+      anyOf: [{ $ref: "#/components/schemas/Cat" }, { type: "string" }],
+    });
+  });
+
+  it("defines request bodies aliased to a union of models", async () => {
+    const openApi = await openApiFor(`
+    model Cat {
+      meow: int32;
+    }
+    model Dog {
+      bark: string;
+    }
+    alias Pet = Cat | Dog;
+    @route("/")
+    namespace root {
+      op create(@body body: Pet): OkResponse<{}>;
+    }
+    `);
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    ok(openApi.components.schemas.Dog, "expected definition named Dog");
+    deepStrictEqual(openApi.paths["/"].post.requestBody.content["application/json"].schema, {
+      "x-cadl-name": "Cat | Dog",
+      anyOf: [{ $ref: "#/components/schemas/Cat" }, { $ref: "#/components/schemas/Dog" }],
+    });
+  });
+
+  it("defines response bodies as unions of models", async () => {
+    const openApi = await openApiFor(`
+      model Cat {
+        meow: int32;
+      }
+      model Dog {
+        bark: string;
+      }
+      @route("/")
+      namespace root {
+        op read(): { @body body: Cat | Dog };
+      }
+      `);
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    ok(openApi.components.schemas.Dog, "expected definition named Dog");
+    deepStrictEqual(openApi.paths["/"].get.responses["200"].content["application/json"].schema, {
+      "x-cadl-name": "Cat | Dog",
+      anyOf: [{ $ref: "#/components/schemas/Cat" }, { $ref: "#/components/schemas/Dog" }],
+    });
+  });
+
+  it("defines response bodies as unions of model and non-model types", async () => {
+    const openApi = await openApiFor(`
+    model Cat {
+      meow: int32;
+    }
+    @route("/")
+    namespace root {
+      op read(): { @body body: Cat | string };
+    }
+    `);
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    deepStrictEqual(openApi.paths["/"].get.responses["200"].content["application/json"].schema, {
+      "x-cadl-name": "Cat | Cadl.string",
+      anyOf: [{ $ref: "#/components/schemas/Cat" }, { type: "string" }],
+    });
+  });
+
+  it("defines response bodies aliased to a union from models", async () => {
+    const openApi = await openApiFor(`
+      model Cat {
+        meow: int32;
+      }
+      model Dog {
+        bark: string;
+      }
+      alias Pet = Cat | Dog;
+      @route("/")
+      namespace root {
+        op read(): { @body body: Pet };
+      }
+      `);
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    ok(openApi.components.schemas.Dog, "expected definition named Dog");
+    deepStrictEqual(openApi.paths["/"].get.responses["200"].content["application/json"].schema, {
+      "x-cadl-name": "Cat | Dog",
+      anyOf: [{ $ref: "#/components/schemas/Cat" }, { $ref: "#/components/schemas/Dog" }],
+    });
+  });
+
+  it("defines response bodies unioned in OkResponse as unions of models", async () => {
+    const openApi = await openApiFor(`
+      model Cat {
+        meow: int32;
+      }
+      model Dog {
+        bark: string;
+      }
+      @route("/")
+      namespace root {
+        op read(): OkResponse<Cat | Dog>;
+      }
+      `);
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    ok(openApi.components.schemas.Dog, "expected definition named Dog");
+    deepStrictEqual(openApi.paths["/"].get.responses["200"].content["application/json"].schema, {
+      "x-cadl-name": "Cat | Dog",
+      anyOf: [{ $ref: "#/components/schemas/Cat" }, { $ref: "#/components/schemas/Dog" }],
+    });
+  });
+
+  it("defines unions with named variants similarly to unnamed unions (it ignores variant names)", async () => {
+    const openApi = await openApiFor(`
+      model Cat {
+        meow: int32;
+      }
+      model Dog {
+        bark: string;
+      }
+      union Pet { cat: Cat, dog: Dog }
+      @route("/")
+      namespace root {
+        op read(): { @body body: Pet };
+      }
+      `);
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    ok(openApi.components.schemas.Dog, "expected definition named Dog");
+    ok(openApi.components.schemas.Pet, "expected definition named Pet");
+    deepStrictEqual(openApi.components.schemas.Pet, {
+      anyOf: [{ $ref: "#/components/schemas/Cat" }, { $ref: "#/components/schemas/Dog" }],
+    });
+    deepStrictEqual(openApi.paths["/"].get.responses["200"].content["application/json"].schema, {
+      $ref: "#/components/schemas/Pet",
+    });
+  });
+
+  it("defines oneOf schema for unions with @oneOf decorator", async () => {
+    const openApi = await openApiFor(`
+      model Cat {
+        meow: int32;
+      }
+      model Dog {
+        bark: string;
+      }
+      @oneOf
+      union Pet { cat: Cat, dog: Dog }
+      @route("/")
+      namespace root {
+        op read(): { @body body: Pet };
+      }
+      `);
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    ok(openApi.components.schemas.Dog, "expected definition named Dog");
+    ok(openApi.components.schemas.Pet, "expected definition named Pet");
+    deepStrictEqual(openApi.components.schemas.Pet, {
+      oneOf: [{ $ref: "#/components/schemas/Cat" }, { $ref: "#/components/schemas/Dog" }],
+    });
+    deepStrictEqual(openApi.paths["/"].get.responses["200"].content["application/json"].schema, {
+      $ref: "#/components/schemas/Pet",
+    });
+  });
 });
 
 describe("openapi3: primitives", () => {


### PR DESCRIPTION
This PR adds support to the openapi3 emitter to produce either an `anyOf` or `oneOf` schema for a Cadl union.

There are two ways to define a union in Cadl.

1. using the "|" symbol, e.g. `Cat | Dog`.
2. with a `union` statement, which (currently) requires that each variant of the union has a name. E.g.

```
union Pet { cat: Cat, dog: Dog }
```

Previously these were supported poorly or not at all in the openapi3 emitter.  With this PR, openapi3 will:

-  emit "|" unions as an `anyOf`.
- support a `@oneOf` decorator on the `union` statement to specify that the union should be emitted as a `oneOf`.
- a union defined with a `union` statement without an `@oneOf` decorator will be rendered as an `anyOf`