### PR TITLE
Extension decorator

### DIFF
--- a/common/changes/@cadl-lang/openapi3/extension-decorator_2021-11-28-18-36.json
+++ b/common/changes/@cadl-lang/openapi3/extension-decorator_2021-11-28-18-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Add support for extension decorator on parameters and tests",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -769,6 +769,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     if (param.default) {
       schema.default = getDefaultValue(param.default);
     }
+    attachExtensions(param, ph);
     ph.schema = schema;
   }
 

--- a/packages/openapi3/test/test-openapi-output.ts
+++ b/packages/openapi3/test/test-openapi-output.ts
@@ -524,6 +524,44 @@ describe("openapi3: responses", () => {
   });
 });
 
+describe("openapi3: extension decorator", () => {
+  it("adds an arbitrary extension to a model", async () => {
+    const oapi = await openApiFor(
+      `
+      @extension("x-model-extension", "foobar")
+      model Pet {
+        name: string;
+      }
+      @route("/")
+      namespace root {
+        @get()
+        op read(): Pet;
+      }
+      `
+    );
+    ok(oapi.components.schemas.Pet);
+    strictEqual(oapi.components.schemas.Pet["x-model-extension"], "foobar");
+  });
+
+  it("adds an arbitrary extension to an operation", async () => {
+    const oapi = await openApiFor(
+      `
+      model Pet {
+        name: string;
+      }
+      @route("/")
+      namespace root {
+        @get()
+        @extension("x-operation-extension", "barbaz")
+        op list(): Pet[];
+      }
+      `
+    );
+    ok(oapi.paths["/"].get);
+    strictEqual(oapi.paths["/"].get["x-operation-extension"], "barbaz");
+  });
+});
+
 async function oapiForModel(name: string, modelDef: string) {
   const oapi = await openApiFor(`
     ${modelDef};

--- a/packages/openapi3/test/test-openapi-output.ts
+++ b/packages/openapi3/test/test-openapi-output.ts
@@ -560,6 +560,33 @@ describe("openapi3: extension decorator", () => {
     ok(oapi.paths["/"].get);
     strictEqual(oapi.paths["/"].get["x-operation-extension"], "barbaz");
   });
+
+  it("adds an arbitrary extension to a parameter", async () => {
+    const oapi = await openApiFor(
+      `
+      model Pet {
+        name: string;
+      }
+      model PetId {
+        @path
+        @extension("x-parameter-extension", "foobaz")
+        petId: string;
+      }
+      @route("/Pets")
+      namespace root {
+        @get()
+        op get(... PetId): Pet;
+      }
+      `
+    );
+    ok(oapi.paths["/Pets/{petId}"].get);
+    strictEqual(
+      oapi.paths["/Pets/{petId}"].get.parameters[0]["$ref"],
+      "#/components/parameters/PetId"
+    );
+    strictEqual(oapi.components.parameters.PetId.name, "petId");
+    strictEqual(oapi.components.parameters.PetId["x-parameter-extension"], "foobaz");
+  });
 });
 
 async function oapiForModel(name: string, modelDef: string) {


### PR DESCRIPTION
This PR adds support in the openapi3 emitter for the `@extension` decorator on parameters and adds tests for `@extension` on models, operations, and parameters.