### PR TITLE
Add openapi3 support for Cadl safeint

### DIFF
--- a/common/changes/@cadl-lang/openapi3/openapi3-safeint_2021-11-28-20-49.json
+++ b/common/changes/@cadl-lang/openapi3/openapi3-safeint_2021-11-28-20-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Add openapi3 support for Cadl safeint",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1161,6 +1161,8 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
             return applyIntrinsicDecorators(cadlType, { type: "integer", format: "int32" });
           case "int64":
             return applyIntrinsicDecorators(cadlType, { type: "integer", format: "int64" });
+          case "safeint":
+            return applyIntrinsicDecorators(cadlType, { type: "integer", format: "int64" });
           case "uint8":
             return applyIntrinsicDecorators(cadlType, { type: "integer", format: "uint8" });
           case "uint16":

--- a/packages/openapi3/test/test-openapi-output.ts
+++ b/packages/openapi3/test/test-openapi-output.ts
@@ -384,6 +384,7 @@ describe("openapi3: primitives", () => {
     ["int16", { type: "integer", format: "int16" }],
     ["int32", { type: "integer", format: "int32" }],
     ["int64", { type: "integer", format: "int64" }],
+    ["safeint", { type: "integer", format: "int64" }],
     ["uint8", { type: "integer", format: "uint8" }],
     ["uint16", { type: "integer", format: "uint16" }],
     ["uint32", { type: "integer", format: "uint32" }],


### PR DESCRIPTION
Tiny PR to add support for the Cadl `safeint` type to openapi3.