### PR TITLE
Openapi3 support for discriminated unions

### DIFF
--- a/common/changes/@cadl-lang/openapi3/discriminator_2021-12-18-14-55.json
+++ b/common/changes/@cadl-lang/openapi3/discriminator_2021-12-18-14-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Openapi3 support for discriminated unions",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -6,7 +6,7 @@ const libDef = {
     "decorator-wrong-type": {
       severity: "error",
       messages: {
-        default: paramMessage`Cannot apply ${"decoratorName"} decorator to ${"entityKind"}`,
+        default: paramMessage`Cannot use @${"decorator"} on a ${"entityKind"}`,
         modelsOperations: paramMessage`${"decoratorName"} decorator can only be applied to models and operation parameters.`,
       },
     },
@@ -68,7 +68,22 @@ const libDef = {
         null: "Unions containing multiple model types cannot be emitted to OpenAPI v2 unless the union is between one model type and 'null'.",
       },
     },
-
+    discriminator: {
+      severity: "error",
+      messages: {
+        duplicate: paramMessage`Discriminator value "${"val"}" defined in two different variants: ${"model1"} and ${"model2"}`,
+        missing: "The discriminator property is not defined in a variant of a discriminated union.",
+        required: "The discriminator property must be a required property.",
+        type: "The discriminator property must be type 'string'.",
+      },
+    },
+    "discriminator-value": {
+      severity: "warning",
+      messages: {
+        literal:
+          "Each variant of a discriminated union should define the discriminator property with a string literal value.",
+      },
+    },
     "invalid-default": {
       severity: "error",
       messages: {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -3,6 +3,7 @@ import {
   checkIfServiceNamespace,
   EnumMemberType,
   EnumType,
+  findChildModels,
   getAllTags,
   getDoc,
   getFormat,
@@ -10,6 +11,7 @@ import {
   getMaxValue,
   getMinLength,
   getMinValue,
+  getProperty,
   getServiceHost,
   getServiceNamespaceString,
   getServiceTitle,
@@ -29,7 +31,7 @@ import {
   UnionType,
   UnionTypeVariant,
 } from "@cadl-lang/compiler";
-import { getAllRoutes, http, OperationDetails } from "@cadl-lang/rest";
+import { getAllRoutes, getDiscriminator, http, OperationDetails } from "@cadl-lang/rest";
 import * as path from "path";
 import { reportDiagnostic } from "./lib.js";
 
@@ -49,7 +51,7 @@ export function $operationId(program: Program, entity: Type, opId: string) {
   if (entity.kind !== "Operation") {
     reportDiagnostic(program, {
       code: "decorator-wrong-type",
-      format: { decoratorName: "operationId", entityKind: entity.kind },
+      format: { decorator: "operationId", entityKind: entity.kind },
       target: entity,
     });
     return;
@@ -62,7 +64,7 @@ export function $pageable(program: Program, entity: Type, nextLinkName: string =
   if (entity.kind !== "Operation") {
     reportDiagnostic(program, {
       code: "decorator-wrong-type",
-      format: { decoratorName: "pageable", entityKind: entity.kind },
+      format: { decorator: "pageable", entityKind: entity.kind },
       target: entity,
     });
     return;
@@ -98,7 +100,7 @@ export function $oneOf(program: Program, entity: Type) {
   if (entity.kind !== "Union") {
     reportDiagnostic(program, {
       code: "decorator-wrong-type",
-      format: { decoratorName: "oneOf", entityKind: entity.kind },
+      format: { decorator: "oneOf", entityKind: entity.kind },
       target: entity,
     });
     return;
@@ -864,6 +866,28 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       description: getDoc(program, model),
     };
 
+    const discriminator = getDiscriminator(program, model);
+    if (discriminator) {
+      const childModels = findChildModels(program, model);
+
+      if (!validateDiscriminator(discriminator, childModels)) {
+        // appropriate diagnostic is generated with the validate function
+        return {};
+      }
+
+      // getSchemaOrRef on all children to push them into components.schemas
+      for (let child of childModels) {
+        getSchemaOrRef(child);
+      }
+
+      const mapping = getDiscriminatorMapping(discriminator, childModels);
+      if (mapping) {
+        discriminator.mapping = mapping;
+      }
+
+      modelSchema.discriminator = discriminator;
+    }
+
     for (const [name, prop] of model.properties) {
       if (!isSchemaProperty(prop)) {
         continue;
@@ -932,6 +956,103 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
         emitObject[key] = extensions.get(key);
       }
     }
+  }
+
+  function validateDiscriminator(discriminator: any, childModels: ModelType[]): boolean {
+    const { propertyName } = discriminator;
+    var retVals = childModels.map((t) => {
+      const prop = getProperty(t, propertyName);
+      if (!prop) {
+        reportDiagnostic(program, { code: "discriminator", messageId: "missing", target: t });
+        return false;
+      }
+      var retval = true;
+      if (!isOasString(prop.type)) {
+        reportDiagnostic(program, { code: "discriminator", messageId: "type", target: prop });
+        retval = false;
+      }
+      if (prop.optional) {
+        reportDiagnostic(program, { code: "discriminator", messageId: "required", target: prop });
+        retval = false;
+      }
+      return retval;
+    });
+    // Map of discriminator value to the model in which it is declared
+    const discriminatorValues = new Map<string, string>();
+    for (let t of childModels) {
+      // Get the discriminator property directly in the child model
+      const prop = t.properties?.get(propertyName);
+      // Issue warning diagnostic if discriminator property missing or is not a string literal
+      if (!prop || !isStringLiteral(prop.type)) {
+        reportDiagnostic(program, {
+          code: "discriminator-value",
+          messageId: "literal",
+          target: prop || t,
+        });
+      }
+      if (prop) {
+        const vals = getStringValues(prop.type);
+        vals.forEach((val) => {
+          if (discriminatorValues.has(val)) {
+            reportDiagnostic(program, {
+              code: "discriminator",
+              messageId: "duplicate",
+              format: { val: val, model1: discriminatorValues.get(val)!, model2: t.name },
+              target: prop,
+            });
+            retVals.push(false);
+          } else {
+            discriminatorValues.set(val, t.name);
+          }
+        });
+      }
+    }
+    return retVals.every((v) => v);
+  }
+
+  function getDiscriminatorMapping(discriminator: any, childModels: ModelType[]) {
+    const { propertyName } = discriminator;
+    const getMapping = (t: ModelType): any => {
+      const prop = t.properties?.get(propertyName);
+      if (prop) {
+        return getStringValues(prop.type).flatMap((v) => [{ [v]: getSchemaOrRef(t).$ref }]);
+      }
+      return undefined;
+    };
+    var mappings = childModels.flatMap(getMapping).filter((v) => v); // only defined values
+    return mappings.length > 0 ? mappings.reduce((a, s) => ({ ...a, ...s }), {}) : undefined;
+  }
+
+  // An openapi "string" can be defined in several different ways in Cadl
+  function isOasString(type: Type): boolean {
+    if (type.kind === "String") {
+      // A string literal
+      return true;
+    } else if (type.kind === "Model" && type.name === "string") {
+      // string type
+      return true;
+    } else if (type.kind === "Union") {
+      // A union where all variants are an OasString
+      return type.options.every((o) => isOasString(o));
+    }
+    return false;
+  }
+
+  function isStringLiteral(type: Type): boolean {
+    return (
+      type.kind === "String" ||
+      (type.kind === "Union" && type.options.every((o) => o.kind === "String"))
+    );
+  }
+
+  // Return any string literal values for type
+  function getStringValues(type: Type): string[] {
+    if (type.kind === "String") {
+      return [type.value];
+    } else if (type.kind === "Union") {
+      return type.options.flatMap(getStringValues).filter((v) => v);
+    }
+    return [];
   }
 
   /**

--- a/packages/openapi3/test/test-discriminator.ts
+++ b/packages/openapi3/test/test-discriminator.ts
@@ -1,0 +1,382 @@
+import { ModelType, ModelTypeProperty } from "@cadl-lang/compiler";
+import { deepStrictEqual, match, ok, strictEqual } from "assert";
+import { createOpenAPITestHost, openApiFor } from "./testHost.js";
+
+describe("openapi3: discriminated unions", () => {
+  it("defines unions with discriminators", async () => {
+    const openApi = await openApiFor(`
+      @discriminator("kind")
+      model Pet { }
+      model Cat extends Pet {
+        kind: "cat";
+        meow: int32;
+      }
+      model Dog extends Pet {
+        kind: "dog";
+        bark: string;
+      }
+
+      @route("/")
+      namespace root {
+        op read(): { @body body: Pet };
+      }
+      `);
+    ok(openApi.components.schemas.Pet, "expected definition named Pet");
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    ok(openApi.components.schemas.Dog, "expected definition named Dog");
+    deepStrictEqual(openApi.paths["/"].get.responses["200"].content["application/json"].schema, {
+      $ref: "#/components/schemas/Pet",
+    });
+    deepStrictEqual(openApi.components.schemas.Pet, {
+      type: "object",
+      properties: {},
+      discriminator: {
+        propertyName: "kind",
+        mapping: {
+          cat: "#/components/schemas/Cat",
+          dog: "#/components/schemas/Dog",
+        },
+      },
+    });
+    deepStrictEqual(openApi.components.schemas.Cat.allOf, [{ $ref: "#/components/schemas/Pet" }]);
+    deepStrictEqual(openApi.components.schemas.Dog.allOf, [{ $ref: "#/components/schemas/Pet" }]);
+  });
+
+  it("defines discriminated unions with non-empty base type", async () => {
+    const openApi = await openApiFor(`
+      @discriminator("kind")
+      model Pet {
+        name: string;
+        weight?: float32;
+      }
+      model Cat extends Pet {
+        kind: "cat";
+        meow: int32;
+      }
+      model Dog extends Pet {
+        kind: "dog";
+        bark: string;
+      }
+
+      @route("/")
+      namespace root {
+        op read(): { @body body: Pet };
+      }
+      `);
+    ok(openApi.components.schemas.Pet, "expected definition named Pet");
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    ok(openApi.components.schemas.Dog, "expected definition named Dog");
+    deepStrictEqual(openApi.paths["/"].get.responses["200"].content["application/json"].schema, {
+      $ref: "#/components/schemas/Pet",
+    });
+    deepStrictEqual(openApi.components.schemas.Pet, {
+      type: "object",
+      properties: { name: { type: "string" }, weight: { type: "number", format: "float" } },
+      required: ["name"],
+      discriminator: {
+        propertyName: "kind",
+        mapping: {
+          cat: "#/components/schemas/Cat",
+          dog: "#/components/schemas/Dog",
+        },
+      },
+    });
+    deepStrictEqual(openApi.components.schemas.Cat.allOf, [{ $ref: "#/components/schemas/Pet" }]);
+    deepStrictEqual(openApi.components.schemas.Dog.allOf, [{ $ref: "#/components/schemas/Pet" }]);
+  });
+
+  it("defines discriminated unions with discriminator property in base type", async () => {
+    const openApi = await openApiFor(`
+    @discriminator("kind")
+    model Pet {
+      kind: "cat" | "dog";
+      name: string;
+    }
+    #suppress "@cadl-lang/openapi3/discriminator-value" "need to do this"
+    model Cat extends Pet {
+      meow: int32;
+    }
+    #suppress "@cadl-lang/openapi3/discriminator-value" "need to do this"
+    model Dog extends Pet {
+      bark: string;
+    }
+
+    @route("/")
+    namespace root {
+      op read(): { @body body: Pet };
+    }
+    `);
+    ok(openApi.components.schemas.Pet, "expected definition named Pet");
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    ok(openApi.components.schemas.Dog, "expected definition named Dog");
+    deepStrictEqual(openApi.paths["/"].get.responses["200"].content["application/json"].schema, {
+      $ref: "#/components/schemas/Pet",
+    });
+    deepStrictEqual(openApi.components.schemas.Pet, {
+      type: "object",
+      properties: {
+        kind: { type: "string", enum: ["cat", "dog"], "x-cadl-name": "cat | dog" },
+        name: { type: "string" },
+      },
+      required: ["kind", "name"],
+      discriminator: { propertyName: "kind" },
+    });
+    deepStrictEqual(openApi.components.schemas.Cat.allOf, [{ $ref: "#/components/schemas/Pet" }]);
+    deepStrictEqual(openApi.components.schemas.Dog.allOf, [{ $ref: "#/components/schemas/Pet" }]);
+  });
+
+  it("defines discriminated unions with more than one level of inheritance", async () => {
+    const openApi = await openApiFor(`
+      @discriminator("kind")
+      model Pet {
+        name: string;
+        weight?: float32;
+      }
+      model Cat extends Pet {
+        kind: "cat";
+        meow: int32;
+      }
+      model Dog extends Pet {
+        kind: "dog";
+        bark: string;
+      }
+      model Beagle extends Dog {
+        purebred: boolean;
+      }
+
+      @route("/")
+      namespace root {
+        op read(): { @body body: Pet };
+      }
+      `);
+    ok(openApi.components.schemas.Pet, "expected definition named Pet");
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    ok(openApi.components.schemas.Dog, "expected definition named Dog");
+    // Child models are not pushed out to the emitter if they are not actually referenced in the API.
+    // This is orthogonal to support for discriminators so I'm leaving it alone.
+    //ok(openApi.components.schemas.Beagle, "expected definition named Beagle");
+    deepStrictEqual(openApi.paths["/"].get.responses["200"].content["application/json"].schema, {
+      $ref: "#/components/schemas/Pet",
+    });
+    deepStrictEqual(openApi.components.schemas.Pet, {
+      type: "object",
+      properties: { name: { type: "string" }, weight: { type: "number", format: "float" } },
+      required: ["name"],
+      discriminator: {
+        propertyName: "kind",
+        mapping: {
+          cat: "#/components/schemas/Cat",
+          dog: "#/components/schemas/Dog",
+        },
+      },
+    });
+    deepStrictEqual(openApi.components.schemas.Cat.allOf, [{ $ref: "#/components/schemas/Pet" }]);
+    deepStrictEqual(openApi.components.schemas.Dog.allOf, [{ $ref: "#/components/schemas/Pet" }]);
+  });
+
+  it("defines nested discriminated unions", async () => {
+    const openApi = await openApiFor(`
+      @discriminator("kind")
+      model Pet {
+        name: string;
+        weight?: float32;
+      }
+      model Cat extends Pet {
+        kind: "cat";
+        meow: int32;
+      }
+      @discriminator("breed")
+      model Dog extends Pet {
+        kind: "dog";
+        bark: string;
+      }
+      #suppress "@cadl-lang/openapi3/discriminator-value" "kind defined in parent"
+      model Beagle extends Dog {
+        breed: "beagle";
+      }
+      #suppress "@cadl-lang/openapi3/discriminator-value" "kind defined in parent"
+      model Poodle extends Dog {
+        breed: "poodle";
+      }
+
+      @route("/")
+      namespace root {
+        op read(): { @body body: Pet };
+      }
+      `);
+    ok(openApi.components.schemas.Pet, "expected definition named Pet");
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    ok(openApi.components.schemas.Dog, "expected definition named Dog");
+    ok(openApi.components.schemas.Beagle, "expected definition named Beagle");
+    ok(openApi.components.schemas.Poodle, "expected definition named Poodle");
+    deepStrictEqual(openApi.paths["/"].get.responses["200"].content["application/json"].schema, {
+      $ref: "#/components/schemas/Pet",
+    });
+    deepStrictEqual(openApi.components.schemas.Pet, {
+      type: "object",
+      properties: { name: { type: "string" }, weight: { type: "number", format: "float" } },
+      required: ["name"],
+      discriminator: {
+        propertyName: "kind",
+        mapping: {
+          cat: "#/components/schemas/Cat",
+          dog: "#/components/schemas/Dog",
+        },
+      },
+    });
+    deepStrictEqual(openApi.components.schemas.Dog, {
+      type: "object",
+      properties: { kind: { type: "string", enum: ["dog"] }, bark: { type: "string" } },
+      required: ["kind", "bark"],
+      allOf: [{ $ref: "#/components/schemas/Pet" }],
+      discriminator: {
+        propertyName: "breed",
+        mapping: {
+          beagle: "#/components/schemas/Beagle",
+          poodle: "#/components/schemas/Poodle",
+        },
+      },
+    });
+    deepStrictEqual(openApi.components.schemas.Beagle.allOf, [
+      { $ref: "#/components/schemas/Dog" },
+    ]);
+    deepStrictEqual(openApi.components.schemas.Poodle.allOf, [
+      { $ref: "#/components/schemas/Dog" },
+    ]);
+  });
+
+  it("adds mapping entries to the discriminator when appropriate", async () => {
+    const openApi = await openApiFor(`
+      @discriminator("kind")
+      model Pet { }
+      model Cat extends Pet {
+        kind: "cat" | "feline";
+        meow: int32;
+      }
+      model Dog extends Pet {
+        kind: "dog";
+        bark: string;
+      }
+      #suppress "@cadl-lang/openapi3/discriminator-value" "need to do this"
+      model Lizard extends Pet {
+        kind: string;
+      }
+
+      @route("/")
+      namespace root {
+        op read(): { @body body: Pet };
+      }
+      `);
+    ok(openApi.components.schemas.Pet, "expected definition named Pet");
+    ok(openApi.components.schemas.Cat, "expected definition named Cat");
+    ok(openApi.components.schemas.Dog, "expected definition named Dog");
+    ok(openApi.components.schemas.Lizard, "expected definition named Lizard");
+    deepStrictEqual(openApi.paths["/"].get.responses["200"].content["application/json"].schema, {
+      $ref: "#/components/schemas/Pet",
+    });
+    deepStrictEqual(openApi.components.schemas.Pet, {
+      type: "object",
+      properties: {},
+      discriminator: {
+        propertyName: "kind",
+        mapping: {
+          cat: "#/components/schemas/Cat",
+          dog: "#/components/schemas/Dog",
+          feline: "#/components/schemas/Cat",
+        },
+      },
+    });
+  });
+
+  it("issues diagnostics for errors in a discriminated union", async () => {
+    let testHost = await createOpenAPITestHost();
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+      import "rest";
+      import "openapi3";
+      using Cadl.Http;
+
+      @discriminator("kind")
+      model Pet {
+        name: string;
+        weight?: float32;
+      }
+      model Cat extends Pet {
+        kind: "cat";
+        meow: int32;
+      }
+      model Dog extends Pet {
+        petType: "dog";
+        bark: string;
+      }
+      model Pig extends Pet {
+        kind: int32;
+        oink: float32;
+      }
+      model Tiger extends Pet {
+        kind?: "tiger";
+        claws: float32;
+      }
+      model Lizard extends Pet {
+        kind: string;
+        tail: float64;
+      }
+
+      @route("/")
+      namespace root {
+        op read(): { @body body: Pet };
+      }
+      `
+    );
+    const diagnostics = await testHost.diagnose("./");
+    strictEqual(diagnostics.length, 6);
+    strictEqual((diagnostics[0].target as ModelType).name, "Dog");
+    match(diagnostics[0].message, /not defined in a variant of a discriminated union/);
+    strictEqual((diagnostics[1].target as ModelTypeProperty).name, "kind"); // Pig.kind
+    match(diagnostics[1].message, /must be type 'string'/);
+    strictEqual((diagnostics[2].target as ModelTypeProperty).name, "kind"); // Tiger.kind
+    match(diagnostics[2].message, /must be a required property/);
+    strictEqual((diagnostics[3].target as ModelType).name, "Dog");
+    match(diagnostics[3].message, /define the discriminator property with a string literal value/);
+    match(diagnostics[4].message, /define the discriminator property with a string literal value/); // Pig.kind
+    match(diagnostics[5].message, /define the discriminator property with a string literal value/); // Lizard.kind
+  });
+
+  it("issues diagnostics for duplicate discriminator values", async () => {
+    let testHost = await createOpenAPITestHost();
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+      import "rest";
+      import "openapi3";
+      using Cadl.Http;
+
+      @discriminator("kind")
+      model Pet {
+      }
+      model Cat extends Pet {
+        kind: "cat" | "feline" | "housepet";
+        meow: int32;
+      }
+      model Dog extends Pet {
+        kind: "dog" | "housepet";
+        bark: string;
+      }
+      model Beagle extends Pet {
+        kind: "dog";
+        bark: string;
+      }
+
+      @route("/")
+      namespace root {
+        op read(): { @body body: Pet };
+      }
+      `
+    );
+    const diagnostics = await testHost.diagnose("./");
+    strictEqual(diagnostics.length, 2);
+    match(diagnostics[0].message, /"housepet" defined in two different variants: Cat and Dog/);
+    match(diagnostics[1].message, /"dog" defined in two different variants: Dog and Beagle/);
+  });
+});


### PR DESCRIPTION
This PR adds support for the OpenAPI `discriminator` as a means to describe the type of polymorphism commonly referred to as "discriminated unions".