### PR TITLE
Fix issues with unhandled exceptions

### DIFF
--- a/common/changes/@cadl-lang/compiler/internal-error-in-language-server_2021-12-01-01-04.json
+++ b/common/changes/@cadl-lang/compiler/internal-error-in-language-server_2021-12-01-01-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix language server crashes in certain error cases",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -1363,6 +1363,7 @@ export function createChecker(program: Program): Checker {
 
       decorators.unshift({
         decorator: sym.value,
+        node: decNode,
         args,
       });
     }
@@ -1644,8 +1645,8 @@ export function createChecker(program: Program): Checker {
         program.reportDiagnostic(
           createDiagnostic({
             code: "decorator-fail",
-            format: { decoratorName: decApp.decorator.name, error },
-            target,
+            format: { decoratorName: decApp.decorator.name, error: error.stack },
+            target: decApp.node ?? target,
           })
         );
       } else {

--- a/packages/compiler/core/cli.ts
+++ b/packages/compiler/core/cli.ts
@@ -10,7 +10,7 @@ import { loadCadlConfigInDir } from "../config/index.js";
 import { CompilerOptions } from "../core/options.js";
 import { compile, Program } from "../core/program.js";
 import { initCadlProject } from "../init/index.js";
-import { compilerAssert, dumpError, logDiagnostics } from "./diagnostics.js";
+import { compilerAssert, logDiagnostics } from "./diagnostics.js";
 import { findUnformattedCadlFiles, formatCadlFiles } from "./formatter.js";
 import { installCadlDependencies } from "./install.js";
 import { Diagnostic } from "./types.js";
@@ -559,8 +559,9 @@ function internalCompilerError(error: Error) {
   // considered a bug and therefore we should not suppress the stack trace as
   // that risks losing it in the case of a bug that does not repro easily.
   console.error("Internal compiler error!");
-  console.error("File issue at https://github.com/azure/adl");
-  dumpError(error, NodeHost.logSink);
+  console.error("File issue at https://github.com/microsoft/cadl");
+  console.error();
+  console.error(error);
   process.exit(1);
 }
 

--- a/packages/compiler/core/diagnostics.ts
+++ b/packages/compiler/core/diagnostics.ts
@@ -1,6 +1,7 @@
 import { AssertionError } from "assert";
 import { CharCode } from "./charcode.js";
 import { formatLog } from "./logger.js";
+import { isSynthetic } from "./parser.js";
 import { Program } from "./program.js";
 import {
   Diagnostic,
@@ -80,45 +81,8 @@ export function createDiagnosticCreator<T extends { [code: string]: DiagnosticMe
   } as any;
 }
 
-/**
- * Represents a failure with multiple errors.
- */
-export class AggregateError extends Error {
-  readonly errors: readonly Error[];
-
-  constructor(...errors: (Error | undefined)[]) {
-    super("Multiple errors. See errors array.");
-    this.errors = errors.filter(isNotUndefined);
-    // Tests don't have our catch all handler so log the inner errors now.
-    logVerboseTestOutput((log) => this.errors.map((e) => dumpError(e, log)));
-  }
-}
-
 export type WriteLine = (text?: string) => void;
 export type DiagnosticHandler = (diagnostic: Diagnostic) => void;
-
-export function computeTargetLocation(
-  target?: DiagnosticTarget | typeof NoTarget
-): SourceLocation | undefined {
-  let location: SourceLocation | undefined;
-  let locationError: Error | undefined;
-  if (target !== undefined && target !== NoTarget) {
-    try {
-      location = getSourceLocation(target);
-    } catch (err: any) {
-      locationError = err;
-      location = createDummySourceLocation();
-    }
-  }
-  if (locationError) {
-    const diagnosticError = new Error(
-      "Error(s) occurred trying to resolve target: " + target?.toString()
-    );
-    throw new AggregateError(diagnosticError, locationError);
-  }
-
-  return location;
-}
 
 export function logDiagnostics(diagnostics: readonly Diagnostic[], logger: LogSink) {
   for (const diagnostic of diagnostics) {
@@ -126,7 +90,7 @@ export function logDiagnostics(diagnostics: readonly Diagnostic[], logger: LogSi
       level: diagnostic.severity,
       message: diagnostic.message,
       code: diagnostic.code,
-      sourceLocation: computeTargetLocation(diagnostic.target),
+      sourceLocation: getSourceLocation(diagnostic.target),
     });
   }
 }
@@ -136,7 +100,7 @@ export function formatDiagnostic(diagnostic: Diagnostic) {
     code: diagnostic.code,
     level: diagnostic.severity,
     message: diagnostic.message,
-    sourceLocation: computeTargetLocation(diagnostic.target),
+    sourceLocation: getSourceLocation(diagnostic.target),
   });
 }
 
@@ -176,7 +140,18 @@ export function createSourceFile(text: string, path: string): SourceFile {
   }
 }
 
-export function getSourceLocation(target: DiagnosticTarget): SourceLocation {
+export function getSourceLocation(target: DiagnosticTarget): SourceLocation;
+export function getSourceLocation(target: typeof NoTarget | undefined): undefined;
+export function getSourceLocation(
+  target: DiagnosticTarget | typeof NoTarget | undefined
+): SourceLocation | undefined;
+export function getSourceLocation(
+  target: DiagnosticTarget | typeof NoTarget | undefined
+): SourceLocation | undefined {
+  if (target === NoTarget || target === undefined) {
+    return undefined;
+  }
+
   if ("file" in target) {
     return target;
   }
@@ -208,7 +183,13 @@ function getSourceLocationOfNode(node: Node): SourceLocation {
     root = root.parent;
   }
 
-  compilerAssert(root.kind === SyntaxKind.CadlScript, "Cannot obtain source file of unbound node.");
+  if (root.kind !== SyntaxKind.CadlScript) {
+    return createDummySourceLocation(
+      isSynthetic(node)
+        ? undefined
+        : "<unknown location - cannot obtain source location of unbound node - file bug at https://github.com/microsoft/cadl>"
+    );
+  }
 
   return {
     file: root.file,
@@ -235,17 +216,6 @@ export function logVerboseTestOutput(messageOrCallback: string | ((log: LogSink)
         log: ({ message }) => console.log(message),
       });
     }
-  }
-}
-
-export function dumpError(error: Error, logger: LogSink) {
-  if (error instanceof AggregateError) {
-    for (const inner of error.errors) {
-      dumpError(inner, logger);
-    }
-  } else {
-    logger.log({ level: "info", message: "" });
-    logger.log({ level: "error", message: error.stack ?? "" });
   }
 }
 
@@ -288,16 +258,7 @@ export function compilerAssert(
     }
   }
 
-  const error = new AssertionError({ message });
-  if (locationError) {
-    throw new AggregateError(error, locationError);
-  } else {
-    throw error;
-  }
-}
-
-function isNotUndefined<T>(value: T | undefined): value is T {
-  return value !== undefined;
+  throw new AssertionError({ message });
 }
 
 function scanLineStarts(text: string): number[] {

--- a/packages/compiler/core/logger.ts
+++ b/packages/compiler/core/logger.ts
@@ -1,4 +1,4 @@
-import { computeTargetLocation } from "./diagnostics.js";
+import { getSourceLocation } from "./diagnostics.js";
 import { Logger, LogInfo, LogLevel, LogSink, ProcessedLog, SourceLocation } from "./types.js";
 
 const LogLevels = {
@@ -42,7 +42,7 @@ function processLog(log: LogInfo): ProcessedLog {
     level: log.level,
     code: log.code,
     message: log.message,
-    sourceLocation: computeTargetLocation(log.target),
+    sourceLocation: getSourceLocation(log.target),
   };
 }
 

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -307,7 +307,7 @@ const diagnostics = {
   "decorator-fail": {
     severity: "error",
     messages: {
-      default: paramMessage`${"decoratorName"} failed with errors. ${"error"}`,
+      default: paramMessage`Decorator ${"decoratorName"} failed!\n\n${"error"}`,
     },
   },
 
@@ -344,14 +344,10 @@ const diagnostics = {
       default: paramMessage`Duplicate name: "${"name"}"`,
     },
   },
-
-  /**
-   * Binder
-   */
   "on-build-fail": {
     severity: "error",
     messages: {
-      default: paramMessage`onBuild failed with errors. ${"error"}`,
+      default: paramMessage`onBuild failed!\n\n${"error"}`,
     },
   },
 

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -114,6 +114,11 @@ export const enum NodeFlags {
    * transitively) has a parse error.
    */
   DescendantHasError = 1 << 2,
+
+  /**
+   * Indicates that a node was created synthetically and therefore may not be parented.
+   */
+  Synthetic = 1 << 3,
 }
 
 /**
@@ -1591,6 +1596,10 @@ export function hasParseError(node: Node) {
 
   checkForDescendantErrors(node);
   return getFlag(node, NodeFlags.DescendantHasError);
+}
+
+export function isSynthetic(node: Node) {
+  return getFlag(node, NodeFlags.Synthetic);
 }
 
 function checkForDescendantErrors(node: Node) {

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -9,6 +9,7 @@ export type DecoratorArgument = Type | number | string | boolean;
 export interface DecoratorApplication {
   decorator: DecoratorFunction;
   args: DecoratorArgument[];
+  node?: DecoratorExpressionNode;
 }
 
 export interface DecoratorFunction {

--- a/packages/compiler/formatter/parser.ts
+++ b/packages/compiler/formatter/parser.ts
@@ -1,5 +1,5 @@
 import { Parser, ParserOptions } from "prettier";
-import { computeTargetLocation } from "../core/diagnostics.js";
+import { getSourceLocation } from "../core/diagnostics.js";
 import { parse as cadlParse } from "../core/parser.js";
 import { CadlScriptNode, Diagnostic } from "../core/types.js";
 
@@ -20,7 +20,7 @@ export class PrettierParserError extends Error {
   public loc: { start: number; end: number };
   public constructor(public readonly error: Diagnostic) {
     super(error.message);
-    const location = computeTargetLocation(error.target);
+    const location = getSourceLocation(error.target);
     this.loc = {
       start: location?.pos ?? 0,
       end: location?.end ?? 0,

--- a/packages/compiler/test/checker/cloneType.ts
+++ b/packages/compiler/test/checker/cloneType.ts
@@ -3,7 +3,7 @@ import { Program } from "../../core/program.js";
 import { Type } from "../../core/types.js";
 import { createTestHost, TestHost } from "../test-host.js";
 
-describe("type cloning", () => {
+describe("compiler: type cloning", () => {
   let testHost: TestHost;
   const blues = new Set();
 


### PR DESCRIPTION
- Simplify handling of unbound target node by replacing AggregateError with embedding note about bug in dummy location
- Add synthetic node flag to detect case where no parent is expected
- Move onBuild catch handler to correct place
- Refine target of decorator failure diagnostic to decorator expression
- Add complete stacks to decorator and onBuild failure diagnostics in language server builds
- Add catch-all to language server compilation and report internal compiler error without tearing down the server
- (Unrelated) Add missing library prefix to one unit test

Failed decorators and onBuild look like this now:

![image](https://user-images.githubusercontent.com/75470/144154629-64da5abe-1a8d-444f-9bc7-f12b96370f94.png)

And any other unhandled exception during language server compilation looks like this:

![image](https://user-images.githubusercontent.com/75470/144154703-d9241967-4fee-4eff-9fbb-3a78979b314a.png)

Fix #92
Fix #93 (except that `using Cadl` still generates a ton of duplicate symbol diagnostics, but that can be handled as part of #79) 
Fix Azure/cadl-azure#963