### PR TITLE
Add READMEs for all packages, update existing ones

### DIFF
--- a/common/changes/@cadl-lang/compiler/readmes_2021-12-01-19-54.json
+++ b/common/changes/@cadl-lang/compiler/readmes_2021-12-01-19-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Update README",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi3/readmes_2021-12-01-19-54.json
+++ b/common/changes/@cadl-lang/openapi3/readmes_2021-12-01-19-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Add README",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/prettier-plugin-cadl/readmes_2021-12-01-19-54.json
+++ b/common/changes/@cadl-lang/prettier-plugin-cadl/readmes_2021-12-01-19-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/prettier-plugin-cadl",
+      "comment": "Update README",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/prettier-plugin-cadl"
+}

--- a/common/changes/@cadl-lang/rest/readmes_2021-12-01-19-54.json
+++ b/common/changes/@cadl-lang/rest/readmes_2021-12-01-19-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add README",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/cadl-vs/readmes_2021-12-01-19-54.json
+++ b/common/changes/cadl-vs/readmes_2021-12-01-19-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vs",
+      "comment": "Update README",
+      "type": "patch"
+    }
+  ],
+  "packageName": "cadl-vs"
+}

--- a/common/changes/cadl-vscode/readmes_2021-12-01-19-54.json
+++ b/common/changes/cadl-vscode/readmes_2021-12-01-19-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vscode",
+      "comment": "Update README",
+      "type": "patch"
+    }
+  ],
+  "packageName": "cadl-vscode"
+}

--- a/common/changes/tmlanguage-generator/readmes_2021-12-01-19-54.json
+++ b/common/changes/tmlanguage-generator/readmes_2021-12-01-19-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "tmlanguage-generator",
+      "comment": "Update README",
+      "type": "patch"
+    }
+  ],
+  "packageName": "tmlanguage-generator"
+}

--- a/packages/cadl-vs/README.md
+++ b/packages/cadl-vs/README.md
@@ -1,5 +1,7 @@
 # Cadl Language Support for Visual Studio
 
-NOTE: This package is used as an implementation detail of the `cadl vs`
-command that installs the Visual Studio Cadl extension, and not intended to
-be used for other purposes.
+This package provides [Cadl](https://github.com/microsoft/cadl) language support for Visual Studio 2019 and 2022.
+
+See https://github.com/microsoft/cadl#installing-visual-studio-extension for installation instructions.
+
+**NOTE**: The npm package is used as an implementation detail of the `cadl vs` command that installs the Visual Studio Cadl extension, and not intended to be used for other purposes.

--- a/packages/cadl-vscode/README.md
+++ b/packages/cadl-vscode/README.md
@@ -1,5 +1,7 @@
 # Cadl Language Support for VS Code
 
-NOTE: This package is used as an implementation detail of the `cadl code`
-command that installs the VS Code Cadl extension, and not intended to be
-used for other purposes.
+This provides provides [Cadl](https://github.com/microsoft/cadl) language support for VS Code.
+
+See https://github.com/microsoft/cadl#installing-vs-code-extension for installation instructions.
+
+**NOTE**: The npm package is used as an implementation detail of the `cadl vscode` command that installs the Visual Studio Cadl extension, and not intended to be used for other purposes.

--- a/packages/openapi3/README.md
+++ b/packages/openapi3/README.md
@@ -1,0 +1,9 @@
+# Cadl OpenAPI 3.0 Emitter
+
+This package provides the [Cadl](https://github.com/microsoft/cadl) emitter to produce OpenAPI 3.0 output from Cadl source.
+
+## See also
+
+- [Cadl Getting Started](https://github.com/microsoft/cadl#getting-started)
+- [Cadl Tutorial](https://github.com/microsoft/cadl/blob/main/docs/tutorial.md)
+- [Cadl for the OpenAPI Developer](https://github.com/microsoft/cadl/blob/main/docs/cadl-for-openapi-dev.md)

--- a/packages/prettier-plugin-cadl/README.md
+++ b/packages/prettier-plugin-cadl/README.md
@@ -16,17 +16,3 @@ You can now call prettier
 ```bash
 ./node_modules/.bin/prettier --write '**/*.cadl'
 ```
-
-# Contributing
-
-This project welcomes contributions and suggestions. Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.microsoft.com.
-
-When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -1,7 +1,6 @@
-# Cadl compiler and CLI
+# Cadl Rest Library
 
-This package implements the core of the [Cadl](https://github.com/microsoft/cadl)
-compiler and its command-line interface.
+This package provides [Cadl](htps://github.com/microsoft/Cadl) decorators to describe REST API.
 
 ## See also
 

--- a/packages/samples/README.md
+++ b/packages/samples/README.md
@@ -1,0 +1,5 @@
+# Cadl Samples
+
+This project has a collection of samples used to demonstrate and test various Cadl features.
+
+It is not published as an npm package.

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -1,1 +1,5 @@
-This project builds the [Cadl Language Specification](../../docs/spec.html)
+# Cadl Specification Source
+
+This project builds the [Cadl Language Specification](../../docs/spec.html).
+
+It is not published as an npm package.

--- a/packages/tmlanguage-generator/README.md
+++ b/packages/tmlanguage-generator/README.md
@@ -1,1 +1,8 @@
-# Helper library for generating TextMate syntax highlighting files
+# TMLanguage Generator
+
+This package provides a helper library for authoring TextMate grammars using TypeScript.
+
+## Usage Examples
+
+- [Cadl](https://github.com/microsoft/cadl/blob/main/packages/cadl-vscode/src/tmlanguage.ts)
+- [Bicep](https://github.com/Azure/bicep/blob/main/src/textmate/src/bicep.ts)


### PR DESCRIPTION
The content is very terse and points back to the main README mostly, but at least we get these seeded and have something on the npm landing page.