### PR TITLE
Recover better from `op` in interface

### DIFF
--- a/common/changes/@cadl-lang/compiler/op-interface-recovery_2021-12-01-22-31.json
+++ b/common/changes/@cadl-lang/compiler/op-interface-recovery_2021-12-01-22-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Improve error recovery from `op` keyword in interfaces",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/cadl-vscode/op-interface-recovery_2021-12-01-22-31.json
+++ b/common/changes/cadl-vscode/op-interface-recovery_2021-12-01-22-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vscode",
+      "comment": "Improve error recovery from `op` keyword in interfaces",
+      "type": "patch"
+    }
+  ],
+  "packageName": "cadl-vscode"
+}

--- a/packages/cadl-vscode/src/tmlanguage.ts
+++ b/packages/cadl-vscode/src/tmlanguage.ts
@@ -349,9 +349,11 @@ const operationStatement: BeginEndRule = {
 const interfaceMember: BeginEndRule = {
   key: "interface-member",
   scope: meta,
-  begin: `(?:(${identifier}))`,
+  // `op` keyword is an error, but a common one, so recover from it
+  begin: `(?:\\b(op)\\b\\s+)?(${identifier})`,
   beginCaptures: {
-    "1": { scope: "entity.name.function.cadl" },
+    "1": { scope: "keyword.other.cadl" },
+    "2": { scope: "entity.name.type.cadl" },
   },
   end: universalEnd,
   patterns: [token, operationParameters, typeAnnotation],

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -166,6 +166,12 @@ const diagnostics = {
       default: paramMessage`Cannot decorate ${"nodeName"}.`,
     },
   },
+  "interface-op": {
+    severity: "error",
+    messages: {
+      default: "Interface operations cannot be prefixed with 'op' keyword",
+    },
+  },
 
   /**
    * Checker

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -490,6 +490,15 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
     pos: number,
     decorators: DecoratorExpressionNode[]
   ): OperationStatementNode {
+    if (token() === Token.OpKeyword) {
+      // Error recovery: common mistake to use `op` in interfaces as in
+      // namespaces or top-level. Better to assume it's an extra token
+      // before the operation name than an attempt to use `op` as the
+      // operation name.
+      error({ code: "interface-op" });
+      nextToken();
+    }
+
     const id = parseIdentifier();
     const parameters = parseOperationParameters();
     parseExpected(Token.Colon);

--- a/packages/compiler/test/test-parser.ts
+++ b/packages/compiler/test/test-parser.ts
@@ -139,6 +139,8 @@ describe("compiler: syntax", () => {
       "interface Foo { foo(): int32; }",
       "interface Foo { foo(): int32; bar(): int32; }",
     ]);
+
+    parseErrorEach([[`interface Foo { op foo(): int32 }`, [/'op' keyword/]]]);
   });
   describe("model expressions", () => {
     parseEach(['model Car { engine: { type: "v8" } }']);


### PR DESCRIPTION
I keep making this mistake and seeing it in @daviwil's video too, I thought it might be worth better deliberate error recovery. I'm not 100% sure if this sort of special casing is worth it or not, but thought I'd offer it up, and see what folks think.