### PR TITLE
Keyword completion and icons 

### DIFF
--- a/common/changes/@cadl-lang/compiler/feature-keyword-completion_2021-12-07-18-20.json
+++ b/common/changes/@cadl-lang/compiler/feature-keyword-completion_2021-12-07-18-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Added** keyword autocomplete and icons",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/server/server.ts
+++ b/packages/compiler/server/server.ts
@@ -366,14 +366,10 @@ async function complete(params: CompletionParams): Promise<CompletionList> {
   if (node === undefined) {
     addKeywordCompletion("root", completions);
   } else {
-    console.error("NOde is", SyntaxKind[node.kind], node.parent && SyntaxKind[node.parent.kind]);
     switch (node.kind) {
       case SyntaxKind.NamespaceStatement:
         addKeywordCompletion("namespace", completions);
         break;
-      // case SyntaxKind.ModelStatement:
-      //   addKeywordCompletion("model", completions);
-      // break;
       case SyntaxKind.Identifier:
         addIdentifierCompletion(program, node, completions);
         break;
@@ -441,7 +437,6 @@ function addIdentifierCompletion(
     if (sym.kind === "type") {
       const type = program!.checker!.getTypeForNode(sym.node);
       documentation = getDoc(program, type);
-      // Todo: have mapping from cadl types https://github.com/microsoft/cadl/issues/112
       kind = getCompletionItemKind(program, type, sym.node.kind);
     } else {
       kind = CompletionItemKind.Function;

--- a/packages/compiler/server/server.ts
+++ b/packages/compiler/server/server.ts
@@ -366,13 +366,14 @@ async function complete(params: CompletionParams): Promise<CompletionList> {
   if (node === undefined) {
     addKeywordCompletion("root", completions);
   } else {
+    console.error("NOde is", SyntaxKind[node.kind], node.parent && SyntaxKind[node.parent.kind]);
     switch (node.kind) {
       case SyntaxKind.NamespaceStatement:
         addKeywordCompletion("namespace", completions);
         break;
-      case SyntaxKind.ModelStatement:
-        addKeywordCompletion("model", completions);
-        break;
+      // case SyntaxKind.ModelStatement:
+      //   addKeywordCompletion("model", completions);
+      // break;
       case SyntaxKind.Identifier:
         addIdentifierCompletion(program, node, completions);
         break;
@@ -430,7 +431,11 @@ function addIdentifierCompletion(
   node: IdentifierNode,
   completions: CompletionList
 ) {
-  for (const [key, { sym, label }] of program.checker!.resolveCompletions(node)) {
+  const result = program.checker!.resolveCompletions(node);
+  if (result.size === 0) {
+    return;
+  }
+  for (const [key, { sym, label }] of result) {
     let documentation: string | undefined;
     let kind: CompletionItemKind;
     if (sym.kind === "type") {


### PR DESCRIPTION
fix #112 
fix https://github.com/Azure/cadl-azure/issues/1030
Add support for autocompleting the available keywords depending on the context as well as showing meaningful icons for each entry.

### Keyword completion

- At the root
![image](https://user-images.githubusercontent.com/1031227/145080659-0b76efb3-a92b-43e5-9ed1-c38e4cde0720.png)
- In a namespace (no `import`)
![image](https://user-images.githubusercontent.com/1031227/145083084-76720a0a-6110-45ad-82b5-fc82c2303223.png)
- in the model definition: unfortunatelly currently it cant really figure out if we are in the model definition part to autocomplete `extends`, `is`. Depending on if the model is complete or not it just resolve to either be the modelStatement which would be the same autocomplete when enterting properties or it is some identifier node.


### Icons

- Models, union, enum, etc.
![image](https://user-images.githubusercontent.com/1031227/145083121-db0d1764-24da-4f51-8b55-16cb0e7383ca.png)

- Decorators
![image](https://user-images.githubusercontent.com/1031227/145083151-616a6a30-0ca4-47bf-8010-9d849acc61b8.png)

- Keywords
![image](https://user-images.githubusercontent.com/1031227/145080659-0b76efb3-a92b-43e5-9ed1-c38e4cde0720.png)
- In a namespace (no `import`)

