### PR TITLE
Fix: Cadl-server issues with Visual Studio

### DIFF
--- a/common/changes/cadl-vs/fix-cadl-vs-path_2021-12-07-20-49.json
+++ b/common/changes/cadl-vs/fix-cadl-vs-path_2021-12-07-20-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vs",
+      "comment": "**Fix** Issues with resolving `cadl-server` path + added support for passing `cadl.cadl-server.path` setting via `.vs/VSWorkspaceSettings.json` file",
+      "type": "minor"
+    }
+  ],
+  "packageName": "cadl-vs"
+}

--- a/packages/cadl-vs/Microsoft.Cadl.VS.sln
+++ b/packages/cadl-vs/Microsoft.Cadl.VS.sln
@@ -1,8 +1,11 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31202.260
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 16.0.31202.260
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Cadl.VS2019", "VS2019\Microsoft.Cadl.VS2019.csproj", "{3B3CF7E4-5B54-47EA-8BE3-60D8F806C69E}"
+	ProjectSection(ProjectDependencies) = postProject
+		{C7566715-9191-4D95-B673-4E569800CE32} = {C7566715-9191-4D95-B673-4E569800CE32}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Cadl.VS2022", "VS2022\Microsoft.Cadl.VS2022.csproj", "{C7566715-9191-4D95-B673-4E569800CE32}"
 EndProject

--- a/packages/cadl-vs/README.md
+++ b/packages/cadl-vs/README.md
@@ -5,3 +5,14 @@ This package provides [Cadl](https://github.com/microsoft/cadl) language support
 See https://github.com/microsoft/cadl#installing-visual-studio-extension for installation instructions.
 
 **NOTE**: The npm package is used as an implementation detail of the `cadl vs` command that installs the Visual Studio Cadl extension, and not intended to be used for other purposes.
+
+## Configure CADL Visual Studio Extension
+
+1. Create a file `.vs/VSWorkspaceSettings.json` at the root of the project.
+2. Add configuration as key value pair in this file. Example:
+
+```json
+{
+  "cadl.cadl-server-path": "./mynestedproject/node_modules/@cadl-lang/compiler"
+}
+```

--- a/packages/cadl-vs/VS2019/Microsoft.Cadl.VS2019.csproj
+++ b/packages/cadl-vs/VS2019/Microsoft.Cadl.VS2019.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Workspace" Version="16.3.43" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="16.3.43" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.1050" PrivateAssets="All" />
   </ItemGroup>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/packages/cadl-vs/VS2019/Properties/launchSettings.json
+++ b/packages/cadl-vs/VS2019/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Visual Studio Extension": {
       "commandName": "Executable",
       "executablePath": "$(DevEnvDir)devenv.exe",
-      "commandLineArgs": "/rootSuffix Exp ../../../../../../cadl-dogfood",
+      "commandLineArgs": "/rootSuffix Exp ../../../../samples/petstore",
       "environmentVariables": {
         "CADL_SERVER_NODE_OPTIONS": "--nolazy --inspect=4242",
         "CADL_DEVELOPMENT_MODE": "true"

--- a/packages/cadl-vs/VS2019/Properties/launchSettings.json
+++ b/packages/cadl-vs/VS2019/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Visual Studio Extension": {
       "commandName": "Executable",
       "executablePath": "$(DevEnvDir)devenv.exe",
-      "commandLineArgs": "/rootSuffix Exp ../../../../samples/petstore",
+      "commandLineArgs": "/rootSuffix Exp ../../../../../../cadl-dogfood",
       "environmentVariables": {
         "CADL_SERVER_NODE_OPTIONS": "--nolazy --inspect=4242",
         "CADL_DEVELOPMENT_MODE": "true"

--- a/packages/cadl-vs/VS2022/Microsoft.Cadl.VS2022.csproj
+++ b/packages/cadl-vs/VS2022/Microsoft.Cadl.VS2022.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Workspace" Version="16.3.43" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="16.3.43" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232" PrivateAssets="All" />
   </ItemGroup>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/packages/cadl-vs/src/VSExtension.cs
+++ b/packages/cadl-vs/src/VSExtension.cs
@@ -39,11 +39,7 @@ namespace Microsoft.Cadl.VisualStudio {
   public sealed class LanguageClient : ILanguageClient {
 
     public string Name => "Cadl";
-    public IEnumerable<string>? ConfigurationSections {
-      get {
-        yield return "cadl";
-      }
-    }
+    public IEnumerable<string>? ConfigurationSections { get; } = new[] { "cadl" }
 
     public object? InitializationOptions => null;
     public bool ShowNotificationOnInitializeFailed => true;
@@ -82,6 +78,7 @@ namespace Microsoft.Cadl.VisualStudio {
 #if DEBUG
       // Use local build of cadl-server in development (lauched from F5 in VS)
       if (InDevelopmentMode()) {
+        // --nolazy isn't supported by NODE_OPTIONS so we pass these via CLI instead
         info.Environment.Remove("NODE_OPTIONS");
       }
 #endif

--- a/packages/cadl-vs/src/VSExtension.cs
+++ b/packages/cadl-vs/src/VSExtension.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Cadl.VisualStudio {
   public sealed class LanguageClient : ILanguageClient {
 
     public string Name => "Cadl";
-    public IEnumerable<string>? ConfigurationSections { get; } = new[] { "cadl" }
+    public IEnumerable<string>? ConfigurationSections { get; } = new[] { "cadl" };
 
     public object? InitializationOptions => null;
     public bool ShowNotificationOnInitializeFailed => true;


### PR DESCRIPTION
fix https://github.com/Azure/cadl-azure/issues/1017

Resolve 2 major issue(and a bonus for development)

1. By default looks for `cadl-server` in the workspace directory instead of the exension startup directory which resulted in the global install of cadl being used instead of the local version and caused version mismatch
2. Added ability to configure the `cadl.cadl-server.path` setting like in VSCode.

Bonus:
- Pressing F5 with the VS2019 project will deploy the VS2022 project as well. No more building and geting confused why the change is not working.