### PR TITLE
Add interfaces for singleton and extension resources

### DIFF
--- a/common/changes/@cadl-lang/rest/extension-singleton-resource_2021-12-10-10-29.json
+++ b/common/changes/@cadl-lang/rest/extension-singleton-resource_2021-12-10-10-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add interfaces for modelling extension and singleton resources",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -117,3 +117,98 @@ interface ResourceCollectionOperations<TResource, TError>
 interface ResourceOperations<TResource, TError>
   mixes ResourceInstanceOperations<TResource, TError>,
     ResourceCollectionOperations<TResource, TError> {}
+
+interface SingletonResourceRead<TSingleton, TResource, TError> {
+  @autoRoute
+  @doc("Gets the singleton resource.")
+  @segmentOf(TSingleton)
+  @readsResource(TSingleton)
+  Get(...ResourceParameters<TResource>): TSingleton | TError;
+}
+
+interface SingletonResourceUpdate<TSingleton, TResource, TError> {
+  @autoRoute
+  @doc("Updates the singleton resource.")
+  @segmentOf(TSingleton)
+  @updatesResource(TSingleton)
+  Update(
+    ...ResourceParameters<TResource>,
+    @body properties: OptionalProperties<UpdateableProperties<TSingleton>>
+  ): TSingleton | TError;
+}
+
+interface SingletonResourceOperations<TSingleton, TResource, TError>
+  mixes SingletonResourceRead<TSingleton, TResource, TError>,
+    SingletonResourceUpdate<TSingleton, TResource, TError> {}
+
+interface ExtensionResourceRead<TExtension, TResource, TError> {
+  @autoRoute
+  @doc("Gets an instance of the extension resource.")
+  @readsResource(TExtension)
+  Get(...ResourceParameters<TResource>, ...ResourceParameters<TExtension>): TExtension | TError;
+}
+
+interface ExtensionResourceCreateOrUpdate<TExtension, TResource, TError> {
+  @autoRoute
+  @doc("Creates or update a instance of the extension resource.")
+  @createsOrUpdatesResource(TExtension)
+  CreateOrUpdate(
+    ...ResourceParameters<TResource>,
+    ...ResourceParameters<TExtension>,
+    @body resource: TExtension
+  ): TExtension | ResourceCreatedResponse<TExtension> | TError;
+}
+
+interface ExtensionResourceCreate<TExtension, TResource, TError> {
+  @autoRoute
+  @doc("Creates a new instance of the extension resource.")
+  @createsResource(TExtension)
+  Create(
+    ...ResourceParameters<TResource>,
+    @body resource: TResource
+  ): TExtension | ResourceCreatedResponse<TExtension> | TError;
+}
+
+interface ExtensionResourceUpdate<TExtension, TResource, TError> {
+  @autoRoute
+  @doc("Updates an existing instance of the extension resource.")
+  @updatesResource(TExtension)
+  Update(
+    ...ResourceParameters<TResource>,
+    ...ResourceParameters<TExtension>,
+    @body properties: OptionalProperties<UpdateableProperties<TExtension>>
+  ): TExtension | TError;
+}
+
+interface ExtensionResourceDelete<TExtension, TResource, TError> {
+  @autoRoute
+  @doc("Deletes an existing instance of the extension resource.")
+  @deletesResource(TExtension)
+  Delete(
+    ...ResourceParameters<TResource>,
+    ...ResourceParameters<TExtension>
+  ): ResourceDeletedResponse | TError;
+}
+
+interface ExtensionResourceList<TExtension, TResource, TError> {
+  @autoRoute
+  @doc("Lists all instances of the extension resource.")
+  @listsResource(TExtension)
+  List(
+    ...ResourceParameters<TResource>,
+    ...ResourceCollectionParameters<TExtension>
+  ): Page<TExtension> | TError;
+}
+
+interface ExtensionResourceInstanceOperations<TExtension, TResource, TError>
+  mixes ExtensionResourceRead<TExtension, TResource, TError>,
+    ExtensionResourceUpdate<TExtension, TResource, TError>,
+    ExtensionResourceDelete<TExtension, TResource, TError> {}
+
+interface ExtensionResourceCollectionOperations<TExtension, TResource, TError>
+  mixes ExtensionResourceCreate<TExtension, TResource, TError>,
+    ExtensionResourceList<TExtension, TResource, TError> {}
+
+interface ExtensionResourceOperations<TExtension, TResource, TError>
+  mixes ExtensionResourceInstanceOperations<TExtension, TResource, TError>,
+    ExtensionResourceCollectionOperations<TExtension, TResource, TError> {}

--- a/packages/rest/src/rest.ts
+++ b/packages/rest/src/rest.ts
@@ -7,6 +7,7 @@ import {
   Type,
 } from "@cadl-lang/compiler";
 import { reportDiagnostic } from "./diagnostics.js";
+import { getResourceTypeKey } from "./resource.js";
 
 const producesTypesKey = Symbol();
 
@@ -61,7 +62,7 @@ export function getDiscriminator(program: Program, entity: Type): any | undefine
 
 const segmentsKey = Symbol();
 export function $segment(program: Program, entity: Type, name: string) {
-  if (entity.kind !== "ModelProperty") {
+  if (entity.kind !== "Model" && entity.kind !== "ModelProperty" && entity.kind !== "Operation") {
     reportDiagnostic(program, {
       code: "decorator-wrong-type",
       format: { decorator: "segment", entityKind: entity.kind },
@@ -73,16 +74,36 @@ export function $segment(program: Program, entity: Type, name: string) {
   program.stateMap(segmentsKey).set(entity, name);
 }
 
-export function getSegment(program: Program, entity: Type): string | undefined {
-  if (entity.kind !== "ModelProperty") {
+export function $segmentOf(program: Program, entity: Type, resourceType: Type) {
+  if (resourceType.kind === "TemplateParameter") {
+    // Skip it, this operation is in a templated interface
+    return;
+  } else if (resourceType.kind !== "Model") {
     reportDiagnostic(program, {
       code: "decorator-wrong-type",
-      format: { decorator: "segment", entityKind: entity.kind },
+      format: { decorator: "segmentOf", entityKind: entity.kind },
       target: entity,
     });
     return;
   }
 
+  // Add path segment for resource type key (if it has one)
+  const resourceKey = getResourceTypeKey(program, resourceType);
+  if (resourceKey) {
+    const keySegment = getSegment(program, resourceKey.keyProperty);
+    if (keySegment) {
+      $segment(program, entity, keySegment);
+    }
+  } else {
+    // Does the model itself have a segment attached?
+    const modelSegment = getSegment(program, resourceType);
+    if (modelSegment) {
+      $segment(program, entity, modelSegment);
+    }
+  }
+}
+
+export function getSegment(program: Program, entity: Type): string | undefined {
   return program.stateMap(segmentsKey).get(entity);
 }
 
@@ -137,6 +158,9 @@ export function $readsResource(program: Program, entity: Type, resourceType: Typ
 }
 
 export function $createsResource(program: Program, entity: Type, resourceType: Type) {
+  // Add path segment for resource type key
+  $segmentOf(program, entity, resourceType);
+
   setResourceOperation(program, entity, resourceType, "create");
 }
 
@@ -159,7 +183,14 @@ export function $listsResource(program: Program, entity: Type, resourceType: Typ
     $list(program, entity, resourceType);
   }
 
+  // Add path segment for resource type key
+  $segmentOf(program, entity, resourceType);
+
   setResourceOperation(program, entity, resourceType, "list");
+}
+
+function lowerCaseFirstChar(str: string): string {
+  return str[0].toLocaleLowerCase() + str.substring(1);
 }
 
 const actionsKey = Symbol();
@@ -173,7 +204,11 @@ export function $action(program: Program, entity: Type, name?: string) {
     return;
   }
 
-  program.stateMap(actionsKey).set(entity, name || entity.name);
+  // Generate the action name and add it as an operation path segment
+  const action = lowerCaseFirstChar(name || entity.name);
+  $segment(program, entity, action);
+
+  program.stateMap(actionsKey).set(entity, action);
 }
 
 export function getAction(program: Program, operation: OperationType): string | null | undefined {
@@ -185,6 +220,7 @@ setDecoratorNamespace(
   $produces,
   $consumes,
   $segment,
+  $segmentOf,
   $readsResource,
   $createsResource,
   $createsOrUpdatesResource,

--- a/packages/rest/test/test-resource.ts
+++ b/packages/rest/test/test-resource.ts
@@ -1,0 +1,216 @@
+import { deepStrictEqual } from "assert";
+import { getRoutesFor } from "./test-host.js";
+
+describe("rest: resources", () => {
+  it("resources: generates standard operations for resource types and their children", async () => {
+    const routes = await getRoutesFor(
+      `
+      using Cadl.Rest.Resource;
+
+      namespace Things {
+        model Thing {
+          @key
+          @segment("things")
+          thingId: string;
+        }
+
+        @parentResource(Thing)
+        model Subthing {
+          @key
+          @segment("subthings")
+          subthingId: string;
+        }
+
+        model Error {}
+
+        interface Things mixes ResourceOperations<Thing, Error> {}
+        interface Subthings mixes ResourceOperations<Subthing, Error> {}
+      }
+      `
+    );
+
+    deepStrictEqual(routes, [
+      {
+        verb: "get",
+        path: "/things/{thingId}",
+        params: ["thingId"],
+      },
+      {
+        verb: "patch",
+        path: "/things/{thingId}",
+        params: ["thingId"],
+      },
+      {
+        verb: "delete",
+        path: "/things/{thingId}",
+        params: ["thingId"],
+      },
+      {
+        verb: "post",
+        path: "/things",
+        params: [],
+      },
+      {
+        verb: "get",
+        path: "/things",
+        params: [],
+      },
+      {
+        verb: "get",
+        path: "/things/{thingId}/subthings/{subthingId}",
+        params: ["thingId", "subthingId"],
+      },
+      {
+        verb: "patch",
+        path: "/things/{thingId}/subthings/{subthingId}",
+        params: ["thingId", "subthingId"],
+      },
+      {
+        verb: "delete",
+        path: "/things/{thingId}/subthings/{subthingId}",
+        params: ["thingId", "subthingId"],
+      },
+      {
+        path: "/things/{thingId}/subthings",
+        verb: "post",
+        params: ["thingId"],
+      },
+      {
+        verb: "get",
+        path: "/things/{thingId}/subthings",
+        params: ["thingId"],
+      },
+    ]);
+  });
+
+  it("singleton resource: generates standard operations", async () => {
+    const routes = await getRoutesFor(
+      `
+      using Cadl.Rest.Resource;
+
+      namespace Things {
+        model Thing {
+          @key
+          @segment("things")
+          thingId: string;
+        }
+
+        @segment("singleton")
+        model Singleton {
+          data: string;
+        }
+
+        model Error {}
+
+        interface Things mixes ResourceRead<Thing, Error> {}
+        interface ThingsSingleton mixes SingletonResourceOperations<Singleton, Thing, Error> {}
+      }
+      `
+    );
+
+    deepStrictEqual(routes, [
+      {
+        verb: "get",
+        path: "/things/{thingId}",
+        params: ["thingId"],
+      },
+      {
+        verb: "get",
+        path: "/things/{thingId}/singleton",
+        params: ["thingId"],
+      },
+      {
+        verb: "patch",
+        path: "/things/{thingId}/singleton",
+        params: ["thingId"],
+      },
+    ]);
+  });
+
+  it("extension resources: generates standard operations for extensions on parent and child resources", async () => {
+    const routes = await getRoutesFor(
+      `
+      using Cadl.Rest.Resource;
+
+      namespace Things {
+        model Thing {
+          @key
+          @segment("things")
+          thingId: string;
+        }
+
+        @parentResource(Thing)
+        model Subthing {
+          @key
+          @segment("subthings")
+          subthingId: string;
+        }
+
+        model Exthing {
+          @key
+          @segment("extension")
+          exthingId: string;
+        }
+
+        model Error {}
+
+        interface ThingsExtension mixes ExtensionResourceOperations<Exthing, Thing, Error> {}
+        interface SubthingsExtension mixes ExtensionResourceOperations<Exthing, Subthing, Error> {}
+      }
+      `
+    );
+
+    deepStrictEqual(routes, [
+      {
+        verb: "get",
+        path: "/things/{thingId}/extension/{exthingId}",
+        params: ["thingId", "exthingId"],
+      },
+      {
+        verb: "patch",
+        path: "/things/{thingId}/extension/{exthingId}",
+        params: ["thingId", "exthingId"],
+      },
+      {
+        verb: "delete",
+        path: "/things/{thingId}/extension/{exthingId}",
+        params: ["thingId", "exthingId"],
+      },
+      {
+        verb: "post",
+        path: "/things/{thingId}/extension",
+        params: ["thingId"],
+      },
+      {
+        verb: "get",
+        path: "/things/{thingId}/extension",
+        params: ["thingId"],
+      },
+      {
+        verb: "get",
+        path: "/things/{thingId}/subthings/{subthingId}/extension/{exthingId}",
+        params: ["thingId", "subthingId", "exthingId"],
+      },
+      {
+        verb: "patch",
+        path: "/things/{thingId}/subthings/{subthingId}/extension/{exthingId}",
+        params: ["thingId", "subthingId", "exthingId"],
+      },
+      {
+        verb: "delete",
+        path: "/things/{thingId}/subthings/{subthingId}/extension/{exthingId}",
+        params: ["thingId", "subthingId", "exthingId"],
+      },
+      {
+        verb: "post",
+        path: "/things/{thingId}/subthings/{subthingId}/extension",
+        params: ["thingId", "subthingId"],
+      },
+      {
+        verb: "get",
+        path: "/things/{thingId}/subthings/{subthingId}/extension",
+        params: ["thingId", "subthingId"],
+      },
+    ]);
+  });
+});

--- a/packages/rest/test/test-routes.ts
+++ b/packages/rest/test/test-routes.ts
@@ -148,6 +148,7 @@ describe("rest: routes", () => {
         interface SubInterface {
           @get
           @list(Subthing)
+          @segmentOf(Subthing)
           GetSubthings(...KeysOf<Thing>): string;
 
           @post CreateSubthing(...KeysOf<Thing>, ...KeysOf<Subthing>): string;
@@ -165,87 +166,6 @@ describe("rest: routes", () => {
         verb: "post",
         path: "/api/things/{thingId}/subthings/{subthingId}",
         params: ["thingId", "subthingId"],
-      },
-    ]);
-  });
-
-  it("generates standard operations for resources types and their children", async () => {
-    const routes = await getRoutesFor(
-      `
-      using Cadl.Rest.Resource;
-
-      namespace Things {
-        model Thing {
-          @key
-          @segment("things")
-          thingId: string;
-        }
-
-        @parentResource(Thing)
-        model Subthing {
-          @key
-          @segment("subthings")
-          subthingId: string;
-        }
-
-        model Error {}
-
-        interface Things mixes ResourceOperations<Thing, Error> {}
-        interface Subthings mixes ResourceOperations<Subthing, Error> {}
-      }
-      `
-    );
-
-    deepStrictEqual(routes, [
-      {
-        verb: "get",
-        path: "/things/{thingId}",
-        params: ["thingId"],
-      },
-      {
-        verb: "patch",
-        path: "/things/{thingId}",
-        params: ["thingId"],
-      },
-      {
-        verb: "delete",
-        path: "/things/{thingId}",
-        params: ["thingId"],
-      },
-      {
-        verb: "post",
-        path: "/things",
-        params: [],
-      },
-      {
-        verb: "get",
-        path: "/things",
-        params: [],
-      },
-      {
-        verb: "get",
-        path: "/things/{thingId}/subthings/{subthingId}",
-        params: ["thingId", "subthingId"],
-      },
-      {
-        verb: "patch",
-        path: "/things/{thingId}/subthings/{subthingId}",
-        params: ["thingId", "subthingId"],
-      },
-      {
-        verb: "delete",
-        path: "/things/{thingId}/subthings/{subthingId}",
-        params: ["thingId", "subthingId"],
-      },
-      {
-        path: "/things/{thingId}/subthings",
-        verb: "post",
-        params: ["thingId"],
-      },
-      {
-        verb: "get",
-        path: "/things/{thingId}/subthings",
-        params: ["thingId"],
       },
     ]);
   });

--- a/packages/samples/rest/petstore/petstore.cadl
+++ b/packages/samples/rest/petstore/petstore.cadl
@@ -24,6 +24,7 @@ model Pet {
   @minValue(0)
   @maxValue(20)
   age: int32;
+  ownerId: int64;
 }
 
 @parentResource(Pet)
@@ -35,22 +36,51 @@ model Toy {
   name: string;
 }
 
-@parentResource(Pet)
+model Owner {
+  @segment("owners")
+  @key("ownerId")
+  id: int64;
+  name: string;
+  age: int32;
+}
+
 model Checkup {
   @segment("checkups")
-  @key
+  @key("checkupId")
   id: int32;
   vetName: string;
   notes: string;
 }
 
+@segment("insurance")
+model Insurance {
+  provider: string;
+  premium: int32;
+  deductible: int32;
+}
+
 interface Pets mixes ResourceOperations<Pet, PetStoreError> {}
+
+interface PetCheckups
+  mixes ExtensionResourceCreateOrUpdate<Checkup, Pet, PetStoreError>,
+    ExtensionResourceList<Checkup, Pet, PetStoreError> {}
+
+interface PetInsurance mixes SingletonResourceOperations<Insurance, Pet, PetStoreError> {}
 
 interface Toys mixes ResourceRead<Toy, PetStoreError> {
   @listsResource(Toy)
   list(...ParentKeysOf<Toy>, @query nameFilter: string): Page<Toy> | PetStoreError;
 }
+interface ToyInsurance mixes SingletonResourceOperations<Insurance, Toy, PetStoreError> {}
 
 interface Checkups
   mixes ResourceCreateOrUpdate<Checkup, PetStoreError>,
     ResourceList<Checkup, PetStoreError> {}
+
+interface Owners mixes ResourceOperations<Owner, PetStoreError> {}
+
+interface OwnerCheckups
+  mixes ExtensionResourceCreateOrUpdate<Checkup, Owner, PetStoreError>,
+    ExtensionResourceList<Checkup, Owner, PetStoreError> {}
+
+interface OwnerInsurance mixes SingletonResourceOperations<Insurance, Owner, PetStoreError> {}

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -85,6 +85,10 @@
                     "format": "int32",
                     "minimum": 0,
                     "maximum": 20
+                  },
+                  "ownerId": {
+                    "type": "integer",
+                    "format": "int64"
                   }
                 },
                 "description": "The template for adding optional properties.",
@@ -201,6 +205,182 @@
         }
       }
     },
+    "/pets/{petId}/checkups/{checkupId}": {
+      "put": {
+        "operationId": "PetCheckups_CreateOrUpdate",
+        "summary": "Creates or update a instance of the extension resource.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Pet.petId"
+          },
+          {
+            "$ref": "#/components/parameters/Checkup.checkupId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Checkup"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Resource create operation completed successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Checkup"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Checkup"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}/checkups": {
+      "get": {
+        "operationId": "PetCheckups_List",
+        "summary": "Lists all instances of the extension resource.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Pet.petId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paged response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cadl.Rest.Resource.Page_Checkup"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}/insurance": {
+      "get": {
+        "operationId": "PetInsurance_Get",
+        "summary": "Gets the singleton resource.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Pet.petId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Insurance"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "PetInsurance_Update",
+        "summary": "Updates the singleton resource.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Pet.petId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Insurance"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "provider": {
+                    "type": "string"
+                  },
+                  "premium": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "deductible": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                },
+                "description": "The template for adding optional properties.",
+                "x-cadl-name": "Cadl.OptionalProperties<Cadl.UpdateableProperties_PetStore.Insurance>"
+              }
+            }
+          }
+        }
+      }
+    },
     "/pets/{petId}/toys/{toyId}": {
       "get": {
         "operationId": "Toys_get",
@@ -277,16 +457,107 @@
         }
       }
     },
-    "/pets/{petId}/checkups/{id}": {
-      "put": {
-        "operationId": "Checkups_createOrUpdate",
-        "summary": "Creates or update a instance of the resource.",
+    "/pets/{petId}/toys/{toyId}/insurance": {
+      "get": {
+        "operationId": "ToyInsurance_Get",
+        "summary": "Gets the singleton resource.",
         "parameters": [
           {
             "$ref": "#/components/parameters/PetStore.Pet.petId"
           },
           {
-            "$ref": "#/components/parameters/Checkup.id"
+            "$ref": "#/components/parameters/Toy.toyId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Insurance"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "ToyInsurance_Update",
+        "summary": "Updates the singleton resource.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PetStore.Pet.petId"
+          },
+          {
+            "$ref": "#/components/parameters/Toy.toyId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Insurance"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "provider": {
+                    "type": "string"
+                  },
+                  "premium": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "deductible": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                },
+                "description": "The template for adding optional properties.",
+                "x-cadl-name": "Cadl.OptionalProperties<Cadl.UpdateableProperties_PetStore.Insurance>"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/checkups/{checkupId}": {
+      "put": {
+        "operationId": "Checkups_createOrUpdate",
+        "summary": "Creates or update a instance of the resource.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Checkup.checkupId"
           }
         ],
         "responses": {
@@ -332,13 +603,287 @@
         }
       }
     },
-    "/pets/{petId}/checkups": {
+    "/checkups": {
       "get": {
         "operationId": "Checkups_list",
         "summary": "Lists all instances of the resource.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Paged response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cadl.Rest.Resource.Page_Checkup"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/owners/{ownerId}": {
+      "get": {
+        "operationId": "Owners_get",
+        "summary": "Gets an instance of the resource.",
         "parameters": [
           {
-            "$ref": "#/components/parameters/PetStore.Pet.petId"
+            "$ref": "#/components/parameters/Owner.ownerId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Owner"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "Owners_update",
+        "summary": "Updates an existing instance of the resource.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Owner.ownerId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Owner"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "age": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                },
+                "description": "The template for adding optional properties.",
+                "x-cadl-name": "Cadl.OptionalProperties<Cadl.UpdateableProperties_PetStore.Owner>"
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Owners_delete",
+        "summary": "Deletes an existing instance of the resource.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Owner.ownerId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cadl.Rest.Resource.ResourceDeletedResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/owners": {
+      "post": {
+        "operationId": "Owners_create",
+        "summary": "Creates a new instance of the resource.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Owner"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Resource create operation completed successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Owner"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Owner"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "Owners_list",
+        "summary": "Lists all instances of the resource.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Paged response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cadl.Rest.Resource.Page_Owner"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/owners/{ownerId}/checkups/{checkupId}": {
+      "put": {
+        "operationId": "OwnerCheckups_CreateOrUpdate",
+        "summary": "Creates or update a instance of the extension resource.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Owner.ownerId"
+          },
+          {
+            "$ref": "#/components/parameters/Checkup.checkupId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Checkup"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Resource create operation completed successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Checkup"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Checkup"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/owners/{ownerId}/checkups": {
+      "get": {
+        "operationId": "OwnerCheckups_List",
+        "summary": "Lists all instances of the extension resource.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Owner.ownerId"
           }
         ],
         "responses": {
@@ -364,12 +909,109 @@
           }
         }
       }
+    },
+    "/owners/{ownerId}/insurance": {
+      "get": {
+        "operationId": "OwnerInsurance_Get",
+        "summary": "Gets the singleton resource.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Owner.ownerId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Insurance"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "OwnerInsurance_Update",
+        "summary": "Updates the singleton resource.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Owner.ownerId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Insurance"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PetStoreError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "provider": {
+                    "type": "string"
+                  },
+                  "premium": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "deductible": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                },
+                "description": "The template for adding optional properties.",
+                "x-cadl-name": "Cadl.OptionalProperties<Cadl.UpdateableProperties_PetStore.Insurance>"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
     "parameters": {
       "Pet.petId": {
         "name": "petId",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "Checkup.checkupId": {
+        "name": "checkupId",
         "in": "path",
         "required": true,
         "schema": {
@@ -395,13 +1037,13 @@
           "format": "int64"
         }
       },
-      "Checkup.id": {
-        "name": "id",
+      "Owner.ownerId": {
+        "name": "ownerId",
         "in": "path",
         "required": true,
         "schema": {
           "type": "integer",
-          "format": "int32"
+          "format": "int64"
         }
       }
     },
@@ -424,12 +1066,17 @@
             "format": "int32",
             "minimum": 0,
             "maximum": 20
+          },
+          "ownerId": {
+            "type": "integer",
+            "format": "int64"
           }
         },
         "required": [
           "id",
           "name",
-          "age"
+          "age",
+          "ownerId"
         ]
       },
       "PetStoreError": {
@@ -474,6 +1121,68 @@
           "value"
         ]
       },
+      "Checkup": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "vetName": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "vetName",
+          "notes"
+        ]
+      },
+      "Cadl.Rest.Resource.Page_Checkup": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Checkup"
+            },
+            "x-cadl-name": "PetStore.Checkup[]",
+            "description": "The items on this page"
+          },
+          "nextLink": {
+            "type": "string",
+            "description": "The link to the next page of items"
+          }
+        },
+        "description": "Paged response",
+        "required": [
+          "value"
+        ]
+      },
+      "Insurance": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string"
+          },
+          "premium": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "deductible": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "provider",
+          "premium",
+          "deductible"
+        ]
+      },
       "Toy": {
         "type": "object",
         "properties": {
@@ -516,35 +1225,36 @@
           "value"
         ]
       },
-      "Checkup": {
+      "Owner": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer",
             "format": "int32"
-          },
-          "vetName": {
-            "type": "string"
-          },
-          "notes": {
-            "type": "string"
           }
         },
         "required": [
           "id",
-          "vetName",
-          "notes"
+          "name",
+          "age"
         ]
       },
-      "Cadl.Rest.Resource.Page_Checkup": {
+      "Cadl.Rest.Resource.Page_Owner": {
         "type": "object",
         "properties": {
           "value": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Checkup"
+              "$ref": "#/components/schemas/Owner"
             },
-            "x-cadl-name": "PetStore.Checkup[]",
+            "x-cadl-name": "PetStore.Owner[]",
             "description": "The items on this page"
           },
           "nextLink": {


### PR DESCRIPTION
This change enables the modelling of two new kinds of resources:

- Singleton resources which represent a single resource instance without a key which is attached to a particular "parent" resource type
- Extension resources which enable a resource type to be added as an effective child resource of multiple resource types without using `@parentResource`

This should give us more flexibility to describe common patterns we see across Azure data plane services.  Check out the expanded [rest/petstore.cadl](https://github.com/daviwil/cadl/blob/extension-singleton-resource/packages/samples/rest/petstore/petstore.cadl) for usage examples.

To enable the new `SingletonResource` interfaces, I've made the `@segment` decorator usable with models and operations so that we have a more flexible way to attach a final segment to an operation's generated route path.  

I also added a new `@segmentOf` decorator to extract the segment from a resource type (or its key property) to bring this to the level of Cadl so that we no longer need to special case these segments in the route logic.

Fixes Azure/cadl-azure#1052