### PR TITLE
Add Cadl.Http.PlainData<T>

### DIFF
--- a/common/changes/@cadl-lang/rest/plain-data_2021-12-13-18-42.json
+++ b/common/changes/@cadl-lang/rest/plain-data_2021-12-13-18-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add Cadl.Http.PlainData<T>",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/lib/http.cadl
+++ b/packages/rest/lib/http.cadl
@@ -2,6 +2,8 @@ import "../dist/src/http.js";
 
 namespace Cadl.Http;
 
+using Private;
+
 @doc("The request has succeeded.")
 model OkResponse<T> {
   @doc("The status code.")
@@ -79,4 +81,15 @@ model ConflictResponse {
   @doc("The status code.")
   @header
   statusCode: 409;
+}
+
+// Produces a new model with the same properties as T, but with @query,
+// @header, @body, and @path decorators removed from all properties.
+//
+// ISSUE: Can't use @doc to document this as it leaks into OpenAPI output.
+// We probably need a way to do Cadl-developer-only docs that show in the
+// IDE but do not leak into output.
+@plainData
+model PlainData<T> {
+  ...T;
 }

--- a/packages/rest/test/test-plaindata.ts
+++ b/packages/rest/test/test-plaindata.ts
@@ -1,0 +1,60 @@
+import { ok } from "assert";
+import { isBody, isHeader, isPathParam, isQueryParam } from "../src/http.js";
+import { createRestTestHost, TestHost } from "./test-host.js";
+
+describe("rest: plain data", () => {
+  let testHost: TestHost;
+
+  beforeEach(async () => {
+    testHost = await createRestTestHost();
+  });
+
+  it("removes header/query/body/path", async () => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+      import "rest";
+      using Cadl.Http;
+
+      @test
+      model Before {
+        @header a: string;
+        @query b: string;
+        @path c: string;
+        @body d: string;
+      }
+
+      @test
+      model After is PlainData<Before> {}
+
+      @test
+      model Spread {
+        ...After
+      }
+      `
+    );
+
+    const { Before, After, Spread } = await testHost.compile("main.cadl");
+    const program = testHost.program;
+
+    ok(Before.kind === "Model", "Model expected");
+    ok(isHeader(program, Before.properties.get("a")!), "header expected");
+    ok(isBody(program, Before.properties.get("d")!), "body expected");
+    ok(isQueryParam(testHost.program, Before.properties.get("b")!), "query expected");
+    ok(isPathParam(testHost.program, Before.properties.get("c")!), "path expected");
+
+    for (const model of [After, Spread]) {
+      ok(model.kind === "Model", "Model expected");
+      ok(!isHeader(program, model.properties.get("a")!), `header not expected in ${model.name}`);
+      ok(!isBody(program, model.properties.get("d")!), `body not expected in ${model.name}`);
+      ok(
+        !isQueryParam(testHost.program, model.properties.get("b")!),
+        `query not expected in ${model.name}`
+      );
+      ok(
+        !isPathParam(testHost.program, model.properties.get("c")!),
+        `path not expected in ${model.name}`
+      );
+    }
+  });
+});


### PR DESCRIPTION
Removes `@header`, `@body`, `@query`, `@path` from properties to reuse T as plain data.