### PR TITLE
Add support for default for unions

### DIFF
--- a/common/changes/@cadl-lang/compiler/feature-union-defaults_2021-12-13-21-28.json
+++ b/common/changes/@cadl-lang/compiler/feature-union-defaults_2021-12-13-21-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Added** support for union default values",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -1301,7 +1301,6 @@ export function createChecker(program: Program): Checker {
       case "Union":
         return checkDefaultForUnionType(defaultType, type);
       default:
-        console.log("Default not supported", type.kind);
         program.reportDiagnostic(
           createDiagnostic({
             code: "unsupported-default",
@@ -1362,31 +1361,29 @@ export function createChecker(program: Program): Checker {
   }
 
   function checkDefaultForUnionType(defaultType: Type, type: UnionType): Type {
-    let found = false;
     for (const option of type.options) {
       if (option.kind === defaultType.kind) {
         switch (defaultType.kind) {
           case "String":
             if (defaultType.value === (option as StringLiteralType).value) {
-              found = true;
+              return defaultType;
             }
           case "Number":
             if (defaultType.value === (option as NumericLiteralType).value) {
-              found = true;
+              return defaultType;
             }
         }
       }
     }
 
-    if (!found) {
-      program.reportDiagnostic(
-        createDiagnostic({
-          code: "unassignable",
-          format: { value: getTypeName(defaultType), targetType: getTypeName(type) },
-          target: defaultType,
-        })
-      );
-    }
+    // Didn't find any compatible options
+    program.reportDiagnostic(
+      createDiagnostic({
+        code: "unassignable",
+        format: { value: getTypeName(defaultType), targetType: getTypeName(type) },
+        target: defaultType,
+      })
+    );
     return defaultType;
   }
 

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -274,6 +274,12 @@ const diagnostics = {
       default: paramMessage`Default must be a ${"type"}`,
     },
   },
+  unassignable: {
+    severity: "error",
+    messages: {
+      default: paramMessage`Type '${"value"}' is not assignable to type '${"targetType"}'`,
+    },
+  },
   "mixes-interface": {
     severity: "error",
     messages: {

--- a/packages/compiler/test/checker/model.ts
+++ b/packages/compiler/test/checker/model.ts
@@ -79,6 +79,7 @@ describe("compiler: models", () => {
       ["int32", `"foo"`, /Default must be a number/],
       ["boolean", `"foo"`, /Default must be a boolean/],
       ["string[]", `["foo", 123]`, /Default must be a string/],
+      [`"foo" | "bar"`, `"foo1"`, /Type 'foo1' is not assignable to type 'foo | bar'/],
     ];
 
     for (const [type, defaultValue, errorRegex] of testCases) {

--- a/packages/samples/optional/optional.cadl
+++ b/packages/samples/optional/optional.cadl
@@ -8,6 +8,7 @@ model HasOptional {
   optionalNumber?: int32 = 123;
   optionalBoolean?: boolean = true;
   optionalArray?: string[] = ["foo", "bar"];
+  optionalUnion?: "foo" | "bar" = "foo";
 }
 
 @route("/test")

--- a/packages/samples/test/output/optional/openapi.json
+++ b/packages/samples/test/output/optional/openapi.json
@@ -66,6 +66,15 @@
               "foo",
               "bar"
             ]
+          },
+          "optionalUnion": {
+            "type": "string",
+            "enum": [
+              "foo",
+              "bar"
+            ],
+            "x-cadl-name": "foo | bar",
+            "default": "foo"
           }
         }
       }


### PR DESCRIPTION
fix https://github.com/Azure/cadl-azure/issues/1041

This doesn't do the same for enums as it is a more involved change which require change in the binding to allow referencing enum members.

PR Adding support for enums. https://github.com/microsoft/cadl/pull/128
