### PR TITLE
Add utility functions to semantic-walker

### DIFF
--- a/common/changes/@cadl-lang/compiler/common-functions_2021-12-14-00-45.json
+++ b/common/changes/@cadl-lang/compiler/common-functions_2021-12-14-00-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add findChildModels and getProperty utility functions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/semantic-walker.ts
+++ b/packages/compiler/core/semantic-walker.ts
@@ -238,6 +238,30 @@ function navigateType(
   }
 }
 
+// Find the immediate children of the given model.
+export function findChildModels(program: Program, parent: ModelType) {
+  const children: ModelType[] = [];
+  navigateProgram(program, {
+    model: (model) => {
+      if (model.baseModel === parent) {
+        children.push(model);
+      }
+    },
+  });
+  return children;
+}
+
+// Return property from type, nesting into baseTypes as needed.
+export function getProperty(type: ModelType, propertyName: string): ModelTypeProperty | undefined {
+  while (type.baseModel) {
+    if (type.properties.has(propertyName)) {
+      return type.properties.get(propertyName);
+    }
+    type = type.baseModel;
+  }
+  return type.properties.get(propertyName);
+}
+
 export class EventEmitter<T extends { [key: string]: (...args: any) => any }> {
   private listeners: Map<keyof T, Array<(...args: any[]) => any>> = new Map();
 

--- a/packages/compiler/test/test-semantic-walker.ts
+++ b/packages/compiler/test/test-semantic-walker.ts
@@ -8,7 +8,7 @@ import {
   UnionType,
   UnionTypeVariant,
 } from "../core/index.js";
-import { navigateProgram } from "../core/semantic-walker.js";
+import { findChildModels, getProperty, navigateProgram } from "../core/semantic-walker.js";
 import { createTestHost, TestHost } from "./test-host.js";
 
 describe("compiler: semantic walker", () => {
@@ -140,5 +140,46 @@ describe("compiler: semantic walker", () => {
     assert.strictEqual(result.interfaces[0].name, "A");
     assert.strictEqual(result.operations.length, 1, "finds operations");
     assert.strictEqual(result.operations[0].name, "a");
+  });
+
+  it("finds child models", async () => {
+    const result = await runNavigator(`
+      model Pet {
+        name: true;
+      }
+
+      model Cat extends Pet {
+        meow: true;
+      }
+
+      model Dog extends Pet {
+        bark: true;
+      }
+    `);
+
+    assert.strictEqual(result.models.length, 3);
+    assert.strictEqual(result.models[0].name, "Pet");
+    const childModels = findChildModels(host.program, result.models[0]);
+    assert.strictEqual(childModels[0].name, "Cat");
+    assert.strictEqual(childModels[1].name, "Dog");
+  });
+
+  it("finds owned or inherited properties", async () => {
+    const result = await runNavigator(`
+      model Pet {
+        name: true;
+      }
+
+      model Cat extends Pet {
+        meow: true;
+      }
+    `);
+
+    assert.strictEqual(result.models.length, 2);
+    assert.strictEqual(result.models[0].name, "Pet");
+    assert.strictEqual(result.models[1].name, "Cat");
+    assert.ok(getProperty(result.models[1], "meow"));
+    assert.ok(getProperty(result.models[1], "name"));
+    assert.strictEqual(getProperty(result.models[1], "bark"), undefined);
   });
 });


### PR DESCRIPTION
This PR adds some simple utility functions to semantic-walker.  These have been factored out of the PR to support discriminators so that they can be made common functions.