### PR TITLE
Handle circular reference for base types

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-circular-issues_2021-12-15-09-01.json
+++ b/common/changes/@cadl-lang/compiler/fix-circular-issues_2021-12-15-09-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Fix** Ciruclar reference in `is` or `extends` now emit a diagnostic instead of crashing",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -444,6 +444,12 @@ const diagnostics = {
       default: paramMessage`Could not add response type "${"responseTypeName"}" to operation ${"operationName"}"`,
     },
   },
+  "circular-base-type": {
+    severity: "error",
+    messages: {
+      default: paramMessage`Type '${"typeName"}' recursively references itself as a base type.`,
+    },
+  },
 } as const;
 
 export type CompilerDiagnostics = TypeOfDiagnostics<typeof diagnostics>;

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -1606,21 +1606,21 @@ function checkForDescendantErrors(node: Node) {
   if (getFlag(node, NodeFlags.DescendantErrorsExamined)) {
     return;
   }
+  setFlag(node, NodeFlags.DescendantErrorsExamined);
 
   visitChildren(node, (child) => {
     if (getFlag(child, NodeFlags.ThisNodeHasError)) {
       setFlag(node, NodeFlags.DescendantHasError | NodeFlags.DescendantErrorsExamined);
       return true;
     }
-
     checkForDescendantErrors(child);
 
     if (getFlag(child, NodeFlags.DescendantHasError)) {
       setFlag(node, NodeFlags.DescendantHasError | NodeFlags.DescendantErrorsExamined);
       return true;
     }
-
     setFlag(child, NodeFlags.DescendantErrorsExamined);
+
     return false;
   });
 }


### PR DESCRIPTION
fix #136

Handle circular reference when using `is` or `extends`. Will emit a recursive reference type diagnostic instead of a stack overflow 