### PR TITLE
Add support for interfaces in @tag decorator; add @tag tests

### DIFF
--- a/common/changes/@cadl-lang/compiler/interface-tags_2021-12-15-14-19.json
+++ b/common/changes/@cadl-lang/compiler/interface-tags_2021-12-15-14-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add support for `interface` as a `@tag` decorator target",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi3/interface-tags_2021-12-15-15-18.json
+++ b/common/changes/@cadl-lang/openapi3/interface-tags_2021-12-15-15-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -378,7 +378,7 @@ const diagnostics = {
       default: paramMessage`Cannot apply ${"decorator"} decorator to ${"to"}`,
       model: paramMessage`The ${"decorator"} decorator can only be applied to models.`,
       operations: paramMessage`The ${"decorator"} decorator can only be applied to operations.`,
-      namespacesOrOperations: paramMessage`The ${"decorator"} decorator can only be applied to namespaces or operations.`,
+      namespacesInterfacesOrOperations: paramMessage`The ${"decorator"} decorator can only be applied to namespaces, interfaces, or operations.`,
       operationsOrModelProps: paramMessage`The ${"decorator"} decorator can only be applied to operations or model properties.`,
     },
   },

--- a/packages/compiler/test/decorators/tags.ts
+++ b/packages/compiler/test/decorators/tags.ts
@@ -1,0 +1,65 @@
+import { deepStrictEqual } from "assert";
+import { InterfaceType, NamespaceType, OperationType } from "../../core/types.js";
+import { getAllTags, getTags } from "../../lib/decorators.js";
+import { createTestHost, TestHost } from "../test-host.js";
+
+describe("compiler: tag decorator", () => {
+  let testHost: TestHost;
+
+  beforeEach(async () => {
+    testHost = await createTestHost();
+  });
+
+  it("applies @tag decorator to namespaces, interfaces, and operations", async (): Promise<void> => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+      @test
+      @tag("namespace")
+      namespace OpNamespace {
+        @test
+        @tag("namespaceOp")
+        op NamespaceOperation(): string;
+      }
+
+      @test
+      @tag("interface")
+      interface OpInterface {
+        @test
+        @tag("interfaceOp")
+        InterfaceOperation(): string;
+      }
+
+      @test
+      interface UntaggedInterface {
+        @test
+        @tag("taggedOp")
+        TaggedOperation(): string;
+      }
+      `
+    );
+
+    const {
+      OpNamespace,
+      OpInterface,
+      NamespaceOperation,
+      UntaggedInterface,
+      InterfaceOperation,
+      TaggedOperation,
+    } = (await testHost.compile("./")) as {
+      OpNamespace: NamespaceType;
+      OpInterface: InterfaceType;
+      UntaggedInterface: InterfaceType;
+      NamespaceOperation: OperationType;
+      InterfaceOperation: OperationType;
+      TaggedOperation: OperationType;
+    };
+
+    deepStrictEqual(getTags(testHost.program, OpNamespace), ["namespace"]);
+    deepStrictEqual(getTags(testHost.program, OpInterface), ["interface"]);
+    deepStrictEqual(getTags(testHost.program, UntaggedInterface), []);
+    deepStrictEqual(getAllTags(testHost.program, NamespaceOperation), ["namespace", "namespaceOp"]);
+    deepStrictEqual(getAllTags(testHost.program, InterfaceOperation), ["interface", "interfaceOp"]);
+    deepStrictEqual(getAllTags(testHost.program, TaggedOperation), ["taggedOp"]);
+  });
+});

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -271,7 +271,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
   }
 
   function emitOperation(operation: OperationDetails): void {
-    const { path: fullPath, operation: op, groupName, container, verb, parameters } = operation;
+    const { path: fullPath, operation: op, groupName, verb, parameters } = operation;
 
     // If path contains a query string, issue msg and don't emit this endpoint
     if (fullPath.indexOf("?") > 0) {
@@ -302,7 +302,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     currentEndpoint.parameters = [];
     currentEndpoint.responses = {};
 
-    const currentTags = getAllTags(program, container, op);
+    const currentTags = getAllTags(program, op);
     if (currentTags) {
       currentEndpoint.tags = currentTags;
       for (const tag of currentTags) {

--- a/packages/samples/tags/tagged-operations.cadl
+++ b/packages/samples/tags/tagged-operations.cadl
@@ -25,6 +25,19 @@ namespace bar {
   op create(@path id: int32): null;
 }
 
+@tag("outer")
+@route("/nested")
+namespace NestedOuter {
+  @tag("inner")
+  namespace NestedInner {
+    @tag("moreInner")
+    namespace NestedMoreInner {
+      @tag("innerOp")
+      op createOther(@path id: int32): null;
+    }
+  }
+}
+
 model Resp {
   out: string;
 }

--- a/packages/samples/test/output/tags/openapi.json
+++ b/packages/samples/test/output/tags/openapi.json
@@ -16,6 +16,18 @@
     },
     {
       "name": "tag3"
+    },
+    {
+      "name": "outer"
+    },
+    {
+      "name": "inner"
+    },
+    {
+      "name": "moreInner"
+    },
+    {
+      "name": "innerOp"
     }
   ],
   "paths": {
@@ -65,8 +77,8 @@
         },
         "tags": [
           "foo",
-          "tag2",
-          "tag1"
+          "tag1",
+          "tag2"
         ]
       }
     },
@@ -115,6 +127,33 @@
         },
         "tags": [
           "tag3"
+        ]
+      }
+    },
+    "/nested/{id}": {
+      "get": {
+        "operationId": "NestedMoreInner_createOther",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        },
+        "tags": [
+          "outer",
+          "inner",
+          "moreInner",
+          "innerOp"
         ]
       }
     }


### PR DESCRIPTION
This was an issue that was encountered a few times while authoring data plane specs.  I added support for `interface` with the `@tag` decorator and added tests to ensure it works as expected.