### PR TITLE
Fix additional circular ref issues(Alias, template)

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-circular-issues_2021-12-15-09-01.json
+++ b/common/changes/@cadl-lang/compiler/fix-circular-issues_2021-12-15-09-01.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@cadl-lang/compiler",
-      "comment": "**Fix** Ciruclar reference in `is` or `extends` now emit a diagnostic instead of crashing",
+      "comment": "**Fix** Circular reference in `is` or `extends` now emit a diagnostic instead of crashing",
       "type": "patch"
     }
   ],

--- a/common/changes/@cadl-lang/compiler/fix-cirucular-issues-2_2021-12-15-16-08.json
+++ b/common/changes/@cadl-lang/compiler/fix-cirucular-issues-2_2021-12-15-16-08.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Fix** Circular reference in `alias` now emit a diagnostic instead of crashing",
+      "type": "patch"
+    },
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Fix** Circular reference between template model and non template model causing unresolved types issues.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -521,7 +521,8 @@ export function createChecker(program: Program): Checker {
     templateInstantiation = args;
     instantiatingTemplate = templateNode;
 
-    const type = pendingModelTypes.get(getNodeSymId(templateNode)) ?? getTypeForNode(templateNode);
+    const pending = pendingModelTypes.get(getNodeSymId(templateNode));
+    const type = pending && oldTemplate === templateNode ? pending : getTypeForNode(templateNode);
 
     symbolLinks.instantiations!.set(args, type);
     if (type.kind === "Model") {

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -152,9 +152,6 @@ export function createChecker(program: Program): Checker {
    */
   const pendingResolutions = new Set<number>();
 
-  // Map keeping track of the models currently being checked.
-  // When a model type start being instantiated it gets added to this map which lets properties
-  // and referenced models to be able to reference back to it without an infinite recursion.
   for (const file of program.jsSourceFiles.values()) {
     mergeJsSourceFile(file);
   }

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -1525,11 +1525,23 @@ export function createChecker(program: Program): Checker {
       return links.declaredType;
     }
 
+    const aliasSymId = getNodeSymId(node);
+    if (pendingResolutions.has(aliasSymId)) {
+      reportDiagnostic(program, {
+        code: "circular-alias-type",
+        format: { typeName: node.id.sv },
+        target: node,
+      });
+      return errorType;
+    }
+
+    pendingResolutions.add(aliasSymId);
     const type = getTypeForNode(node.value);
     if (!instantiatingThisTemplate) {
       links.declaredType = type;
       links.instantiations = new TypeInstantiationMap();
     }
+    pendingResolutions.delete(aliasSymId);
 
     return type;
   }

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -19,6 +19,7 @@ import {
   EnumStatementNode,
   EnumType,
   ErrorType,
+  Expression,
   IdentifierNode,
   InterfaceStatementNode,
   InterfaceType,
@@ -155,6 +156,7 @@ export function createChecker(program: Program): Checker {
   // When a model type start being instantiated it gets added to this map which lets properties
   // and referenced models to be able to reference back to it without an infinite recursion.
   const pendingModelTypes = new Map<number, ModelType>();
+
   for (const file of program.jsSourceFiles.values()) {
     mergeJsSourceFile(file);
   }
@@ -376,17 +378,23 @@ export function createChecker(program: Program): Checker {
     if (!sym) {
       return errorType;
     }
+    return checkTypeReferenceSymbol(sym, node.arguments);
+  }
 
+  function checkTypeReferenceSymbol(
+    sym: TypeSymbol | DecoratorSymbol,
+    nodeArgs: Expression[]
+  ): Type {
     if (sym.kind === "decorator") {
       program.reportDiagnostic(
-        createDiagnostic({ code: "invalid-type-ref", messageId: "decorator", target: node })
+        createDiagnostic({ code: "invalid-type-ref", messageId: "decorator", target: sym })
       );
 
       return errorType;
     }
 
     const symbolLinks = getSymbolLinks(sym);
-    let args = node.arguments.map(getTypeForNode);
+    let args = nodeArgs.map(getTypeForNode);
 
     if (
       sym.node.kind === SyntaxKind.ModelStatement ||
@@ -400,7 +408,7 @@ export function createChecker(program: Program): Checker {
             createDiagnostic({
               code: "invalid-template-args",
               messageId: "notTemplate",
-              target: node,
+              target: sym,
             })
           );
         }
@@ -440,7 +448,7 @@ export function createChecker(program: Program): Checker {
             createDiagnostic({
               code: "invalid-template-args",
               messageId: "tooFew",
-              target: node,
+              target: sym,
             })
           );
           args = [...args, ...new Array(templateParameters.length - args.length).fill(errorType)];
@@ -449,7 +457,7 @@ export function createChecker(program: Program): Checker {
             createDiagnostic({
               code: "invalid-template-args",
               messageId: "tooMany",
-              target: node,
+              target: sym,
             })
           );
           args = args.slice(0, templateParameters.length);
@@ -464,7 +472,7 @@ export function createChecker(program: Program): Checker {
         createDiagnostic({
           code: "invalid-template-args",
           messageId: "notTemplate",
-          target: node,
+          target: sym,
         })
       );
     }
@@ -1079,20 +1087,29 @@ export function createChecker(program: Program): Checker {
       // we're not instantiating this model and we've already checked it
       return links.declaredType;
     }
+    const decorators: DecoratorApplication[] = [];
+
+    const type: ModelType = {
+      kind: "Model",
+      name: node.id.sv,
+      node: node,
+      properties: new Map<string, ModelTypeProperty>(),
+      namespace: getParentNamespaceType(node),
+      decorators,
+    };
+    pendingModelTypes.set(getNodeSymId(node), type);
 
     const isBase = checkModelIs(node, node.is);
 
-    const decorators: DecoratorApplication[] = [];
     if (isBase) {
       // copy decorators
       decorators.push(...isBase.decorators);
     }
     decorators.push(...checkDecorators(node));
 
-    const properties = new Map<string, ModelTypeProperty>();
     if (isBase) {
       for (const prop of isBase.properties.values()) {
-        properties.set(
+        type.properties.set(
           prop.name,
           createType({
             ...prop,
@@ -1101,27 +1118,14 @@ export function createChecker(program: Program): Checker {
       }
     }
 
-    let baseModels;
     if (isBase) {
-      baseModels = isBase.baseModel;
+      type.baseModel = isBase.baseModel;
     } else if (node.extends) {
-      baseModels = checkClassHeritage(node, node.extends);
+      type.baseModel = checkClassHeritage(node, node.extends);
     }
-
-    const type: ModelType = {
-      kind: "Model",
-      name: node.id.sv,
-      node: node,
-      properties,
-      baseModel: baseModels,
-      namespace: getParentNamespaceType(node),
-      decorators,
-    };
 
     // Hold on to the model type that's being defined so that it
     // can be referenced
-    pendingModelTypes.set(getNodeSymId(node), type);
-
     if (!instantiatingThisTemplate) {
       links.declaredType = type;
       links.instantiations = new TypeInstantiationMap();
@@ -1133,7 +1137,7 @@ export function createChecker(program: Program): Checker {
     );
 
     // Evaluate the properties after
-    checkModelProperties(node, properties, inheritedPropNames);
+    checkModelProperties(node, type.properties, inheritedPropNames);
 
     if (shouldCreateTypeForTemplate(node)) {
       createType(type);
@@ -1225,17 +1229,21 @@ export function createChecker(program: Program): Checker {
     heritageRef: TypeReferenceNode
   ): ModelType | undefined {
     const modelSymId = getNodeSymId(model);
-    if (pendingResolutions.has(modelSymId)) {
+    pendingResolutions.add(modelSymId);
+
+    const target = resolveTypeReference(heritageRef) as TypeSymbol;
+    if (target === undefined) {
+      return undefined;
+    }
+    if (pendingResolutions.has(getNodeSymId(target.node as any))) {
       reportDiagnostic(program, {
         code: "circular-base-type",
-        format: { typeName: model.id.sv },
-        target: model,
+        format: { typeName: (target.node as any).id.sv },
+        target: target,
       });
       return undefined;
     }
-    pendingResolutions.add(modelSymId);
-
-    const heritageType = getTypeForNode(heritageRef);
+    const heritageType = checkTypeReferenceSymbol(target, heritageRef.arguments);
     pendingResolutions.delete(modelSymId);
     if (isErrorType(heritageType)) {
       compilerAssert(program.hasError(), "Should already have reported an error.", heritageRef);
@@ -1256,16 +1264,20 @@ export function createChecker(program: Program): Checker {
   ): ModelType | undefined {
     if (!isExpr) return undefined;
     const modelSymId = getNodeSymId(model);
-    if (pendingResolutions.has(modelSymId)) {
+    pendingResolutions.add(modelSymId);
+    const target = resolveTypeReference(isExpr) as TypeSymbol;
+    if (target === undefined) {
+      return undefined;
+    }
+    if (pendingResolutions.has(getNodeSymId(target.node as any))) {
       reportDiagnostic(program, {
         code: "circular-base-type",
-        format: { typeName: model.id.sv },
-        target: model,
+        format: { typeName: (target.node as any).id.sv },
+        target: target,
       });
       return undefined;
     }
-    pendingResolutions.add(modelSymId);
-    const isType = getTypeForNode(isExpr);
+    const isType = checkTypeReferenceSymbol(target, isExpr.arguments);
     pendingResolutions.delete(modelSymId);
 
     if (isType.kind !== "Model") {

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -447,7 +447,13 @@ const diagnostics = {
   "circular-base-type": {
     severity: "error",
     messages: {
-      default: paramMessage`Type '${"typeName"}' recursively references itself as a base type.`,
+      default: paramMessage`Model type '${"typeName"}' recursively references itself as a base type.`,
+    },
+  },
+  "circular-alias-type": {
+    severity: "error",
+    messages: {
+      default: paramMessage`Alias type '${"typeName"}' recursively references itself.`,
     },
   },
 } as const;

--- a/packages/compiler/test/checker/alias.ts
+++ b/packages/compiler/test/checker/alias.ts
@@ -162,4 +162,28 @@ describe("compiler: aliases", () => {
     ok(B.properties.has("a"));
     strictEqual(C.properties.get("c")!.type, Test);
   });
+
+  it("emit diagnostics if assign itself", async () => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+      alias A = A;
+      `
+    );
+    const diagnostics = await testHost.diagnose("main.cadl");
+    strictEqual(diagnostics.length, 1);
+    strictEqual(diagnostics[0].message, "Alias type 'A' recursively references itself.");
+  });
+
+  it("emit diagnostics if reference itself", async () => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+      alias A = "string" | A;
+      `
+    );
+    const diagnostics = await testHost.diagnose("main.cadl");
+    strictEqual(diagnostics.length, 1);
+    strictEqual(diagnostics[0].message, "Alias type 'A' recursively references itself.");
+  });
 });

--- a/packages/compiler/test/checker/model.ts
+++ b/packages/compiler/test/checker/model.ts
@@ -273,5 +273,29 @@ describe("compiler: models", () => {
       const diagnostics = await testHost.diagnose("main.cadl");
       strictEqual(diagnostics.length, 0);
     });
+
+    it("resolve recursive template types", async () => {
+      testHost.addCadlFile(
+        "main.cadl",
+        `
+        model A<T> {
+          c: T;
+          b: B
+        }
+        @test
+        model B is A<string> {}
+        @test
+        model C is A<int32> {}
+        `
+      );
+      const { B, C } = await testHost.compile("main.cadl");
+      strictEqual((B as ModelType).properties.size, 2);
+      strictEqual(((B as ModelType).properties.get("c")?.type as any).name, "string");
+      strictEqual(((B as ModelType).properties.get("b")?.type as any).name, "B");
+
+      strictEqual((C as ModelType).properties.size, 2);
+      strictEqual(((C as ModelType).properties.get("c")?.type as any).name, "int32");
+      strictEqual(((C as ModelType).properties.get("b")?.type as any).name, "B");
+    });
   });
 });

--- a/packages/compiler/test/checker/model.ts
+++ b/packages/compiler/test/checker/model.ts
@@ -135,6 +135,20 @@ describe("compiler: models", () => {
       strictEqual(diagnostics.length, 1);
       strictEqual(diagnostics[0].message, "Type 'A' recursively references itself as a base type.");
     });
+
+    it("emit no error when extends has property to base model", async () => {
+      testHost.addCadlFile(
+        "main.cadl",
+        `
+        model A extends B {}
+        model B {
+          a: A
+        }
+        `
+      );
+      const diagnostics = await testHost.diagnose("main.cadl");
+      strictEqual(diagnostics.length, 0);
+    });
   });
 
   describe("with is", () => {
@@ -244,6 +258,20 @@ describe("compiler: models", () => {
       const diagnostics = await testHost.diagnose("main.cadl");
       strictEqual(diagnostics.length, 1);
       strictEqual(diagnostics[0].message, "Type 'A' recursively references itself as a base type.");
+    });
+
+    it("emit no error when extends has property to base model", async () => {
+      testHost.addCadlFile(
+        "main.cadl",
+        `
+        model A is B {}
+        model B {
+          a: A
+        }
+        `
+      );
+      const diagnostics = await testHost.diagnose("main.cadl");
+      strictEqual(diagnostics.length, 0);
     });
   });
 });

--- a/packages/compiler/test/checker/model.ts
+++ b/packages/compiler/test/checker/model.ts
@@ -120,7 +120,10 @@ describe("compiler: models", () => {
       );
       const diagnostics = await testHost.diagnose("main.cadl");
       strictEqual(diagnostics.length, 1);
-      strictEqual(diagnostics[0].message, "Type 'A' recursively references itself as a base type.");
+      strictEqual(
+        diagnostics[0].message,
+        "Model type 'A' recursively references itself as a base type."
+      );
     });
 
     it("emit error when extends ciruclar reference", async () => {
@@ -133,7 +136,10 @@ describe("compiler: models", () => {
       );
       const diagnostics = await testHost.diagnose("main.cadl");
       strictEqual(diagnostics.length, 1);
-      strictEqual(diagnostics[0].message, "Type 'A' recursively references itself as a base type.");
+      strictEqual(
+        diagnostics[0].message,
+        "Model type 'A' recursively references itself as a base type."
+      );
     });
 
     it("emit no error when extends has property to base model", async () => {
@@ -231,7 +237,10 @@ describe("compiler: models", () => {
       );
       const diagnostics = await testHost.diagnose("main.cadl");
       strictEqual(diagnostics.length, 1);
-      strictEqual(diagnostics[0].message, "Type 'A' recursively references itself as a base type.");
+      strictEqual(
+        diagnostics[0].message,
+        "Model type 'A' recursively references itself as a base type."
+      );
     });
 
     it("emit error when 'is' has circular reference", async () => {
@@ -244,7 +253,10 @@ describe("compiler: models", () => {
       );
       const diagnostics = await testHost.diagnose("main.cadl");
       strictEqual(diagnostics.length, 1);
-      strictEqual(diagnostics[0].message, "Type 'A' recursively references itself as a base type.");
+      strictEqual(
+        diagnostics[0].message,
+        "Model type 'A' recursively references itself as a base type."
+      );
     });
 
     it("emit error when 'is' circular reference via extends", async () => {
@@ -257,7 +269,10 @@ describe("compiler: models", () => {
       );
       const diagnostics = await testHost.diagnose("main.cadl");
       strictEqual(diagnostics.length, 1);
-      strictEqual(diagnostics[0].message, "Type 'A' recursively references itself as a base type.");
+      strictEqual(
+        diagnostics[0].message,
+        "Model type 'A' recursively references itself as a base type."
+      );
     });
 
     it("emit no error when extends has property to base model", async () => {


### PR DESCRIPTION
Resolve more issues with circular references:


## Alias circular reference
fix #139
```cadl
alias A = A;
alias A = string | A;
```

## Issue with template circular reference
fix #133
fix #134
Those issues seems to be caused when the cirucular reference involve a non template model in a templated model



Problematic code in cadl
```cadl
import "@cadl-lang/rest";

using Cadl.Http;

model ErrorTemplate<T> {
  @doc("Error code.") code: T;
  innererror?: InnerError;
}

model Error is ErrorTemplate<ErrorCode> {}
model InnerError is ErrorTemplate<InnerErrorCode> {}

enum ErrorCode {
  A,
  B,
  C,
}

enum InnerErrorCode {
  C,
  D,
  E,
}

@route("/")
namespace N {
  op M(): Error;
}

```

Produce the following OpenAPI3:

```json
{
  "openapi": "3.0.0",
  "info": {
    "title": "(title)",
    "version": "0000-00-00"
  },
  "tags": [],
  "paths": {
    "/": {
      "get": {
        "operationId": "N_M",
        "parameters": [],
        "responses": {
          "200": {
            "description": "A successful response",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/Error"
                }
              }
            }
          }
        }
      }
    }
  },
  "components": {
    "schemas": {
      "Error": {
        "type": "object",
        "properties": {
          "code": {
            "$ref": "#/components/schemas/ErrorCode",
            "description": "Error code."
          },
          "innererror": {
            "$ref": "#/components/schemas/InnerError"
          }
        },
        "required": [
          "code"
        ]
      },
      "ErrorCode": {
        "type": "string",
        "enum": [
          "A",
          "B",
          "C"
        ]
      },
      "InnerError": {
        "type": "object",
        "properties": {
          "code": {
            "$ref": "#/components/schemas/InnerErrorCode",
            "description": "Error code."
          },
          "innererror": {
            "$ref": "#/components/schemas/InnerError"
          }
        },
        "required": [
          "code"
        ]
      },
      "InnerErrorCode": {
        "type": "string",
        "enum": [
          "C",
          "D",
          "E"
        ]
      }
    }
  }
}

```
