### PR TITLE
Add support for discriminator decorator

### DIFF
--- a/common/changes/@cadl-lang/rest/discriminator_2021-12-01-13-32.json
+++ b/common/changes/@cadl-lang/rest/discriminator_2021-12-01-13-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add support for discriminator decorator",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/src/rest.ts
+++ b/packages/rest/src/rest.ts
@@ -38,6 +38,27 @@ export function getConsumes(program: Program, entity: Type): string[] {
   return program.stateMap(consumesTypesKey).get(entity) || [];
 }
 
+const discriminatorKey = Symbol();
+export function $discriminator(program: Program, entity: Type, propertyName: string) {
+  if (entity.kind !== "Model") {
+    reportDiagnostic(program, {
+      code: "decorator-wrong-type",
+      format: { decorator: "discriminator", entityKind: entity.kind },
+      target: entity,
+    });
+    return;
+  }
+  program.stateMap(discriminatorKey).set(entity, propertyName);
+}
+
+export function getDiscriminator(program: Program, entity: Type): any | undefined {
+  const propertyName = program.stateMap(discriminatorKey).get(entity);
+  if (propertyName) {
+    return { propertyName };
+  }
+  return undefined;
+}
+
 const segmentsKey = Symbol();
 export function $segment(program: Program, entity: Type, name: string) {
   if (entity.kind !== "ModelProperty") {


### PR DESCRIPTION
This PR simply adds the discriminator decorator without any actual implementation in the emitters.  Emitter support will be added in follow-on PRs.