### PR TITLE
Support nullable in openapi3 emitter

### DIFF
--- a/common/changes/@cadl-lang/openapi3/nullable_2021-12-16-15-33.json
+++ b/common/changes/@cadl-lang/openapi3/nullable_2021-12-16-15-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Support nullable in openapi3 emitter",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -782,6 +782,9 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       if (nonNullOptions.length === 1) {
         // Get the schema for the model type
         const schema: any = getSchemaForType(nonNullOptions[0]);
+        if (nullable) {
+          schema["nullable"] = true;
+        }
 
         return schema;
       } else {
@@ -805,6 +808,9 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     const schema: any = { type };
     if (values.length > 0) {
       schema.enum = values;
+    }
+    if (nullable) {
+      schema["nullable"] = true;
     }
 
     return schema;

--- a/packages/openapi3/test/test-openapi-output.ts
+++ b/packages/openapi3/test/test-openapi-output.ts
@@ -354,6 +354,53 @@ describe("openapi3: definitions", () => {
     deepStrictEqual(res.schemas.PetType.enum, ["Dog", "Cat"]);
   });
 
+  it("defines nullable properties", async () => {
+    const res = await oapiForModel(
+      "Pet",
+      `
+      model Pet {
+        name: string | null;
+      };
+      `
+    );
+    ok(res.isRef);
+    deepStrictEqual(res.schemas.Pet, {
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          nullable: true,
+          "x-cadl-name": "Cadl.string | Cadl.null",
+        },
+      },
+      required: ["name"],
+    });
+  });
+
+  it("defines enums with a nullable variant", async () => {
+    const res = await oapiForModel(
+      "Pet",
+      `
+      model Pet {
+        type: "cat" | "dog" | null;
+      };
+    `
+    );
+    ok(res.isRef);
+    deepStrictEqual(res.schemas.Pet, {
+      type: "object",
+      properties: {
+        type: {
+          type: "string",
+          enum: ["cat", "dog"],
+          nullable: true,
+          "x-cadl-name": "cat | dog | Cadl.null",
+        },
+      },
+      required: ["type"],
+    });
+  });
+
   it("throws diagnostics for empty enum definitions", async () => {
     let testHost = await createOpenAPITestHost();
     testHost.addCadlFile(

--- a/packages/samples/test/output/nullable/openapi.json
+++ b/packages/samples/test/output/nullable/openapi.json
@@ -15,7 +15,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "nullable": true
             }
           }
         ],
@@ -48,6 +49,7 @@
           },
           "strOrNull": {
             "type": "string",
+            "nullable": true,
             "x-cadl-name": "Cadl.string | Cadl.null"
           },
           "modelOrNull": {
@@ -61,6 +63,7 @@
             "required": [
               "num"
             ],
+            "nullable": true,
             "x-cadl-name": "AnotherModel | Cadl.null"
           },
           "literalsOrNull": {
@@ -69,10 +72,12 @@
               "one",
               "two"
             ],
+            "nullable": true,
             "x-cadl-name": "one | two | Cadl.null"
           },
           "manyNullsOneString": {
             "type": "string",
+            "nullable": true,
             "x-cadl-name": "Cadl.null | Cadl.null | Cadl.string | Cadl.null"
           },
           "manyNullsSomeValues": {
@@ -81,6 +86,7 @@
               42,
               100
             ],
+            "nullable": true,
             "x-cadl-name": "Cadl.null | 42 | Cadl.null | 100 | Cadl.null"
           }
         },


### PR DESCRIPTION
This PR adds `nullable: true` to a schema if it is unioned with `null`.