### PR TITLE
Move change to correct version in changelog

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-changelog_2021-12-16-16-24.json
+++ b/common/changes/@cadl-lang/compiler/fix-changelog_2021-12-16-16-24.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@cadl-lang/compiler",
-      "comment": "Add findChildModels and getProperty utility functions",
-      "type": "patch"
+      "comment": "",
+      "type": "none"
     }
   ],
   "packageName": "@cadl-lang/compiler"

--- a/packages/compiler/CHANGELOG.json
+++ b/packages/compiler/CHANGELOG.json
@@ -25,6 +25,9 @@
         ],
         "patch": [
           {
+            "comment": "Add findChildModels and getProperty utility functions"
+          },
+          {
             "comment": "**Fix** Circular reference in `is` or `extends` now emit a diagnostic instead of crashing"
           },
           {

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @cadl-lang/compiler
 
-This log was last generated on Thu, 16 Dec 2021 08:02:20 GMT and should not be manually modified.
+This log was last generated on Thu, 16 Dec 2021 16:21:46 GMT and should not be manually modified.
 
 ## 0.25.0
 Thu, 16 Dec 2021 08:02:20 GMT
@@ -15,6 +15,7 @@ Thu, 16 Dec 2021 08:02:20 GMT
 
 ### Patches
 
+- Add findChildModels and getProperty utility functions
 - **Fix** Circular reference in `is` or `extends` now emit a diagnostic instead of crashing
 - **Fix** Circular reference in `alias` now emit a diagnostic instead of crashing
 - **Fix** Circular reference between template model and non template model causing unresolved types issues.


### PR DESCRIPTION
Due to PR being merged while publish PR was outstanding, a change that was published in the release didn't make it into the changelog. 

Fixup the changelog to at least be historically accurate.

See https://github.com/Azure/cadl-azure/issues/1089 for follow-up to avoid this in the future.
