### PR TITLE
Add statusCode decorator for http status code

### DIFF
--- a/common/changes/@cadl-lang/openapi3/status-codes_2022-01-06-22-15.json
+++ b/common/changes/@cadl-lang/openapi3/status-codes_2022-01-06-22-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Add statusCode decorator for http status code",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/status-codes_2022-01-06-22-15.json
+++ b/common/changes/@cadl-lang/rest/status-codes_2022-01-06-22-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add statusCode decorator for http status code",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/docs/cadl-for-openapi-dev.md
+++ b/docs/cadl-for-openapi-dev.md
@@ -179,7 +179,7 @@ The responses object maps a HTTP response code to the expected response.
 [v2-responses]: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md#responsesObject
 [v3-responses]: https://github.com/OAI/OpenAPI-Specification/blob/3.0.3/versions/3.0.3.md#responsesObject
 
-In Cadl, operation responses are defined by the return types of the `op`. The status code for a response can be specified as an `@header` property in the return type called `statusCode`. The Cadl.Http package also defines several standard response types:
+In Cadl, operation responses are defined by the return types of the `op`. The status code for a response can be specified as a property in the return type with the `@statusCode` decorator (the property name is ignored). The Cadl.Http package also defines several standard response types:
 
 | OpenAPI response | Cadl construct         | Notes                                |
 | ---------------- | ---------------------- | ------------------------------------ |
@@ -193,8 +193,7 @@ In Cadl, operation responses are defined by the return types of the `op`. The st
 | `404`            | `NotFoundResponse`     |                                      |
 | `409`            | `ConflictResponse`     |                                      |
 
-If the first return type does not contain a `statusCode` header, it is assumed to be the `200` response.
-Any return type after the first that does not contain a `statusCode` header is assumed to be the `default` response.
+If a return type does not contain a `statusCode`, it is assumed to be the `200` response.
 
 ### Response Object
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -645,18 +645,18 @@ Use the `@header` decorator on a property named `statusCode` to declare a status
 @route("/pets")
 namespace Pets {
   op list(@query skip: int32, @query top: int32): {
-    @header statusCode: 200;
+    @statusCode statusCode: 200;
     @body pets: Pet[];
   };
   op read(@path petId: int32, @header ifMatch?: string): {
-    @header statusCode: 200;
+    @statusCode statusCode: 200;
     @header eTag: string;
     @body pet: Pet;
   } | {
-    @header statusCode: 404;
+    @statusCode statusCode: 404;
   };
   op create(@body pet: Pet): {
-    @header statusCode: 200;
+    @statusCode statusCode: 200;
   };
 }
 

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -34,6 +34,12 @@ const libDef = {
         default: "Duplicate @body declarations on response type",
       },
     },
+    "duplicate-status-code": {
+      severity: "error",
+      messages: {
+        default: "Duplicate @statusCode declarations on response type",
+      },
+    },
     "duplicate-body-types": {
       severity: "error",
       messages: {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -35,7 +35,7 @@ import { getAllRoutes, getDiscriminator, http, OperationDetails } from "@cadl-la
 import * as path from "path";
 import { reportDiagnostic } from "./lib.js";
 
-const { getHeaderFieldName, getPathParamName, getQueryParamName, isBody } = http;
+const { getHeaderFieldName, getPathParamName, getQueryParamName, isBody, isStatusCode } = http;
 
 export async function $onBuild(p: Program) {
   const options: OpenAPIEmitterOptions = {
@@ -321,7 +321,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
   function emitResponses(responseType: Type) {
     if (responseType.kind === "Union") {
       for (const [i, option] of responseType.options.entries()) {
-        emitResponseObject(option, i === 0 ? "200" : "default");
+        emitResponseObject(option);
       }
     } else {
       emitResponseObject(responseType);
@@ -337,8 +337,9 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     );
   }
 
-  function emitResponseObject(responseModel: Type, statusCode: string = "200") {
-    let contentType: string = "application/json";
+  function emitResponseObject(responseModel: Type) {
+    let statusCode = undefined;
+    let contentType = "application/json";
     if (
       responseModel.kind === "Model" &&
       !responseModel.baseModel &&
@@ -349,8 +350,8 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
         ? { type: "string", format: "binary" }
         : mapCadlTypeToOpenAPI(responseModel);
       if (schema) {
-        currentEndpoint.responses[statusCode] = {
-          description: getResponseDescription(responseModel, statusCode),
+        currentEndpoint.responses["200"] = {
+          description: getResponseDescription(responseModel, "200"),
           content: {
             [contentType]: {
               schema: schema,
@@ -358,7 +359,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
           },
         };
       } else {
-        currentEndpoint.responses[204] = {
+        currentEndpoint.responses["204"] = {
           description: "No content",
         };
       }
@@ -380,15 +381,21 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
 
           bodyModel = prop.type;
         }
+        if (isStatusCode(program, prop)) {
+          if (statusCode) {
+            reportDiagnostic(program, { code: "duplicate-status-code", target: responseModel });
+            continue;
+          }
+          if (prop.type.kind === "Number") {
+            statusCode = String(prop.type.value);
+          } else if (prop.type.kind === "String") {
+            statusCode = prop.type.value;
+          }
+        }
         const type = prop.type;
         const headerName = getHeaderFieldName(program, prop);
         switch (headerName) {
           case undefined:
-            break;
-          case "status-code":
-            if (type.kind === "Number") {
-              statusCode = String(type.value);
-            }
             break;
           case "content-type":
             if (type.kind === "String") {
@@ -406,6 +413,9 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     contentEntry.schema = isBinary
       ? { type: "string", format: "binary" }
       : getSchemaOrRef(bodyModel);
+
+    // If no status code was defined in the response model, use 200.
+    statusCode ??= "200";
 
     const response: any = {
       description: getResponseDescription(responseModel, statusCode),
@@ -1081,7 +1091,8 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     const headerInfo = getHeaderFieldName(program, property);
     const queryInfo = getQueryParamName(program, property);
     const pathInfo = getPathParamName(program, property);
-    return !(headerInfo || queryInfo || pathInfo);
+    const statusCodeinfo = isStatusCode(program, property);
+    return !(headerInfo || queryInfo || pathInfo || statusCodeinfo);
   }
 
   function getTypeNameForSchemaProperties(type: Type) {

--- a/packages/rest/lib/http.cadl
+++ b/packages/rest/lib/http.cadl
@@ -7,8 +7,8 @@ using Private;
 @doc("The request has succeeded.")
 model OkResponse<T> {
   @doc("The status code.")
-  @header
-  statusCode: 200;
+  @statusCode
+  _: 200;
 
   @doc("The reponse body.")
   @body
@@ -25,58 +25,58 @@ model LocationHeader {
 @doc("The request has succeeded and a new resource has been created as a result.")
 model CreatedResponse {
   @doc("The status code.")
-  @header
-  statusCode: 201;
+  @statusCode
+  _: 201;
 }
 
 @doc("The request has been received but not yet acted upon.")
 model AcceptedResponse {
   @doc("The status code.")
-  @header
-  statusCode: 202;
+  @statusCode
+  _: 202;
 }
 
 @doc("There is no content to send for this request, but the headers may be useful. ")
 model NoContentResponse {
   @doc("The status code.")
-  @header
-  statusCode: 204;
+  @statusCode
+  _: 204;
 }
 
 @doc("The URL of the requested resource has been changed permanently. The new URL is given in the response.")
 model MovedResponse {
   @doc("The status code.")
-  @header
-  statusCode: 301;
+  @statusCode
+  _: 301;
   ...LocationHeader;
 }
 
 @doc("This is used for caching purposes.")
 model NotModifiedResponse {
   @doc("The status code.")
-  @header
-  statusCode: 304;
+  @statusCode
+  _: 304;
 }
 
 @doc("The server could not understand the request due to invalid syntax.")
 model UnauthorizedResponse {
   @doc("The status code.")
-  @header
-  statusCode: 401;
+  @statusCode
+  _: 401;
 }
 
 @doc("The server can not find the requested resource.")
 model NotFoundResponse {
   @doc("The status code.")
-  @header
-  statusCode: 404;
+  @statusCode
+  _: 404;
 }
 
 @doc("This response is sent when a request conflicts with the current state of the server.")
 model ConflictResponse {
   @doc("The status code.")
-  @header
-  statusCode: 409;
+  @statusCode
+  _: 409;
 }
 
 // Produces a new model with the same properties as T, but with @query,

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -78,8 +78,8 @@ interface ResourceUpdate<TResource, TError> {
 @doc("Resource deleted successfully.")
 model ResourceDeletedResponse {
   @doc("The status code.")
-  @header
-  statusCode: 200;
+  @statusCode
+  _: 200;
 }
 
 interface ResourceDelete<TResource, TError> {

--- a/packages/samples/documentation/docs.cadl
+++ b/packages/samples/documentation/docs.cadl
@@ -24,23 +24,24 @@ model RespWithDocs {
   value: int32;
 }
 
-// Will have default error description
 model Error {
+  @statusCode _: "default";
   code: int32;
 }
 
 @doc("Error from @doc")
 model ErrorWithDocs {
+  @statusCode _: "default";
   code: int32;
 }
 
 model NotFoundResp {
-  @header statusCode: 404;
+  @statusCode _: 404;
   details: string;
 }
 
 @doc("Not found")
 model NotFoundWithDocsResp {
-  @header statusCode: 404;
+  @statusCode _: 404;
   details: string;
 }

--- a/packages/samples/grpc-kiosk-example/types.cadl
+++ b/packages/samples/grpc-kiosk-example/types.cadl
@@ -31,6 +31,7 @@ model Empty {}
 
 @doc("An unexpected error response.")
 model RpcStatus {
+  @statusCode _: "default";
   code?: int32;
   message?: string;
   details?: ProtobufAny[];

--- a/packages/samples/grpc-library-example/library.cadl
+++ b/packages/samples/grpc-library-example/library.cadl
@@ -268,6 +268,7 @@ model Empty {}
 
 @doc("An unexpected error response.")
 model RpcStatus {
+  @statusCode _: "default";
   code?: int32;
   message?: string;
   details?: ProtobufAny[];

--- a/packages/samples/mutation/common.cadl
+++ b/packages/samples/mutation/common.cadl
@@ -1,3 +1,8 @@
+import "@cadl-lang/rest";
+
+using Cadl.Http;
+
 model OtherModel {
+  @statusCode _: "default";
   num: int32;
 }

--- a/packages/samples/petstore/petstore.cadl
+++ b/packages/samples/petstore/petstore.cadl
@@ -25,13 +25,14 @@ model Toy {
 
 @doc("Error")
 model Error {
+  @statusCode _: "default";
   code: int32;
   message: string;
 }
 
 @doc("Not modified")
 model NotModified<T> {
-  @header statusCode: 304;
+  @statusCode _: 304;
   @body body: T;
 }
 

--- a/packages/samples/rest/petstore/petstore.cadl
+++ b/packages/samples/rest/petstore/petstore.cadl
@@ -10,6 +10,7 @@ using Cadl.Rest;
 using Cadl.Rest.Resource;
 
 model PetStoreError {
+  @statusCode _: "default";
   code: int32;
   message: string;
 }

--- a/packages/samples/testserver/body-boolean/body-boolean.cadl
+++ b/packages/samples/testserver/body-boolean/body-boolean.cadl
@@ -4,6 +4,7 @@ using Cadl.Http;
 
 @doc("Error")
 model Error {
+  @statusCode _: "default";
   code: int32;
   message: string;
 }

--- a/packages/samples/testserver/body-string/body-string.cadl
+++ b/packages/samples/testserver/body-string/body-string.cadl
@@ -4,6 +4,7 @@ using Cadl.Http;
 
 @doc("Error")
 model Error {
+  @statusCode _: "default";
   status: int32;
   message: string;
 }

--- a/packages/samples/testserver/body-time/body-time.cadl
+++ b/packages/samples/testserver/body-time/body-time.cadl
@@ -4,6 +4,7 @@ using Cadl.Http;
 
 @doc("Error")
 model Error {
+  @statusCode _: "default";
   status: int32;
   message: string;
 }

--- a/packages/samples/testserver/multiple-inheritance/multiple-inheritance.cadl
+++ b/packages/samples/testserver/multiple-inheritance/multiple-inheritance.cadl
@@ -25,6 +25,7 @@ model Horse extends Pet {
 
 @doc("Unexpected error")
 model ErrorResponse {
+  @statusCode _: "default";
   @body body: string;
 }
 


### PR DESCRIPTION
This PR adds a new decorator `@statusCode` to identify the status code value for a response, replacing the prior convention of using `@header statusCode` for this purpose.  This decorator is only permitted on a model property.  We also flag a return type with multiple properties with the `@statusCode` decorator.

Note that the field name is not significant, and in some cases I have used `_` to avoid conflicts with other field names.

I have also changed the logic to _always_ default the status code to `200` if one is not specified, and now allow the status code to be explicitly defined as `default`.

A follow-on PR will extend this logic to support unions of status code values for cases like `200 | 201`.
