### PR TITLE
Add a sample for polymorphic model support

### DIFF
--- a/packages/samples/polymorphism/main.cadl
+++ b/packages/samples/polymorphism/main.cadl
@@ -1,0 +1,1 @@
+import "./polymorphism.cadl";

--- a/packages/samples/polymorphism/polymorphism.cadl
+++ b/packages/samples/polymorphism/polymorphism.cadl
@@ -1,0 +1,24 @@
+import "@cadl-lang/rest";
+
+using Cadl.Http;
+
+@discriminator("kind")
+model Pet {
+  name: string;
+  weight?: float32;
+}
+model Cat extends Pet {
+  kind: "cat";
+  meow: int32;
+}
+model Dog extends Pet {
+  kind: "dog";
+  bark: string;
+}
+
+@route("/Pets")
+namespace root {
+  op read(): {
+    @body body: Pet;
+  };
+}

--- a/packages/samples/test/output/polymorphism/openapi.json
+++ b/packages/samples/test/output/polymorphism/openapi.json
@@ -1,0 +1,101 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "(title)",
+    "version": "0000-00-00"
+  },
+  "tags": [],
+  "paths": {
+    "/Pets": {
+      "get": {
+        "operationId": "root_read",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "weight": {
+            "type": "number",
+            "format": "float"
+          }
+        },
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "cat": "#/components/schemas/Cat",
+            "dog": "#/components/schemas/Dog"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "Cat": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "cat"
+            ]
+          },
+          "meow": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "kind",
+          "meow"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          }
+        ]
+      },
+      "Dog": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "dog"
+            ]
+          },
+          "bark": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "bark"
+        ],
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Pet"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a sample using the `@discriminator` decorator introduced in #89.