### PR TITLE
Minor changes to @cadl-lang/compiler to support RPaaS interfaces

### DIFF
--- a/common/changes/@cadl-lang/compiler/core-tweaks_2022-01-26-13-24.json
+++ b/common/changes/@cadl-lang/compiler/core-tweaks_2022-01-26-13-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add `sourceObject` parameter to `@doc` decorator to aid in producing messages using a context object",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/compiler/core-tweaks_2022-01-26-13-27.json
+++ b/common/changes/@cadl-lang/compiler/core-tweaks_2022-01-26-13-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "`@list` decorator will now ignore `TemplateParameter` objects",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/rest/core-tweaks_2022-01-26-13-24.json
+++ b/common/changes/@cadl-lang/rest/core-tweaks_2022-01-26-13-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Move `@key`, `@parentResource`, and `@copyResourceKeyParameters` decorators into `Cadl.Rest`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/rest/core-tweaks_2022-01-26-13-27.json
+++ b/common/changes/@cadl-lang/rest/core-tweaks_2022-01-26-13-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Operations marked with `@action` will now default to `POST` verb unless another verb has been explicitly specified",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -486,6 +486,11 @@ export function $list(program: Program, target: Type, listedType?: Type) {
     return;
   }
 
+  if (listedType && listedType.kind == "TemplateParameter") {
+    // Silently return because this is probably being used in a templated interface
+    return;
+  }
+
   if (listedType && listedType.kind !== "Model") {
     program.reportDiagnostic(
       createDiagnostic({

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -12,7 +12,7 @@ import {
 export const namespace = "Cadl";
 
 const docsKey = Symbol();
-export function $doc(program: Program, target: Type, text: string) {
+export function $doc(program: Program, target: Type, text: string, sourceObject: Type) {
   // TODO: replace with built-in decorator validation https://github.com/Azure/cadl-azure/issues/1022
   if (typeof text !== "string") {
     reportDiagnostic(program, {
@@ -26,6 +26,19 @@ export function $doc(program: Program, target: Type, text: string) {
     });
     return;
   }
+
+  // If an object was passed in, use it to format the documentation string
+  if (sourceObject) {
+    // Template parameters are not valid source objects, just skip them
+    if (sourceObject.kind === "ModelProperty") {
+      return;
+    }
+
+    text = text.replace(/{(\w+)}/g, (_, propName) => {
+      return (sourceObject as any)[propName];
+    });
+  }
+
   program.stateMap(docsKey).set(target, text);
 }
 

--- a/packages/compiler/test/decorators/decorators.ts
+++ b/packages/compiler/test/decorators/decorators.ts
@@ -24,6 +24,29 @@ describe("compiler: built-in decorators", () => {
       strictEqual(getDoc(testHost.program, A), "My Doc");
     });
 
+    it("formats @doc string using source object", async () => {
+      testHost.addCadlFile(
+        "main.cadl",
+        `
+        @doc("Templated {name}", T)
+        model Template<T>  {
+        }
+
+        @test
+        @doc("Model {name}", A)
+        model A { }
+
+        @test
+        model B is Template<B> {
+        }
+        `
+      );
+
+      const { A, B } = await testHost.compile("./");
+      strictEqual(getDoc(testHost.program, A), "Model A");
+      strictEqual(getDoc(testHost.program, B), "Templated B");
+    });
+
     it("emit diagnostic if doc is not a string", async () => {
       testHost.addCadlFile(
         "main.cadl",

--- a/packages/rest/src/resource.ts
+++ b/packages/rest/src/resource.ts
@@ -164,4 +164,4 @@ export function $parentResource(program: Program, entity: Type, parentType: Type
   program.stateMap(parentResourceTypesKey).set(entity, parentType);
 }
 
-setDecoratorNamespace("Cadl.Rest.Resource", $parentResource, $copyResourceKeyParameters, $key);
+setDecoratorNamespace("Cadl.Rest", $parentResource, $copyResourceKeyParameters, $key);

--- a/packages/rest/src/rest.ts
+++ b/packages/rest/src/rest.ts
@@ -177,11 +177,8 @@ export function $deletesResource(program: Program, entity: Type, resourceType: T
 }
 
 export function $listsResource(program: Program, entity: Type, resourceType: Type) {
-  // Skip this for template parameters passed into the decorator
-  if (resourceType.kind !== "TemplateParameter") {
-    // Add the @list decorator too so that collection routes are generated correctly
-    $list(program, entity, resourceType);
-  }
+  // Add the @list decorator too so that collection routes are generated correctly
+  $list(program, entity, resourceType);
 
   // Add path segment for resource type key
   $segmentOf(program, entity, resourceType);

--- a/packages/rest/src/route.ts
+++ b/packages/rest/src/route.ts
@@ -17,7 +17,7 @@ import {
   HttpVerb,
   isBody,
 } from "./http.js";
-import { getResourceOperation, getSegment } from "./rest.js";
+import { getAction, getResourceOperation, getSegment } from "./rest.js";
 
 export type OperationContainer = NamespaceType | InterfaceType;
 
@@ -276,7 +276,10 @@ function getVerbForOperation(
   const resourceOperation = getResourceOperation(program, operation);
   const verb =
     (resourceOperation && resourceOperationToVerb[resourceOperation.operation]) ??
-    getOperationVerb(program, operation);
+    getOperationVerb(program, operation) ??
+    // TODO: Enable this verb choice to be customized!
+    (getAction(program, operation) ? "post" : undefined);
+
   if (verb !== undefined) {
     return verb;
   }

--- a/packages/rest/test/test-routes.ts
+++ b/packages/rest/test/test-routes.ts
@@ -96,6 +96,7 @@ describe("rest: routes", () => {
 
       @autoRoute
       namespace Things {
+        @get
         @action
         op ActionOne(...ThingId): string;
 
@@ -103,7 +104,7 @@ describe("rest: routes", () => {
         @put op ActionTwo(...ThingId): string;
 
         @action
-        @post op ActionThree(...ThingId, @body bodyParam: string): string;
+        op ActionThree(...ThingId, @body bodyParam: string): string;
       }
       `
     );


### PR DESCRIPTION
This PR contributes a few small tweaks that help to enable what I'm doing in the new interface-based RPaaS library design (PR Azure/cadl-azure#1106):

- `list` decorator should ignore `TemplateParameter` types when they are encountered (usually in templated interface)
- Move `key`, `parentResource` and `copyResourceKeyParameters` decorators to `Cadl.Rest` so that they can also be used by other resource libraries
- Add `formatDoc` decorator for simple `doc` formatting with a `{name}`-style syntax.  It just pulls whatever the value is from the property of the object passed as the last parameter.