### PR TITLE
Remove support for "outerfaces"

### DIFF
--- a/common/changes/@cadl-lang/compiler/no-outerfaces_2022-01-12-16-59.json
+++ b/common/changes/@cadl-lang/compiler/no-outerfaces_2022-01-12-16-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix issue where identifiers could be confused with keywords when they had common endings.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/scanner.ts
+++ b/packages/compiler/core/scanner.ts
@@ -167,7 +167,6 @@ export const enum KeywordLimit {
   // have to change the keyword lookup algorithm in that case.
   MaxLength = 9,
 }
-
 const KeywordMap: ReadonlyMap<number, Token> = new Map(
   Keywords.map((e) => [keywordKey(e[0]), e[1]])
 );
@@ -178,9 +177,16 @@ const KeywordMap: ReadonlyMap<number, Token> = new Map(
 function keywordKey(keyword: string) {
   let key = 0;
   for (let i = 0; i < keyword.length; i++) {
-    key = (key << 5) | (keyword.charCodeAt(i) - CharCode.a);
+    key = updateKeywordKey(key, keyword.charCodeAt(i));
   }
   return key;
+}
+
+function updateKeywordKey(key: number, ch: number) {
+  // Do not simplify this to (key << 5) | (ch - CharCode.a) as JavaScript
+  // bitwise operations truncate to 32-bits, and that will create
+  // collisions.
+  return key * 32 + (ch - CharCode.a);
 }
 
 export interface Scanner {
@@ -830,7 +836,7 @@ export function createScanner(
     while (true) {
       position++;
       count++;
-      key = (key << 5) | (ch - CharCode.a);
+      key = updateKeywordKey(key, ch);
 
       if (eof()) {
         break;

--- a/packages/compiler/test/test-scanner.ts
+++ b/packages/compiler/test/test-scanner.ts
@@ -319,12 +319,12 @@ describe("compiler: scanner", () => {
       KeywordLimit.MinLength,
       `min keyword length is incorrect, set KeywordLimit.MinLength to ${minKeywordLengthFound}`
     );
+
     assert.strictEqual(
       maxKeywordLengthFound,
       KeywordLimit.MaxLength,
       `max keyword length is incorrect, set KeywordLimit.MaxLength to ${maxKeywordLengthFound}`
     );
-
     assert(
       maxKeywordLengthFound < 11,
       "We need to change the keyword lookup algorithm in the scanner if we ever add a keyword with 11 characters or more."
@@ -393,6 +393,15 @@ describe("compiler: scanner", () => {
 
     assert(isIdentifierContinue(0x200c), "U+200C (ZWNJ) should be allowed to continue identifier.");
     assert(isIdentifierContinue(0x200d), "U+200D (ZWJ) should be allowed to continue identifier.");
+  });
+
+  describe("keyword collision", () => {
+    for (const identifier of ["outerface", "famespace", "notanamespace", "notaninterface"]) {
+      it(`does not think ${identifier} is a keyword`, () => {
+        const [[token]] = tokens(identifier);
+        assert.strictEqual(token, Token.Identifier);
+      });
+    }
   });
 
   it("scans this file", async () => {


### PR DESCRIPTION
Joking in the title. There was no outerface feature, but the scanner would scan `outerface` as `interface`! LOL!

JavaScript truncates bitwise integer math to 32 bits and that caused our actual limit in the keyword scanning algorithm that used 5 bits per letter to be 6 characters instead of the 10 we thought we had in the "safe" integer range. The fix is to use equivalent, but non-bitwise arithmetic.

Perf testing on my machine shows this is still faster than not having the optimization at all by 4 or 5% when scanning petstore.cadl thousands of times, but a little slower than the (broken) bitwise version. This isn't likely to be noticeable in a full compile, but could be useful if we ever need to quickly scan for something and skip most of the tokens.