### PR TITLE
Fix nullable arrays in openapi3 emitter

### DIFF
--- a/common/changes/@cadl-lang/openapi3/fix-array-nullable_2022-01-13-21-31.json
+++ b/common/changes/@cadl-lang/openapi3/fix-array-nullable_2022-01-13-21-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "**Fix** Added support for nullable array `xzy[] | null`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -69,6 +69,7 @@ const libDef = {
       severity: "error",
       messages: {
         default: "Unions are not supported unless all options are literals of the same type.",
+        type: paramMessage`Type "${"kind"}" cannot be used in unions`,
         empty:
           "Empty unions are not supported for OpenAPI v3 - enums must have at least one value.",
         null: "Unions containing multiple model types cannot be emitted to OpenAPI v2 unless the union is between one model type and 'null'.",

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -801,12 +801,15 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       case "UnionVariant":
         type = "model";
         break;
+      case "Array":
+        type = "array";
+        break;
       default:
-        reportUnsupportedUnion();
+        reportUnsupportedUnionType(nonNullOptions[0]);
         return {};
     }
 
-    if (type === "model") {
+    if (type === "model" || type === "array") {
       if (nonNullOptions.length === 1) {
         // Get the schema for the model type
         const schema: any = getSchemaForType(nonNullOptions[0]);
@@ -842,6 +845,15 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     }
 
     return schema;
+
+    function reportUnsupportedUnionType(type: Type) {
+      reportDiagnostic(program, {
+        code: "union-unsupported",
+        messageId: "type",
+        format: { kind: type.kind },
+        target: type,
+      });
+    }
 
     function reportUnsupportedUnion() {
       reportDiagnostic(program, { code: "union-unsupported", target: union });

--- a/packages/openapi3/test/test-openapi-output.ts
+++ b/packages/openapi3/test/test-openapi-output.ts
@@ -377,6 +377,33 @@ describe("openapi3: definitions", () => {
     });
   });
 
+  it("defines nullable array", async () => {
+    const res = await oapiForModel(
+      "Pet",
+      `
+      model Pet {
+        name: int32[] | null;
+      };
+      `
+    );
+    ok(res.isRef);
+    deepStrictEqual(res.schemas.Pet, {
+      type: "object",
+      properties: {
+        name: {
+          type: "array",
+          items: {
+            type: "integer",
+            format: "int32",
+          },
+          nullable: true,
+          "x-cadl-name": "Cadl.int32[] | Cadl.null",
+        },
+      },
+      required: ["name"],
+    });
+  });
+
   it("defines enums with a nullable variant", async () => {
     const res = await oapiForModel(
       "Pet",

--- a/packages/samples/nullable/nullable.cadl
+++ b/packages/samples/nullable/nullable.cadl
@@ -10,6 +10,7 @@ model HasNullables {
   literalsOrNull: "one" | "two" | null;
   manyNullsOneString: null | null | string | null;
   manyNullsSomeValues: null | 42 | null | 100 | null;
+  arr: string[] | null;
   // thisWillFail: AnotherModel | string | null;
 }
 

--- a/packages/samples/test/output/nullable/openapi.json
+++ b/packages/samples/test/output/nullable/openapi.json
@@ -88,6 +88,14 @@
             ],
             "nullable": true,
             "x-cadl-name": "Cadl.null | 42 | Cadl.null | 100 | Cadl.null"
+          },
+          "arr": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true,
+            "x-cadl-name": "Cadl.string[] | Cadl.null"
           }
         },
         "required": [
@@ -97,7 +105,8 @@
           "modelOrNull",
           "literalsOrNull",
           "manyNullsOneString",
-          "manyNullsSomeValues"
+          "manyNullsSomeValues",
+          "arr"
         ]
       }
     }


### PR DESCRIPTION
fix https://github.com/Azure/cadl-azure/issues/1120 in openapi3 emitter

Also update the error message when the type in the union is not supported at all.