### PR TITLE
Formatter: Separate Enum members with decorator

### DIFF
--- a/common/changes/@cadl-lang/compiler/formatter-enum-members-deco_2022-01-14-19-25.json
+++ b/common/changes/@cadl-lang/compiler/formatter-enum-members-deco_2022-01-14-19-25.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@cadl-lang/compiler",
-      "comment": "Formatter: Seperate Enum members with decorator",
+      "comment": "Formatter: Separate Enum members with decorator with new lines",
       "type": "minor"
     }
   ],

--- a/common/changes/@cadl-lang/compiler/formatter-enum-members-deco_2022-01-14-19-25.json
+++ b/common/changes/@cadl-lang/compiler/formatter-enum-members-deco_2022-01-14-19-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Formatter: Seperate Enum members with decorator",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -369,8 +369,10 @@ export function printEnumMember(
   const node = path.getValue();
   const id = path.call(print, "id");
   const value = node.value ? [": ", path.call(print, "value")] : "";
-  const { decorators } = printDecorators(path, options, print, { tryInline: true });
-  return [decorators, id, value];
+  const { decorators, multiline } = printDecorators(path, options, print, { tryInline: true });
+  const propertyIndex = path.stack[path.stack.length - 2];
+  const isNotFirst = typeof propertyIndex === "number" && propertyIndex > 0;
+  return [multiline && isNotFirst ? hardline : "", decorators, id, value];
 }
 
 export function printUnionStatement(

--- a/packages/compiler/test/formatter/formatter.ts
+++ b/packages/compiler/test/formatter/formatter.ts
@@ -518,6 +518,35 @@ enum Bar {
 `,
       });
     });
+
+    it("seperate members if there is decorators", () => {
+      assertFormat({
+        code: `
+enum      Foo       {   
+  @doc("foo") 
+        A:   "a",    @doc("bar") 
+           B    : "b", 
+
+
+
+      @doc("third")   
+       C    : "c"}
+
+`,
+        expected: `
+enum Foo {
+  @doc("foo")
+  A: "a",
+
+  @doc("bar")
+  B: "b",
+
+  @doc("third")
+  C: "c",
+}
+`,
+      });
+    });
   });
 
   describe("namespaces", () => {


### PR DESCRIPTION
fix  #162

formats: 
```cadl
enum Foo {
  @doc("foo")
  A: "a",
  @doc("bar")
  B: "b",
  @doc("third")
  C: "c",
}
```

into 
```cadl
enum Foo {
  @doc("foo")
  A: "a",

  @doc("bar")
  B: "b",

  @doc("third")
  C: "c",
}

```