### PR TITLE
Remove leftover console.log

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-remove-console-log_2022-01-15-00-38.json
+++ b/common/changes/@cadl-lang/compiler/fix-remove-console-log_2022-01-15-00-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/program.ts
+++ b/packages/compiler/core/program.ts
@@ -344,7 +344,6 @@ export async function createProgram(
       resolvePath(fileURLToPath(import.meta.url), "../index.js")
     );
 
-    console.log("Expected", { expected, actual });
     if (actual !== expected) {
       // we have resolved node_modules/@cadl-lang/compiler/dist/core/index.js and we want to get
       // to the shim executable node_modules/.bin/cadl-server


### PR DESCRIPTION
Merged pr to early. I might look into adding eslint to have thing like console.log be shown as warnings