### PR TITLE
Union status codes and other response improvements

### DIFF
--- a/common/changes/@cadl-lang/openapi3/2022-01-18-20-41.json
+++ b/common/changes/@cadl-lang/openapi3/2022-01-18-20-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Support union values for status-code and content-type in responses",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/js-status-codes_2022-01-18-20-43.json
+++ b/common/changes/@cadl-lang/rest/js-status-codes_2022-01-18-20-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Expose response template in Http library and refactor",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -34,17 +34,30 @@ export const libDef = {
         default: "Duplicate @body declarations on response type",
       },
     },
-    "duplicate-status-code": {
+    "duplicate-response": {
       severity: "error",
       messages: {
-        default: "Duplicate @statusCode declarations on response type",
+        default: paramMessage`Multiple return types for status code ${"statusCode"}`,
+      },
+    },
+    "content-type-ignored": {
+      severity: "warning",
+      messages: {
+        default: "content-type header ignored because return type has no body",
       },
     },
     "content-type-string": {
       severity: "error",
       messages: {
-        default: "contentType parameter must be a string or union of strings",
-        unionOfString: "The contentType property union must contain only string values",
+        default: "contentType parameter must be a string literal or union of string literals",
+      },
+    },
+    "status-code-invalid": {
+      severity: "error",
+      messages: {
+        default:
+          "status-code header must be a numeric or string literal or union of numeric or string literals",
+        value: "status-code value must be a specific code between 100 and 599, or nXX, or default",
       },
     },
     "invalid-schema": {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -35,7 +35,8 @@ import {
 import { getAllRoutes, getDiscriminator, http, OperationDetails } from "@cadl-lang/rest";
 import { reportDiagnostic } from "./lib.js";
 
-const { getHeaderFieldName, getPathParamName, getQueryParamName, isBody, isStatusCode } = http;
+const { getHeaderFieldName, getPathParamName, getQueryParamName, isBody, isHeader, isStatusCode } =
+  http;
 
 export async function $onBuild(p: Program) {
   const options: OpenAPIEmitterOptions = {
@@ -320,7 +321,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
 
   function emitResponses(responseType: Type) {
     if (responseType.kind === "Union") {
-      for (const [i, option] of responseType.options.entries()) {
+      for (const option of responseType.options) {
         emitResponseObject(option);
       }
     } else {
@@ -338,95 +339,180 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
   }
 
   function emitResponseObject(responseModel: Type) {
-    let statusCode = undefined;
-    let contentType = "application/json";
-    if (
-      responseModel.kind === "Model" &&
-      !responseModel.baseModel &&
-      responseModel.properties.size === 0
-    ) {
-      const isBinary = isBinaryPayload(responseModel, contentType);
-      const schema = isBinary
-        ? { type: "string", format: "binary" }
-        : mapCadlTypeToOpenAPI(responseModel);
-      if (schema) {
-        currentEndpoint.responses["200"] = {
-          description: getResponseDescription(responseModel, "200"),
-          content: {
-            [contentType]: {
-              schema: schema,
-            },
-          },
-        };
+    // Get explicity defined status codes
+    let statusCodes = getResponseStatusCodes(responseModel);
+
+    // Get explicitly defined content types
+    const contentTypes = getResponseContentTypes(responseModel);
+
+    // Get response headers
+    const headers = getResponseHeaders(responseModel);
+
+    // Get explicitly defined body
+    let bodyModel = getResponseBody(responseModel);
+
+    // If there is no explicit body, it should be conjured from the return type
+    // if it is a primitive type or it contains more than just response metadata
+    if (!bodyModel) {
+      if (responseModel.kind === "Model") {
+        if (mapCadlTypeToOpenAPI(responseModel)) {
+          bodyModel = responseModel;
+        } else {
+          const isResponseMetadata = (p: ModelTypeProperty) =>
+            isHeader(program, p) || isStatusCode(program, p);
+          const allProperties = (p: ModelType): ModelTypeProperty[] => {
+            return [...p.properties.values(), ...(p.baseModel ? allProperties(p.baseModel) : [])];
+          };
+          if (allProperties(responseModel).some((p) => !isResponseMetadata(p))) {
+            bodyModel = responseModel;
+          }
+        }
       } else {
-        currentEndpoint.responses["204"] = {
-          description: "No content",
-        };
+        // body is array or possibly something else
+        bodyModel = responseModel;
       }
-
-      return;
     }
 
-    let contentEntry: any = {};
-    let headers: any = {};
+    // If there is no explicit status code, set the default
+    if (statusCodes.length === 0) {
+      const defaultStatusCode = bodyModel ? "200" : "204";
+      statusCodes.push(defaultStatusCode);
+    }
 
-    let bodyModel = responseModel;
+    // If there is a body but no explicit content types, use application/json
+    if (bodyModel && contentTypes.length === 0) {
+      contentTypes.push("application/json");
+    }
+
+    if (!bodyModel && contentTypes.length > 0) {
+      reportDiagnostic(program, {
+        code: "content-type-ignored",
+        target: responseModel,
+      });
+    }
+
+    // Assertion: bodyModel <=> contentTypes.length > 0
+
+    // Put them into currentEndpoint.responses
+
+    for (const statusCode of statusCodes) {
+      if (currentEndpoint.responses[statusCode]) {
+        reportDiagnostic(program, {
+          code: "duplicate-response",
+          format: { statusCode },
+          target: responseModel,
+        });
+        continue;
+      }
+      const response: any = {
+        description: getResponseDescription(responseModel, statusCode),
+      };
+      if (Object.keys(headers).length > 0) {
+        response.headers = headers;
+      }
+
+      for (const contentType of contentTypes) {
+        response.content ??= {};
+        const isBinary = isBinaryPayload(bodyModel!, contentType);
+        const schema = isBinary ? { type: "string", format: "binary" } : getSchemaOrRef(bodyModel!);
+        response.content[contentType] = { schema };
+      }
+      currentEndpoint.responses[statusCode] = response;
+    }
+  }
+
+  // Get explicity defined status codes from response Model
+  // Return is an array of strings, possibly empty, which indicates no explicitly defined status codes.
+  // We do not check for duplicates here -- that will be done by the caller.
+  function getResponseStatusCodes(responseModel: Type): string[] {
+    const codes: string[] = [];
     if (responseModel.kind === "Model") {
+      if (responseModel.baseModel) {
+        codes.push(...getResponseStatusCodes(responseModel.baseModel));
+      }
       for (const prop of responseModel.properties.values()) {
-        if (isBody(program, prop)) {
-          if (bodyModel !== responseModel) {
-            reportDiagnostic(program, { code: "duplicate-body", target: responseModel });
-            continue;
-          }
-
-          bodyModel = prop.type;
-        }
         if (isStatusCode(program, prop)) {
-          if (statusCode) {
-            reportDiagnostic(program, { code: "duplicate-status-code", target: responseModel });
-            continue;
-          }
-          if (prop.type.kind === "Number") {
-            statusCode = String(prop.type.value);
-          } else if (prop.type.kind === "String") {
-            statusCode = prop.type.value;
-          }
-        }
-        const type = prop.type;
-        const headerName = getHeaderFieldName(program, prop);
-        switch (headerName) {
-          case undefined:
-            break;
-          case "content-type":
-            if (type.kind === "String") {
-              contentType = type.value;
+          if (prop.type.kind === "String") {
+            if (validStatusCode(prop.type.value, prop)) {
+              codes.push(prop.type.value);
             }
-            break;
-          default:
-            headers[headerName] = getResponseHeader(prop);
-            break;
+          } else if (prop.type.kind === "Number") {
+            if (validStatusCode(String(prop.type.value), prop)) {
+              codes.push(String(prop.type.value));
+            }
+          } else if (prop.type.kind === "Union") {
+            for (const option of prop.type.options) {
+              if (option.kind === "String") {
+                if (validStatusCode(option.value, option)) {
+                  codes.push(option.value);
+                }
+              } else if (option.kind === "Number") {
+                if (validStatusCode(String(option.value), option)) {
+                  codes.push(String(option.value));
+                }
+              } else {
+                reportDiagnostic(program, { code: "status-code-invalid", target: prop });
+              }
+            }
+          } else {
+            reportDiagnostic(program, { code: "status-code-invalid", target: prop });
+          }
         }
       }
     }
+    return codes;
+  }
 
-    const isBinary = isBinaryPayload(bodyModel, contentType);
-    contentEntry.schema = isBinary
-      ? { type: "string", format: "binary" }
-      : getSchemaOrRef(bodyModel);
-
-    // If no status code was defined in the response model, use 200.
-    statusCode ??= "200";
-
-    const response: any = {
-      description: getResponseDescription(responseModel, statusCode),
-      content: {
-        [contentType ?? "application/json"]: contentEntry,
-      },
-    };
-    if (Object.keys(headers).length > 0) {
-      response.headers = headers;
+  // Check status code value: 3 digits, 1 digit + "XX", or default
+  // Issue a diagnostic if not valid
+  function validStatusCode(code: string, entity: Type): boolean {
+    // regex for three character status codes:
+    // - starts with 1-5
+    // - last two digits are numeric or "X"
+    const statusCodePatten = /[1-5][-09X][0-9X]/;
+    if (code.match(statusCodePatten) || code === "default") {
+      return true;
     }
-    currentEndpoint.responses[statusCode] = response;
+    reportDiagnostic(program, {
+      code: "status-code-invalid",
+      target: entity,
+      messageId: "value",
+    });
+    return false;
+  }
+
+  // Note: these descriptions come from https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+  function getDescriptionForStatusCode(statusCode: string) {
+    switch (statusCode) {
+      case "2XX":
+        return "Successful";
+      case "200":
+        return "Ok";
+      case "201":
+        "Created";
+      case "202":
+        return "Accepted";
+      case "204":
+        return "No Content";
+      case "3XX":
+        return "Redirection";
+      case "4XX":
+        return "Client Error";
+      case "400":
+        return "Bad Request";
+      case "401":
+        return "Unauthorized";
+      case "403":
+        return "Forbidden";
+      case "404":
+        return "Not Found";
+      case "5XX":
+        return "Server Error";
+      case "default":
+        return "An unexpected error response";
+    }
+    // We might want to throw here -- rather than giving some default
+    return "A successful response";
   }
 
   function getResponseDescription(responseModel: Type, statusCode: string) {
@@ -435,10 +521,60 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       return desc;
     }
 
-    if (statusCode === "default") {
-      return "An unexpected error response";
+    // We might want to throw here -- rather than giving some default
+    return getDescriptionForStatusCode(statusCode);
+  }
+
+  // Get explicity defined content-types from response Model
+  // Return is an array of strings, possibly empty, which indicates no explicitly defined content-type.
+  // We do not check for duplicates here -- that will be done by the caller.
+  function getResponseContentTypes(responseModel: Type): string[] {
+    const contentTypes: string[] = [];
+    if (responseModel.kind === "Model") {
+      if (responseModel.baseModel) {
+        contentTypes.push(...getResponseContentTypes(responseModel.baseModel));
+      }
+      for (const prop of responseModel.properties.values()) {
+        if (isHeader(program, prop) && getHeaderFieldName(program, prop) === "content-type") {
+          contentTypes.push(...getContentTypes(prop));
+        }
+      }
     }
-    return "A successful response";
+    return contentTypes;
+  }
+
+  // Get response headers from response Model
+  function getResponseHeaders(responseModel: Type) {
+    if (responseModel.kind === "Model") {
+      const responseHeaders: any = responseModel.baseModel
+        ? getResponseHeaders(responseModel.baseModel)
+        : {};
+      for (const prop of responseModel.properties.values()) {
+        const headerName = getHeaderFieldName(program, prop);
+        if (isHeader(program, prop) && headerName !== "content-type") {
+          responseHeaders[headerName] = getResponseHeader(prop);
+        }
+      }
+      return responseHeaders;
+    }
+    return {};
+  }
+
+  // Get explicity defined response body from response Model
+  // The "outermost" body is used -- so we only look at basemodel if no body is defined
+  function getResponseBody(responseModel: Type): Type | undefined {
+    if (responseModel.kind === "Model") {
+      const bodyProps = [...responseModel.properties.values()].filter((t) => isBody(program, t));
+      if (bodyProps.length === 0) {
+        return responseModel.baseModel ? getResponseBody(responseModel.baseModel) : undefined;
+      }
+      // Report all but first body as duplicate
+      for (const prop of bodyProps.slice(1)) {
+        reportDiagnostic(program, { code: "duplicate-body", target: prop });
+      }
+      return bodyProps[0].type;
+    }
+    return undefined;
   }
 
   function getResponseHeader(prop: ModelTypeProperty) {
@@ -613,7 +749,6 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
         } else {
           reportDiagnostic(program, {
             code: "content-type-string",
-            messageId: "unionOfString",
             target: param,
           });
           continue;

--- a/packages/openapi3/test/test-openapi-output.ts
+++ b/packages/openapi3/test/test-openapi-output.ts
@@ -857,7 +857,7 @@ async function oapiForModel(name: string, modelDef: string) {
     ${modelDef};
     @route("/")
     namespace root {
-      op read(): ${name};
+      op read(): { @body body: ${name} };
     }
   `);
 

--- a/packages/openapi3/test/test-return-types.ts
+++ b/packages/openapi3/test/test-return-types.ts
@@ -42,6 +42,51 @@ describe("openapi3: return types", () => {
     ok(res.paths["/"].put.responses["201"].content["application/json"].schema);
   });
 
+  it("defines responses with numeric status codes", async () => {
+    const res = await openApiFor(
+      `
+      model CreatedResponse {
+        @statusCode code: 201;
+      }
+      model Key {
+        key: string;
+      }
+      @route("/")
+      namespace root {
+        @put
+        op create(): CreatedResponse & Key;
+      }
+      `
+    );
+    ok(res.paths["/"].put.responses["201"]);
+    ok(res.paths["/"].put.responses["201"].content["application/json"].schema);
+  });
+
+  it("defines responses with status code range", async () => {
+    const res = await openApiFor(
+      `
+      model SuccessResponse {
+        @statusCode _: "2XX";
+      }
+      model BadRequestResponse {
+        @statusCode _: "4XX";
+        code: string
+      }
+      model Key {
+        key: string;
+      }
+      @route("/")
+      namespace root {
+        @put
+        op create(): SuccessResponse & Key | BadRequestResponse;
+      }
+      `
+    );
+    const responses = res.paths["/"].put.responses;
+    ok(responses["2XX"]);
+    ok(responses["4XX"]);
+  });
+
   it("defines responses with headers and status codes", async () => {
     const res = await openApiFor(
       `
@@ -66,6 +111,99 @@ describe("openapi3: return types", () => {
     deepStrictEqual(res.paths["/"].put.responses["201"].content["application/json"].schema, {
       $ref: "#/components/schemas/Key",
     });
+  });
+
+  it("defines responses with headers and status codes in base model", async () => {
+    const res = await openApiFor(
+      `
+      model CreatedResponse {
+        @statusCode code: "201";
+        @header contentType: "text/html";
+        @header location: string;
+      }
+      model Page {
+        content: string;
+      }
+      model CreatePageResponse extends CreatedResponse {
+        @body body: Page;
+      }
+      @route("/")
+      namespace root {
+        @put
+        op create(): CreatePageResponse;
+      }
+      `
+    );
+    ok(res.paths["/"].put.responses["201"]);
+    ok(res.paths["/"].put.responses["201"].headers["location"]);
+    deepStrictEqual(res.paths["/"].put.responses["201"].content["text/html"].schema, {
+      $ref: "#/components/schemas/Page",
+    });
+  });
+
+  it("defines separate responses for each status code defined as a union of values", async () => {
+    const res = await openApiFor(
+      `
+      model CreatedOrUpdatedResponse {
+        @statusCode code: "200" | "201";
+      }
+      model DateHeader {
+        @header date: zonedDateTime;
+      }
+      model Key {
+        key: string;
+      }
+      @route("/")
+      namespace root {
+        @put
+        op create(): CreatedOrUpdatedResponse & DateHeader & Key;
+      }
+      `
+    );
+    ok(res.paths["/"].put.responses["200"]);
+    ok(res.paths["/"].put.responses["201"]);
+    // Note: 200 and 201 response should be equal except for description
+    deepStrictEqual(
+      res.paths["/"].put.responses["200"].headers,
+      res.paths["/"].put.responses["201"].headers
+    );
+    deepStrictEqual(
+      res.paths["/"].put.responses["200"].content,
+      res.paths["/"].put.responses["201"].content
+    );
+  });
+
+  it("defines separate responses for each status code property in return type", async () => {
+    const res = await openApiFor(
+      `
+      model CreatedOrUpdatedResponse {
+        @statusCode ok: "200";
+        @statusCode created: "201";
+      }
+      model DateHeader {
+        @header date: zonedDateTime;
+      }
+      model Key {
+        key: string;
+      }
+      @route("/")
+      namespace root {
+        @put
+        op create(): CreatedOrUpdatedResponse & DateHeader & Key;
+      }
+      `
+    );
+    ok(res.paths["/"].put.responses["200"]);
+    ok(res.paths["/"].put.responses["201"]);
+    // Note: 200 and 201 response should be equal except for description
+    deepStrictEqual(
+      res.paths["/"].put.responses["200"].headers,
+      res.paths["/"].put.responses["201"].headers
+    );
+    deepStrictEqual(
+      res.paths["/"].put.responses["200"].content,
+      res.paths["/"].put.responses["201"].content
+    );
   });
 
   it("defines separate responses for each variant of a union return type", async () => {
@@ -129,6 +267,25 @@ describe("openapi3: return types", () => {
     });
   });
 
+  it("defines the multiple response media types for content-type header with union value", async () => {
+    const res = await openApiFor(
+      `
+      model TextMulti {
+        @header contentType: "text/plain" | "text/html" | "text/csv";
+      }
+      @route("/")
+      namespace root {
+        @get
+        op read(): { ...TextMulti, @body body: string };
+      }
+    `
+    );
+    ok(res.paths["/"].get.responses["200"]);
+    ok(res.paths["/"].get.responses["200"].content["text/plain"]);
+    ok(res.paths["/"].get.responses["200"].content["text/html"]);
+    ok(res.paths["/"].get.responses["200"].content["text/csv"]);
+  });
+
   it("returns diagnostics for duplicate body decorator", async () => {
     const diagnostics = await checkFor(
       `
@@ -150,6 +307,95 @@ describe("openapi3: return types", () => {
     strictEqual(diagnostics[0].message, "Duplicate @body declarations on response type");
   });
 
+  it("issues diagnostics for return type with duplicate status code", async () => {
+    const diagnostics = await checkFor(
+      `
+    model Foo {
+      foo: string;
+    }
+    model Error {
+      code: string;
+    }
+    @route("/")
+    namespace root {
+      @get
+      op read(): Foo | Error;
+    }
+    `
+    );
+    strictEqual(diagnostics.length, 1);
+    strictEqual(diagnostics[0].code, "@cadl-lang/openapi3/duplicate-response");
+    strictEqual(diagnostics[0].message, "Multiple return types for status code 200");
+  });
+
+  it("issues diagnostics for invalid status codes", async () => {
+    const diagnostics = await checkFor(
+      `
+      model Foo {
+        foo: string;
+      }
+
+      model BadRequest {
+        code: "4XX";
+      }
+
+      namespace root {
+        @route("/test1")
+        @get
+        op test1(): { @statusCode code: string, @body body: Foo };
+        @route("/test2")
+        @get
+        op test2(): { @statusCode code: "Ok", @body body: Foo };
+        @route("/test3")
+        @get
+        op test3(): { @statusCode code: "200" | BadRequest, @body body: Foo };
+      }
+    `
+    );
+    strictEqual(diagnostics.length, 3);
+    ok(diagnostics.every((e) => e.code === "@cadl-lang/openapi3/status-code-invalid"));
+    ok(diagnostics[0].message.includes("must be a numeric or string literal"));
+    ok(
+      diagnostics[1].message.includes(
+        "must be a specific code between 100 and 599, or nXX, or default"
+      )
+    );
+    ok(diagnostics[2].message.includes("must be a numeric or string literal"));
+  });
+
+  it("issues diagnostics for invalid content types", async () => {
+    const diagnostics = await checkFor(
+      `
+      model Foo {
+        foo: string;
+      }
+
+      model TextPlain {
+        contentType: "text/plain";
+      }
+
+      namespace root {
+        @route("/test1")
+        @get
+        op test1(): { @header contentType: string, @body body: Foo };
+        @route("/test2")
+        @get
+        op test2(): { @header contentType: 42, @body body: Foo };
+        @route("/test3")
+        @get
+        op test3(): { @header contentType: "application/json" | TextPlain, @body body: Foo };
+      }
+    `
+    );
+    strictEqual(diagnostics.length, 3);
+    ok(diagnostics.every((e) => e.code === "@cadl-lang/openapi3/content-type-string"));
+    ok(
+      diagnostics.every((e) =>
+        e.message.includes("must be a string literal or union of string literals")
+      )
+    );
+  });
+
   it("defines responses with primitive types", async () => {
     const res = await openApiFor(
       `
@@ -166,6 +412,110 @@ describe("openapi3: return types", () => {
       res.paths["/"].get.responses["200"].content["application/json"].schema.type,
       "string"
     );
+  });
+
+  it("defines responses with top-level array type", async () => {
+    const res = await openApiFor(
+      `
+      model Foo {
+        foo: string;
+      }
+      @route("/")
+      namespace root {
+        @get()
+        op read(): Foo[];
+      }
+      `
+    );
+    ok(res.paths["/"].get.responses["200"]);
+    ok(res.paths["/"].get.responses["200"].content);
+    strictEqual(
+      res.paths["/"].get.responses["200"].content["application/json"].schema.type,
+      "array"
+    );
+  });
+
+  it("return type with no properties should be 204 response w/ no content", async () => {
+    const res = await openApiFor(
+      `
+      @route("/")
+      namespace root {
+        @get op delete(): {};
+      }
+      `
+    );
+
+    const responses = res.paths["/"].get.responses;
+    ok(responses["204"]);
+    ok(responses["204"].content === undefined, "response should have no content");
+    ok(responses["200"] === undefined);
+  });
+
+  it("return type with only response metadata should be 204 response w/ no content", async () => {
+    const res = await openApiFor(
+      `
+      @route("/")
+      namespace root {
+        @get op delete(): {@header date: string};
+      }
+      `
+    );
+
+    const responses = res.paths["/"].get.responses;
+    ok(responses["204"]);
+    ok(responses["204"].content === undefined, "response should have no content");
+    ok(responses["200"] === undefined);
+  });
+
+  it("defaults status code to 204 when implicit body has no content", async () => {
+    const res = await openApiFor(
+      `
+      @route("/")
+      namespace root {
+        @delete
+        op delete(): { @header date: string };
+      }
+      `
+    );
+    const responses = res.paths["/"].delete.responses;
+    ok(responses["200"] === undefined);
+    ok(responses["204"]);
+    ok(responses["204"].headers["date"]);
+    ok(responses["204"].content === undefined);
+  });
+
+  it("defines body schema when explicit body has no content", async () => {
+    const res = await openApiFor(
+      `
+      @route("/")
+      namespace root {
+        @delete
+        op delete(): { @header date: string, @body body: {} };
+      }
+      `
+    );
+    const responses = res.paths["/"].delete.responses;
+    ok(responses["204"] === undefined);
+    ok(responses["200"]);
+    ok(responses["200"].headers["date"]);
+    ok(responses["200"].content["application/json"].schema);
+  });
+
+  it("return type with only statusCode should have specified status code and no content", async () => {
+    const res = await openApiFor(
+      `
+      @route("/")
+      namespace root {
+        @get op create(): {@statusCode code: 201};
+      }
+      `
+    );
+
+    const responses = res.paths["/"].get.responses;
+    ok(responses["201"]);
+    ok(responses["201"].content === undefined, "response should have no content");
+    ok(responses["200"] === undefined);
+    ok(responses["204"] === undefined);
   });
 
   describe("binary responses", () => {

--- a/packages/rest/lib/http.cadl
+++ b/packages/rest/lib/http.cadl
@@ -4,15 +4,18 @@ namespace Cadl.Http;
 
 using Private;
 
-@doc("The request has succeeded.")
-model OkResponse<T> {
+@doc("Http response with status code")
+model Response<Status> {
   @doc("The status code.")
   @statusCode
-  _: 200;
+  _: Status;
+}
 
+@doc("The request has succeeded.")
+model OkResponse<Body> is Response<200> {
   @doc("The reponse body.")
   @body
-  body: T;
+  body: Body;
 }
 
 @doc("The Location header.")
@@ -23,61 +26,30 @@ model LocationHeader {
 }
 
 @doc("The request has succeeded and a new resource has been created as a result.")
-model CreatedResponse {
-  @doc("The status code.")
-  @statusCode
-  _: 201;
-}
+model CreatedResponse is Response<201> {}
 
 @doc("The request has been received but not yet acted upon.")
-model AcceptedResponse {
-  @doc("The status code.")
-  @statusCode
-  _: 202;
-}
+model AcceptedResponse is Response<202> {}
 
 @doc("There is no content to send for this request, but the headers may be useful. ")
-model NoContentResponse {
-  @doc("The status code.")
-  @statusCode
-  _: 204;
-}
+model NoContentResponse is Response<204> {}
 
 @doc("The URL of the requested resource has been changed permanently. The new URL is given in the response.")
-model MovedResponse {
-  @doc("The status code.")
-  @statusCode
-  _: 301;
+model MovedResponse is Response<301> {
   ...LocationHeader;
 }
 
 @doc("This is used for caching purposes.")
-model NotModifiedResponse {
-  @doc("The status code.")
-  @statusCode
-  _: 304;
-}
+model NotModifiedResponse is Response<304> {}
 
 @doc("The server could not understand the request due to invalid syntax.")
-model UnauthorizedResponse {
-  @doc("The status code.")
-  @statusCode
-  _: 401;
-}
+model UnauthorizedResponse is Response<401> {}
 
 @doc("The server can not find the requested resource.")
-model NotFoundResponse {
-  @doc("The status code.")
-  @statusCode
-  _: 404;
-}
+model NotFoundResponse is Response<404> {}
 
 @doc("This response is sent when a request conflicts with the current state of the server.")
-model ConflictResponse {
-  @doc("The status code.")
-  @statusCode
-  _: 409;
-}
+model ConflictResponse is Response<409> {}
 
 // Produces a new model with the same properties as T, but with @query,
 // @header, @body, and @path decorators removed from all properties.

--- a/packages/samples/test/output/binary/openapi.json
+++ b/packages/samples/test/output/binary/openapi.json
@@ -12,7 +12,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -39,7 +39,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "text/plain": {
                 "schema": {
@@ -68,7 +68,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/octect-stream": {
                 "schema": {
@@ -97,7 +97,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "image/png": {
                 "schema": {

--- a/packages/samples/test/output/documentation/openapi.json
+++ b/packages/samples/test/output/documentation/openapi.json
@@ -12,7 +12,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -68,7 +68,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -116,7 +116,7 @@
             }
           },
           "404": {
-            "description": "A successful response",
+            "description": "Not Found",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/grpc-kiosk-example/openapi.json
+++ b/packages/samples/test/output/grpc-kiosk-example/openapi.json
@@ -138,7 +138,7 @@
         ],
         "responses": {
           "204": {
-            "description": "No content"
+            "description": "No Content"
           },
           "default": {
             "description": "An unexpected error response.",
@@ -274,7 +274,7 @@
         ],
         "responses": {
           "204": {
-            "description": "No content"
+            "description": "No Content"
           },
           "default": {
             "description": "An unexpected error response.",
@@ -303,7 +303,7 @@
         ],
         "responses": {
           "204": {
-            "description": "No content"
+            "description": "No Content"
           },
           "default": {
             "description": "An unexpected error response.",

--- a/packages/samples/test/output/grpc-library-example/openapi.json
+++ b/packages/samples/test/output/grpc-library-example/openapi.json
@@ -134,7 +134,7 @@
         ],
         "responses": {
           "204": {
-            "description": "No content"
+            "description": "No body returned"
           },
           "default": {
             "description": "An unexpected error response.",
@@ -309,7 +309,7 @@
         ],
         "responses": {
           "204": {
-            "description": "No content"
+            "description": "No body returned"
           },
           "default": {
             "description": "An unexpected error response.",

--- a/packages/samples/test/output/nested/openapi.json
+++ b/packages/samples/test/output/nested/openapi.json
@@ -30,7 +30,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/nullable/openapi.json
+++ b/packages/samples/test/output/nullable/openapi.json
@@ -22,7 +22,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/optional/openapi.json
+++ b/packages/samples/test/output/optional/openapi.json
@@ -22,7 +22,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/polymorphism/openapi.json
+++ b/packages/samples/test/output/polymorphism/openapi.json
@@ -12,7 +12,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -17,7 +17,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -48,7 +48,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -108,14 +108,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Resource deleted successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Cadl.Rest.Resource.ResourceDeletedResponse"
-                }
-              }
-            }
+            "description": "Resource deleted successfully."
           },
           "default": {
             "description": "An unexpected error response",
@@ -137,7 +130,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -219,7 +212,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -304,7 +297,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -335,7 +328,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -395,7 +388,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -471,7 +464,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -505,7 +498,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -562,7 +555,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -643,7 +636,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -674,7 +667,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -725,14 +718,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Resource deleted successfully.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Cadl.Rest.Resource.ResourceDeletedResponse"
-                }
-              }
-            }
+            "description": "Resource deleted successfully."
           },
           "default": {
             "description": "An unexpected error response",
@@ -754,7 +740,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -836,7 +822,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -921,7 +907,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -952,7 +938,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -1094,11 +1080,6 @@
           "code",
           "message"
         ]
-      },
-      "Cadl.Rest.Resource.ResourceDeletedResponse": {
-        "type": "object",
-        "properties": {},
-        "description": "Resource deleted successfully."
       },
       "Cadl.Rest.Resource.Page_Pet": {
         "type": "object",

--- a/packages/samples/test/output/simple/openapi.json
+++ b/packages/samples/test/output/simple/openapi.json
@@ -21,7 +21,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -48,7 +48,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/tags/openapi.json
+++ b/packages/samples/test/output/tags/openapi.json
@@ -48,7 +48,7 @@
         ],
         "responses": {
           "204": {
-            "description": "No content"
+            "description": "No Content"
           }
         },
         "tags": [
@@ -72,7 +72,7 @@
         ],
         "responses": {
           "204": {
-            "description": "No content"
+            "description": "No Content"
           }
         },
         "tags": [
@@ -89,7 +89,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -122,7 +122,7 @@
         ],
         "responses": {
           "204": {
-            "description": "No content"
+            "description": "No Content"
           }
         },
         "tags": [
@@ -146,7 +146,7 @@
         ],
         "responses": {
           "204": {
-            "description": "No content"
+            "description": "No Content"
           }
         },
         "tags": [

--- a/packages/samples/test/output/testserver/body-boolean/openapi.json
+++ b/packages/samples/test/output/testserver/body-boolean/openapi.json
@@ -13,7 +13,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -86,7 +86,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -116,7 +116,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -157,7 +157,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -167,7 +167,7 @@
             }
           },
           "204": {
-            "description": "No content"
+            "description": "No Content"
           },
           "default": {
             "description": "Error",
@@ -189,7 +189,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/visibility/openapi.json
+++ b/packages/samples/test/output/visibility/openapi.json
@@ -32,7 +32,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -50,7 +50,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {
@@ -66,7 +66,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response",
+            "description": "Ok",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
This PR will:

-  Allow a property decorated with `@statusCode` to specify a union of values.
-  Allow multiple properties decorated with `@statusCode` in a response - values will be unioned.
-  Allow `@statusCode` to be specified in the parent model of a response.
-  Validate the value(s) of `@statusCode` - diagnostics issued for any invalid values
    - Must be numeric or string literal
    - Must be in the range 100 <= x < 600 or [1-5]XX or default

- Issue diagnostics for duplicate response (status code) (not silently drop)

- Use explicit status code for empty response (not force to 204)

- Allow contentType header to specify a union of values.
- Allow contentType to be specified in the parent model of a response
- Validate contentType - diagnostics issued for any invalid values
    - Must be string literal or union of string literals

- Generate body as empty schema if specified on @body decorated property
- Do not generate schema if no @body decorated property and all props response metadata

- Set response description derived from status code when no @doc on return type
