### PR TITLE
Add @head decorator

### DIFF
--- a/common/changes/@cadl-lang/rest/feature-verb-head_2022-01-18-23-49.json
+++ b/common/changes/@cadl-lang/rest/feature-verb-head_2022-01-18-23-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "**Added** `@head` decorator to describe `head` http verb operation",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/src/http.ts
+++ b/packages/rest/src/http.ts
@@ -79,7 +79,7 @@ export function isStatusCode(program: Program, entity: Type) {
   return program.stateSet(statusCodeKey).has(entity);
 }
 
-export type HttpVerb = "get" | "put" | "post" | "patch" | "delete";
+export type HttpVerb = "get" | "put" | "post" | "patch" | "delete" | "head";
 
 const operationVerbsKey = Symbol();
 
@@ -125,6 +125,10 @@ export function $patch(program: Program, entity: Type) {
 
 export function $delete(program: Program, entity: Type) {
   setOperationVerb(program, entity, "delete");
+}
+
+export function $head(program: Program, entity: Type) {
+  setOperationVerb(program, entity, "head");
 }
 
 setDecoratorNamespace(


### PR DESCRIPTION
fix https://github.com/Azure/cadl-azure/issues/520

Realized this was missing for some sample specs which were then incorrectly defined.