### PR TITLE
Fix: invalid use of templates show correct location

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-generic-error_2022-01-19-00-33.json
+++ b/common/changes/@cadl-lang/compiler/fix-generic-error_2022-01-19-00-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Fix** Diagnostic location for invalid use of templated models",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -19,7 +19,6 @@ import {
   EnumStatementNode,
   EnumType,
   ErrorType,
-  Expression,
   IdentifierNode,
   InterfaceStatementNode,
   InterfaceType,
@@ -374,12 +373,12 @@ export function createChecker(program: Program): Checker {
     if (!sym) {
       return errorType;
     }
-    return checkTypeReferenceSymbol(sym, node.arguments);
+    return checkTypeReferenceSymbol(sym, node);
   }
 
   function checkTypeReferenceSymbol(
     sym: TypeSymbol | DecoratorSymbol,
-    nodeArgs: readonly Expression[]
+    node: TypeReferenceNode
   ): Type {
     if (sym.kind === "decorator") {
       program.reportDiagnostic(
@@ -390,7 +389,7 @@ export function createChecker(program: Program): Checker {
     }
 
     const symbolLinks = getSymbolLinks(sym);
-    let args = nodeArgs.map(getTypeForNode);
+    let args = node.arguments.map(getTypeForNode);
 
     if (
       sym.node.kind === SyntaxKind.ModelStatement ||
@@ -404,7 +403,7 @@ export function createChecker(program: Program): Checker {
             createDiagnostic({
               code: "invalid-template-args",
               messageId: "notTemplate",
-              target: sym,
+              target: node,
             })
           );
         }
@@ -439,7 +438,7 @@ export function createChecker(program: Program): Checker {
             createDiagnostic({
               code: "invalid-template-args",
               messageId: "tooFew",
-              target: sym,
+              target: node,
             })
           );
           args = [...args, ...new Array(templateParameters.length - args.length).fill(errorType)];
@@ -448,7 +447,7 @@ export function createChecker(program: Program): Checker {
             createDiagnostic({
               code: "invalid-template-args",
               messageId: "tooMany",
-              target: sym,
+              target: node,
             })
           );
           args = args.slice(0, templateParameters.length);
@@ -463,7 +462,7 @@ export function createChecker(program: Program): Checker {
         createDiagnostic({
           code: "invalid-template-args",
           messageId: "notTemplate",
-          target: sym,
+          target: node,
         })
       );
     }
@@ -1235,7 +1234,7 @@ export function createChecker(program: Program): Checker {
       });
       return undefined;
     }
-    const heritageType = checkTypeReferenceSymbol(target, heritageRef.arguments);
+    const heritageType = checkTypeReferenceSymbol(target, heritageRef);
     pendingResolutions.delete(modelSymId);
     if (isErrorType(heritageType)) {
       compilerAssert(program.hasError(), "Should already have reported an error.", heritageRef);
@@ -1269,7 +1268,7 @@ export function createChecker(program: Program): Checker {
       });
       return undefined;
     }
-    const isType = checkTypeReferenceSymbol(target, isExpr.arguments);
+    const isType = checkTypeReferenceSymbol(target, isExpr);
     pendingResolutions.delete(modelSymId);
 
     if (isType.kind !== "Model") {

--- a/packages/compiler/test/checker/templates.ts
+++ b/packages/compiler/test/checker/templates.ts
@@ -3,7 +3,7 @@ import { getSourceLocation } from "../../core/diagnostics.js";
 import { Diagnostic } from "../../core/types.js";
 import { createTestHost, TestHost } from "../test-host.js";
 
-describe.only("compiler: templates", () => {
+describe("compiler: templates", () => {
   let testHost: TestHost;
 
   beforeEach(async () => {

--- a/packages/compiler/test/checker/templates.ts
+++ b/packages/compiler/test/checker/templates.ts
@@ -1,0 +1,84 @@
+import { deepStrictEqual, fail, strictEqual } from "assert";
+import { getSourceLocation } from "../../core/diagnostics.js";
+import { Diagnostic } from "../../core/types.js";
+import { createTestHost, TestHost } from "../test-host.js";
+
+describe.only("compiler: templates", () => {
+  let testHost: TestHost;
+
+  beforeEach(async () => {
+    testHost = await createTestHost();
+  });
+
+  function getLineAndCharOfDiagnostic(diagnostic: Diagnostic) {
+    const source = getSourceLocation(diagnostic.target);
+    if (source === undefined) {
+      fail(`Couldn't resolve the source of diagnostic ${diagnostic}`);
+    }
+    return source.file.getLineAndCharacterOfPosition(source.pos);
+  }
+
+  it("emit diagnostics when using template params on non templated model", async () => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+        model A {}
+        model B { 
+          foo: A<string>
+        };
+      `
+    );
+    const diagnostics = await testHost.diagnose("main.cadl");
+    strictEqual(diagnostics.length, 1);
+    strictEqual(diagnostics[0].code, "invalid-template-args");
+    strictEqual(diagnostics[0].message, "Can't pass template arguments to non-templated type");
+    // Should point to the start of A<string>
+    deepStrictEqual(getLineAndCharOfDiagnostic(diagnostics[0]), {
+      line: 3,
+      character: 15,
+    });
+  });
+
+  it("emit diagnostics when using template without passing any arguments", async () => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+        model A<T> {}
+        model B { 
+          foo: A
+        };
+      `
+    );
+    const diagnostics = await testHost.diagnose("main.cadl");
+    strictEqual(diagnostics.length, 1);
+    strictEqual(diagnostics[0].code, "invalid-template-args");
+    strictEqual(diagnostics[0].message, "Too few template arguments provided.");
+    // Should point to the start of A
+    deepStrictEqual(getLineAndCharOfDiagnostic(diagnostics[0]), {
+      line: 3,
+      character: 15,
+    });
+  });
+
+  it("emit diagnostics when using template with too many arguments", async () => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+        model A<T> {}
+        model B { 
+          foo: A<string, string>
+        };
+      `
+    );
+    const diagnostics = await testHost.diagnose("main.cadl");
+    strictEqual(diagnostics.length, 1);
+    strictEqual(diagnostics[0].code, "invalid-template-args");
+    strictEqual(diagnostics[0].message, "Too many template arguments provided.");
+
+    // Should point to the start of A<string, string>
+    deepStrictEqual(getLineAndCharOfDiagnostic(diagnostics[0]), {
+      line: 3,
+      character: 15,
+    });
+  });
+});


### PR DESCRIPTION
fix #165

Fix error location when using template model incorrectly to be the type reference node instead of the actual referenced model.