### PR TITLE
Fix: Unterminated multi-line comment error when ending with multi-line comment

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-multi-line-unterminated_2022-01-20-17-56.json
+++ b/common/changes/@cadl-lang/compiler/fix-multi-line-unterminated_2022-01-20-17-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix error with file ending with mutline comment",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/scanner.ts
+++ b/packages/compiler/core/scanner.ts
@@ -603,7 +603,7 @@ export function createScanner(
   function scanMultiLineComment() {
     position = skipMultiLineComment(input, position);
     token = Token.MultiLineComment;
-    return position === input.length ? unterminated(token) : token;
+    return position > input.length ? unterminated(token) : token;
   }
 
   function scanString() {
@@ -948,10 +948,9 @@ function skipMultiLineComment(input: string, position: number): number {
       input.charCodeAt(position) === CharCode.Asterisk &&
       input.charCodeAt(position + 1) === CharCode.Slash
     ) {
-      position += 2;
-      break;
+      return position + 2;
     }
   }
 
-  return position;
+  return input.length + 1;
 }

--- a/packages/compiler/core/scanner.ts
+++ b/packages/compiler/core/scanner.ts
@@ -601,9 +601,10 @@ export function createScanner(
   }
 
   function scanMultiLineComment() {
-    position = skipMultiLineComment(input, position);
+    const [newPosition, terminated] = skipMultiLineComment(input, position);
+    position = newPosition;
     token = Token.MultiLineComment;
-    return position > input.length ? unterminated(token) : token;
+    return terminated ? token : unterminated(token);
   }
 
   function scanString() {
@@ -917,7 +918,7 @@ export function skipTrivia(input: string, position: number): number {
           position = skipSingleLineComment(input, position);
           continue;
         case CharCode.Asterisk:
-          position = skipMultiLineComment(input, position);
+          position = skipMultiLineComment(input, position)[0];
           continue;
       }
     }
@@ -940,7 +941,10 @@ function skipSingleLineComment(input: string, position: number): number {
   return position;
 }
 
-function skipMultiLineComment(input: string, position: number): number {
+function skipMultiLineComment(
+  input: string,
+  position: number
+): [position: number, terminated: boolean] {
   position += 2; // consume '/*'
 
   for (; position < input.length; position++) {
@@ -948,9 +952,9 @@ function skipMultiLineComment(input: string, position: number): number {
       input.charCodeAt(position) === CharCode.Asterisk &&
       input.charCodeAt(position + 1) === CharCode.Slash
     ) {
-      return position + 2;
+      return [position + 2, true];
     }
   }
 
-  return input.length + 1;
+  return [position, false];
 }

--- a/packages/compiler/test/test-scanner.ts
+++ b/packages/compiler/test/test-scanner.ts
@@ -283,6 +283,22 @@ describe("compiler: scanner", () => {
     ]);
   });
 
+  // https://github.com/microsoft/cadl/issues/168
+  it("scan file ending with multi-line comment", () => {
+    const multiLineComment = "/* foo\n*bar\n*/";
+    verify(tokens(multiLineComment), [
+      [Token.MultiLineComment, multiLineComment, { pos: 0, line: 0, character: 0 }],
+    ]);
+    verify(tokens(`namespace Bar;\n${multiLineComment}`), [
+      [Token.NamespaceKeyword, "namespace", { pos: 0, line: 0, character: 0 }],
+      [Token.Whitespace, " ", { pos: 9, line: 0, character: 9 }],
+      [Token.Identifier, "Bar", { pos: 10, line: 0, character: 10 }],
+      [Token.Semicolon, ";", { pos: 13, line: 0, character: 13 }],
+      [Token.NewLine, "\n", { pos: 14, line: 0, character: 14 }],
+      [Token.MultiLineComment, multiLineComment, { pos: 15, line: 1, character: 0 }],
+    ]);
+  });
+
   // It's easy to forget to update TokenDisplay or Min/Max ranges...
   it("provides friendly token display and classification", () => {
     const tokenCount = Object.values(Token).filter((v) => typeof v === "number").length;

--- a/packages/samples/nullable/nullable.cadl
+++ b/packages/samples/nullable/nullable.cadl
@@ -22,7 +22,3 @@ namespace NullableMethods {
 model AnotherModel {
   num: int32;
 }
-
-/**
- *
- */

--- a/packages/samples/nullable/nullable.cadl
+++ b/packages/samples/nullable/nullable.cadl
@@ -22,3 +22,7 @@ namespace NullableMethods {
 model AnotherModel {
   num: int32;
 }
+
+/**
+ *
+ */


### PR DESCRIPTION
fix #168

Issue was the `skipMultiLineComment` resulted in the same behavior if it got to the end of the file or if the last 2 characters were `*/`