### PR TITLE
Configure eslint for all packages with shared config pkg

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+}

--- a/common/changes/@cadl-lang/compiler/internal-eslint_2022-01-21-16-42.json
+++ b/common/changes/@cadl-lang/compiler/internal-eslint_2022-01-21-16-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/eslint-config-cadl/internal-eslint_2022-01-21-16-42.json
+++ b/common/changes/@cadl-lang/eslint-config-cadl/internal-eslint_2022-01-21-16-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/eslint-config-cadl",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/eslint-config-cadl"
+}

--- a/common/changes/@cadl-lang/openapi/internal-eslint_2022-02-04-20-12.json
+++ b/common/changes/@cadl-lang/openapi/internal-eslint_2022-02-04-20-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/openapi3/internal-eslint_2022-01-21-16-42.json
+++ b/common/changes/@cadl-lang/openapi3/internal-eslint_2022-01-21-16-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/internal-eslint_2022-01-21-16-42.json
+++ b/common/changes/@cadl-lang/rest/internal-eslint_2022-01-21-16-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/versioning/internal-eslint_2022-02-04-20-12.json
+++ b/common/changes/@cadl-lang/versioning/internal-eslint_2022-02-04-20-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/common/changes/cadl-vscode/internal-eslint_2022-01-21-16-42.json
+++ b/common/changes/cadl-vscode/internal-eslint_2022-01-21-16-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vscode",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "cadl-vscode"
+}

--- a/common/changes/tmlanguage-generator/internal-eslint_2022-01-21-16-42.json
+++ b/common/changes/tmlanguage-generator/internal-eslint_2022-01-21-16-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "tmlanguage-generator",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "tmlanguage-generator"
+}

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -62,6 +62,20 @@
       "shellCommand": "node eng/scripts/dogfood.js"
     },
     {
+      "commandKind": "bulk",
+      "name": "lint",
+      "summary": "Lint projects. Runs `npm run lint` on all projects.",
+      "enableParallelism": true,
+      "ignoreMissingScript": true
+    },
+    {
+      "commandKind": "bulk",
+      "name": "lint:fix",
+      "summary": "Fix lint issues in projects. Runs `npm run lint:fix` on all projects.",
+      "enableParallelism": true,
+      "ignoreMissingScript": true
+    },
+    {
       "commandKind": "global",
       "safeForSimultaneousRushProcesses": true,
       "name": "e2e",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -6,6 +6,7 @@ dependencies:
   '@rush-temp/cadl-vs': file:projects/cadl-vs.tgz
   '@rush-temp/cadl-vscode': file:projects/cadl-vscode.tgz
   '@rush-temp/compiler': file:projects/compiler.tgz
+  '@rush-temp/eslint-config-cadl': file:projects/eslint-config-cadl.tgz_prettier@2.5.1
   '@rush-temp/openapi': file:projects/openapi.tgz
   '@rush-temp/openapi3': file:projects/openapi3.tgz
   '@rush-temp/prettier-plugin-cadl': file:projects/prettier-plugin-cadl.tgz
@@ -14,22 +15,28 @@ dependencies:
   '@rush-temp/spec': file:projects/spec.tgz
   '@rush-temp/tmlanguage-generator': file:projects/tmlanguage-generator.tgz
   '@rush-temp/versioning': file:projects/versioning.tgz
+  '@rushstack/eslint-patch': 1.1.0
   '@types/glob': 7.1.4
-  '@types/js-yaml': 4.0.5
+  '@types/js-yaml': 4.0.4
   '@types/mkdirp': 1.0.2
   '@types/mocha': 9.1.0
   '@types/mustache': 4.1.2
   '@types/node': 14.0.27
   '@types/plist': 3.0.2
-  '@types/prettier': 2.4.3
+  '@types/prettier': 2.4.1
   '@types/prompts': 2.0.14
   '@types/vscode': 1.53.0
-  '@types/yargs': 17.0.8
+  '@types/yargs': 17.0.5
+  '@typescript-eslint/eslint-plugin': 5.10.0_706fb07ce74b1db611f19a02ad2ce784
+  '@typescript-eslint/parser': 5.10.0_eslint@8.7.0+typescript@4.5.5
   ajv: 8.9.0
   autorest: 3.3.2
   c8: 7.11.0
   change-case: 4.1.2
   ecmarkup: 9.8.1
+  eslint: 8.7.0
+  eslint-config-prettier: 8.3.0_eslint@8.7.0
+  eslint-plugin-prettier: 4.0.0_4660519532e4c3b0a9e5bb6623cfedf6
   glob: 7.1.7
   grammarkdown: 3.1.2
   js-yaml: 4.1.0
@@ -37,7 +44,7 @@ dependencies:
   mocha: 9.2.0
   mustache: 4.2.0
   node-fetch: 3.2.0
-  node-watch: 0.7.3
+  node-watch: 0.7.2
   onigasm: 2.2.5
   plist: 3.0.4
   prettier: 2.5.1
@@ -45,12 +52,12 @@ dependencies:
   prompts: 2.4.2
   rimraf: 3.0.2
   rollup: 2.41.5
-  source-map-support: 0.5.21
+  source-map-support: 0.5.20
   typescript: 4.5.5
   vsce: 2.6.7
   vscode-languageclient: 7.0.0
   vscode-languageserver: 7.0.0
-  vscode-languageserver-textdocument: 1.0.4
+  vscode-languageserver-textdocument: 1.0.2
   vscode-oniguruma: 1.6.1
   vscode-textmate: 6.0.0
   watch: 1.0.2
@@ -59,26 +66,26 @@ lockfileVersion: 5.2
 packages:
   /@babel/code-frame/7.12.11:
     dependencies:
-      '@babel/highlight': 7.16.10
+      '@babel/highlight': 7.16.0
     dev: false
     resolution:
       integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
-  /@babel/helper-validator-identifier/7.16.7:
+  /@babel/helper-validator-identifier/7.15.7:
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
-  /@babel/highlight/7.16.10:
+      integrity: sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
+  /@babel/highlight/7.16.0:
     dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
+      '@babel/helper-validator-identifier': 7.15.7
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: false
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
+      integrity: sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==
   /@bcoe/v8-coverage/0.2.3:
     dev: false
     resolution:
@@ -149,27 +156,53 @@ packages:
       ajv: 6.12.6
       debug: 4.3.3
       espree: 7.3.1
-      globals: 13.12.1
+      globals: 13.12.0
       ignore: 4.0.6
       import-fresh: 3.3.0
       js-yaml: 3.14.1
-      minimatch: 3.0.5
+      minimatch: 3.0.4
       strip-json-comments: 3.1.1
     dev: false
     engines:
       node: ^10.12.0 || >=12.0.0
     resolution:
       integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==
+  /@eslint/eslintrc/1.0.5:
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.2
+      espree: 9.3.0
+      globals: 13.12.0
+      ignore: 4.0.6
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.0.4
+      strip-json-comments: 3.1.1
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    resolution:
+      integrity: sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==
   /@humanwhocodes/config-array/0.5.0:
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
       debug: 4.3.3
-      minimatch: 3.0.5
+      minimatch: 3.0.4
     dev: false
     engines:
       node: '>=10.10.0'
     resolution:
       integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==
+  /@humanwhocodes/config-array/0.9.2:
+    dependencies:
+      '@humanwhocodes/object-schema': 1.2.1
+      debug: 4.3.2
+      minimatch: 3.0.4
+    dev: false
+    engines:
+      node: '>=10.10.0'
+    resolution:
+      integrity: sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==
   /@humanwhocodes/object-schema/1.2.1:
     dev: false
     resolution:
@@ -212,7 +245,7 @@ packages:
       glob: 7.1.7
       is-reference: 1.2.1
       magic-string: 0.25.7
-      resolve: 1.22.0
+      resolve: 1.20.0
       rollup: 2.41.5
     dev: false
     engines:
@@ -237,7 +270,7 @@ packages:
       builtin-modules: 3.2.0
       deepmerge: 4.2.2
       is-module: 1.0.0
-      resolve: 1.22.0
+      resolve: 1.20.0
       rollup: 2.41.5
     dev: false
     engines:
@@ -260,7 +293,7 @@ packages:
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
-      picomatch: 2.3.1
+      picomatch: 2.3.0
       rollup: 2.41.5
     dev: false
     engines:
@@ -269,14 +302,18 @@ packages:
       rollup: ^1.20.0||^2.0.0
     resolution:
       integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  /@rushstack/eslint-patch/1.1.0:
+    dev: false
+    resolution:
+      integrity: sha512-JLo+Y592QzIE+q7Dl2pMUtt4q8SKYI5jDrZxrozEQxnGVOyYE+GWK9eLkwTaeN9DDctlaRAQ3TBmzZ1qdLE30A==
   /@types/estree/0.0.39:
     dev: false
     resolution:
       integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
-  /@types/estree/0.0.51:
+  /@types/estree/0.0.50:
     dev: false
     resolution:
-      integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
+      integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
   /@types/glob/7.1.4:
     dependencies:
       '@types/minimatch': 3.0.5
@@ -288,10 +325,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==
-  /@types/js-yaml/4.0.5:
+  /@types/js-yaml/4.0.4:
     dev: false
     resolution:
-      integrity: sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
+      integrity: sha512-AuHubXUmg0AzkXH0Mx6sIxeY/1C110mm/EkE/gB1sTRz3h2dao2W/63q42SlVST+lICxz5Oki2hzYA6+KnnieQ==
+  /@types/json-schema/7.0.9:
+    dev: false
+    resolution:
+      integrity: sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
   /@types/minimatch/3.0.5:
     dev: false
     resolution:
@@ -321,10 +362,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ULqvZNGMv0zRFvqn8/4LSPtnmN4MfhlPNtJCTpKuIIxGVGZ2rYWzFXrvEBoh9CVyqSE7D6YFRJ1hydLHI6kbWw==
-  /@types/prettier/2.4.3:
+  /@types/prettier/2.4.1:
     dev: false
     resolution:
-      integrity: sha512-QzSuZMBuG5u8HqYz01qtMdg/Jfctlnvj1z/lYnIDXs/golxw0fxtRAHd9KrzjR7Yxz1qVeI00o0kiO3PmVdJ9w==
+      integrity: sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==
   /@types/prompts/2.0.14:
     dependencies:
       '@types/node': 14.0.27
@@ -345,12 +386,136 @@ packages:
     dev: false
     resolution:
       integrity: sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==
-  /@types/yargs/17.0.8:
+  /@types/yargs/17.0.5:
     dependencies:
       '@types/yargs-parser': 20.2.1
     dev: false
     resolution:
-      integrity: sha512-wDeUwiUmem9FzsyysEwRukaEdDNcwbROvQ9QGRKaLI6t+IltNzbn4/i4asmB10auvZGQCzSQ6t0GSczEThlUXw==
+      integrity: sha512-4HNq144yhaVjJs+ON6A07NEoi9Hh0Rhl/jI9Nt/l/YRjt+T6St/QK3meFARWZ8IgkzoD1LC0PdTdJenlQQi2WQ==
+  /@typescript-eslint/eslint-plugin/5.10.0_706fb07ce74b1db611f19a02ad2ce784:
+    dependencies:
+      '@typescript-eslint/parser': 5.10.0_eslint@8.7.0+typescript@4.5.5
+      '@typescript-eslint/scope-manager': 5.10.0
+      '@typescript-eslint/type-utils': 5.10.0_eslint@8.7.0+typescript@4.5.5
+      '@typescript-eslint/utils': 5.10.0_eslint@8.7.0+typescript@4.5.5
+      debug: 4.3.2
+      eslint: 8.7.0
+      functional-red-black-tree: 1.0.1
+      ignore: 5.2.0
+      regexpp: 3.2.0
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    resolution:
+      integrity: sha512-XXVKnMsq2fuu9K2KsIxPUGqb6xAImz8MEChClbXmE3VbveFtBUU5bzM6IPVWqzyADIgdkS2Ws/6Xo7W2TeZWjQ==
+  /@typescript-eslint/parser/5.10.0_eslint@8.7.0+typescript@4.5.5:
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.10.0
+      '@typescript-eslint/types': 5.10.0
+      '@typescript-eslint/typescript-estree': 5.10.0_typescript@4.5.5
+      debug: 4.3.2
+      eslint: 8.7.0
+      typescript: 4.5.5
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    resolution:
+      integrity: sha512-pJB2CCeHWtwOAeIxv8CHVGJhI5FNyJAIpx5Pt72YkK3QfEzt6qAlXZuyaBmyfOdM62qU0rbxJzNToPTVeJGrQw==
+  /@typescript-eslint/scope-manager/5.10.0:
+    dependencies:
+      '@typescript-eslint/types': 5.10.0
+      '@typescript-eslint/visitor-keys': 5.10.0
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    resolution:
+      integrity: sha512-tgNgUgb4MhqK6DoKn3RBhyZ9aJga7EQrw+2/OiDk5hKf3pTVZWyqBi7ukP+Z0iEEDMF5FDa64LqODzlfE4O/Dg==
+  /@typescript-eslint/type-utils/5.10.0_eslint@8.7.0+typescript@4.5.5:
+    dependencies:
+      '@typescript-eslint/utils': 5.10.0_eslint@8.7.0+typescript@4.5.5
+      debug: 4.3.2
+      eslint: 8.7.0
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    resolution:
+      integrity: sha512-TzlyTmufJO5V886N+hTJBGIfnjQDQ32rJYxPaeiyWKdjsv2Ld5l8cbS7pxim4DeNs62fKzRSt8Q14Evs4JnZyQ==
+  /@typescript-eslint/types/5.10.0:
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    resolution:
+      integrity: sha512-wUljCgkqHsMZbw60IbOqT/puLfyqqD5PquGiBo1u1IS3PLxdi3RDGlyf032IJyh+eQoGhz9kzhtZa+VC4eWTlQ==
+  /@typescript-eslint/typescript-estree/5.10.0_typescript@4.5.5:
+    dependencies:
+      '@typescript-eslint/types': 5.10.0
+      '@typescript-eslint/visitor-keys': 5.10.0
+      debug: 4.3.2
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.5
+      tsutils: 3.21.0_typescript@4.5.5
+      typescript: 4.5.5
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    resolution:
+      integrity: sha512-x+7e5IqfwLwsxTdliHRtlIYkgdtYXzE0CkFeV6ytAqq431ZyxCFzNMNR5sr3WOlIG/ihVZr9K/y71VHTF/DUQA==
+  /@typescript-eslint/utils/5.10.0_eslint@8.7.0+typescript@4.5.5:
+    dependencies:
+      '@types/json-schema': 7.0.9
+      '@typescript-eslint/scope-manager': 5.10.0
+      '@typescript-eslint/types': 5.10.0
+      '@typescript-eslint/typescript-estree': 5.10.0_typescript@4.5.5
+      eslint: 8.7.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.7.0
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    resolution:
+      integrity: sha512-IGYwlt1CVcFoE2ueW4/ioEwybR60RAdGeiJX/iDAw0t5w0wK3S7QncDwpmsM70nKgGTuVchEWB8lwZwHqPAWRg==
+  /@typescript-eslint/visitor-keys/5.10.0:
+    dependencies:
+      '@typescript-eslint/types': 5.10.0
+      eslint-visitor-keys: 3.2.0
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    resolution:
+      integrity: sha512-GMxj0K1uyrFLPKASLmZzCuSddmjZVbVj3Ouy5QVuIGKZopxvOr24JsS7gruz6C3GExE01mublZ3mIBOaon9zuQ==
   /@ungap/promise-all-settled/1.1.2:
     dev: false
     resolution:
@@ -373,6 +538,14 @@ packages:
   /acorn-jsx/5.3.2_acorn@7.4.1:
     dependencies:
       acorn: 7.4.1
+    dev: false
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+    resolution:
+      integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+  /acorn-jsx/5.3.2_acorn@8.7.0:
+    dependencies:
+      acorn: 8.7.0
     dev: false
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -405,6 +578,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+  /acorn/8.7.0:
+    dev: false
+    engines:
+      node: '>=0.4.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
   /ajv/6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -472,7 +652,7 @@ packages:
   /anymatch/3.1.2:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.0
     dev: false
     engines:
       node: '>= 8'
@@ -503,6 +683,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=
+  /array-union/2.1.0:
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
   /asn1/0.2.6:
     dependencies:
       safer-buffer: 2.1.2
@@ -636,7 +822,7 @@ packages:
       foreground-child: 2.0.0
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-report: 3.0.0
-      istanbul-reports: 3.1.4
+      istanbul-reports: 3.1.3
       rimraf: 3.0.2
       test-exclude: 6.0.0
       v8-to-istanbul: 8.1.1
@@ -668,12 +854,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
-  /camelcase/6.3.0:
+  /camelcase/6.2.0:
     dev: false
     engines:
       node: '>=10'
     resolution:
-      integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
+      integrity: sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
   /capital-case/1.0.4:
     dependencies:
       no-case: 3.0.4
@@ -746,10 +932,10 @@ packages:
       integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==
   /cheerio-select/1.5.0:
     dependencies:
-      css-select: 4.2.1
+      css-select: 4.1.3
       css-what: 5.1.0
       domelementtype: 2.2.0
-      domhandler: 4.3.0
+      domhandler: 4.2.2
       domutils: 2.8.0
     dev: false
     resolution:
@@ -758,7 +944,7 @@ packages:
     dependencies:
       cheerio-select: 1.5.0
       dom-serializer: 1.3.2
-      domhandler: 4.3.0
+      domhandler: 4.2.2
       htmlparser2: 6.1.0
       parse5: 6.0.1
       parse5-htmlparser2-tree-adapter: 6.0.1
@@ -868,10 +1054,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
-  /core-util-is/1.0.3:
-    dev: false
-    resolution:
-      integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
   /cross-spawn/7.0.3:
     dependencies:
       path-key: 3.1.1
@@ -882,16 +1064,16 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
-  /css-select/4.2.1:
+  /css-select/4.1.3:
     dependencies:
       boolbase: 1.0.0
       css-what: 5.1.0
-      domhandler: 4.3.0
+      domhandler: 4.2.2
       domutils: 2.8.0
       nth-check: 2.0.1
     dev: false
     resolution:
-      integrity: sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==
+      integrity: sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==
   /css-what/5.1.0:
     dev: false
     engines:
@@ -930,6 +1112,19 @@ packages:
     dev: false
     resolution:
       integrity: sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==
+  /debug/4.3.2:
+    dependencies:
+      ms: 2.1.2
+    dev: false
+    engines:
+      node: '>=6.0'
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    resolution:
+      integrity: sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   /debug/4.3.3:
     dependencies:
       ms: 2.1.2
@@ -1001,18 +1196,26 @@ packages:
     dev: false
     resolution:
       integrity: sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
-  /detect-libc/2.0.0:
+  /detect-libc/2.0.1:
     dev: false
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-S55LzUl8HUav8l9E2PBTlC5PAJrHK7tkM+XXFGD+fbsbkTzhCpG6K05LxJcUOEWzMa4v6ptcMZ9s3fOdJDu0Zw==
+      integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
   /diff/5.0.0:
     dev: false
     engines:
       node: '>=0.3.1'
     resolution:
       integrity: sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+  /dir-glob/3.0.1:
+    dependencies:
+      path-type: 4.0.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   /doctrine/3.0.0:
     dependencies:
       esutils: 2.0.3
@@ -1024,7 +1227,7 @@ packages:
   /dom-serializer/1.3.2:
     dependencies:
       domelementtype: 2.2.0
-      domhandler: 4.3.0
+      domhandler: 4.2.2
       entities: 2.2.0
     dev: false
     resolution:
@@ -1039,19 +1242,19 @@ packages:
     dev: false
     resolution:
       integrity: sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
-  /domhandler/4.3.0:
+  /domhandler/4.2.2:
     dependencies:
       domelementtype: 2.2.0
     dev: false
     engines:
       node: '>= 4'
     resolution:
-      integrity: sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==
+      integrity: sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==
   /domutils/2.8.0:
     dependencies:
       dom-serializer: 1.3.2
       domelementtype: 2.2.0
-      domhandler: 4.3.0
+      domhandler: 4.2.2
     dev: false
     resolution:
       integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
@@ -1158,6 +1361,33 @@ packages:
       source-map: 0.6.1
     resolution:
       integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
+  /eslint-config-prettier/8.3.0_eslint@8.7.0:
+    dependencies:
+      eslint: 8.7.0
+    dev: false
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+    resolution:
+      integrity: sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
+  /eslint-plugin-prettier/4.0.0_4660519532e4c3b0a9e5bb6623cfedf6:
+    dependencies:
+      eslint: 8.7.0
+      eslint-config-prettier: 8.3.0_eslint@8.7.0
+      prettier: 2.5.1
+      prettier-linter-helpers: 1.0.0
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    peerDependencies:
+      eslint: '>=7.28.0'
+      eslint-config-prettier: '*'
+      prettier: '>=2.0.0'
+    peerDependenciesMeta:
+      eslint-config-prettier:
+        optional: true
+    resolution:
+      integrity: sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
   /eslint-scope/5.1.1:
     dependencies:
       esrecurse: 4.3.0
@@ -1167,6 +1397,15 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  /eslint-scope/7.1.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    resolution:
+      integrity: sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==
   /eslint-utils/2.1.0:
     dependencies:
       eslint-visitor-keys: 1.3.0
@@ -1175,6 +1414,17 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+  /eslint-utils/3.0.0_eslint@8.7.0:
+    dependencies:
+      eslint: 8.7.0
+      eslint-visitor-keys: 2.1.0
+    dev: false
+    engines:
+      node: ^10.0.0 || ^12.0.0 || >= 14.0.0
+    peerDependencies:
+      eslint: '>=5'
+    resolution:
+      integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
   /eslint-visitor-keys/1.3.0:
     dev: false
     engines:
@@ -1187,6 +1437,12 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+  /eslint-visitor-keys/3.2.0:
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    resolution:
+      integrity: sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==
   /eslint/7.32.0:
     dependencies:
       '@babel/code-frame': 7.12.11
@@ -1209,7 +1465,7 @@ packages:
       file-entry-cache: 6.0.1
       functional-red-black-tree: 1.0.1
       glob-parent: 5.1.2
-      globals: 13.12.1
+      globals: 13.12.0
       ignore: 4.0.6
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
@@ -1218,7 +1474,7 @@ packages:
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
-      minimatch: 3.0.5
+      minimatch: 3.0.4
       natural-compare: 1.4.0
       optionator: 0.9.1
       progress: 2.0.3
@@ -1226,7 +1482,7 @@ packages:
       semver: 7.3.5
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
-      table: 6.8.0
+      table: 6.7.3
       text-table: 0.2.0
       v8-compile-cache: 2.3.0
     dev: false
@@ -1235,6 +1491,49 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==
+  /eslint/8.7.0:
+    dependencies:
+      '@eslint/eslintrc': 1.0.5
+      '@humanwhocodes/config-array': 0.9.2
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.2
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.1.0
+      eslint-utils: 3.0.0_eslint@8.7.0
+      eslint-visitor-keys: 3.2.0
+      espree: 9.3.0
+      esquery: 1.4.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      functional-red-black-tree: 1.0.1
+      glob-parent: 6.0.2
+      globals: 13.12.0
+      ignore: 5.2.0
+      import-fresh: 3.3.0
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.0.4
+      natural-compare: 1.4.0
+      optionator: 0.9.1
+      regexpp: 3.2.0
+      strip-ansi: 6.0.1
+      strip-json-comments: 3.1.1
+      text-table: 0.2.0
+      v8-compile-cache: 2.3.0
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    hasBin: true
+    resolution:
+      integrity: sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==
   /espree/7.3.1:
     dependencies:
       acorn: 7.4.1
@@ -1245,6 +1544,16 @@ packages:
       node: ^10.12.0 || >=12.0.0
     resolution:
       integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
+  /espree/9.3.0:
+    dependencies:
+      acorn: 8.7.0
+      acorn-jsx: 5.3.2_acorn@8.7.0
+      eslint-visitor-keys: 3.2.0
+    dev: false
+    engines:
+      node: ^12.22.0 || ^14.17.0 || >=16.0.0
+    resolution:
+      integrity: sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==
   /esprima/4.0.1:
     dev: false
     engines:
@@ -1320,6 +1629,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+  /fast-diff/1.2.0:
+    dev: false
+    resolution:
+      integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
   /fast-glob/3.2.11:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1388,7 +1701,7 @@ packages:
       integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
   /flat-cache/3.0.4:
     dependencies:
-      flatted: 3.2.5
+      flatted: 3.2.4
       rimraf: 3.0.2
     dev: false
     engines:
@@ -1400,10 +1713,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
-  /flatted/3.2.5:
+  /flatted/3.2.4:
     dev: false
     resolution:
-      integrity: sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
+      integrity: sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==
   /foreground-child/2.0.0:
     dependencies:
       cross-spawn: 7.0.3
@@ -1505,12 +1818,20 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  /glob-parent/6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+    dev: false
+    engines:
+      node: '>=10.13.0'
+    resolution:
+      integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   /glob/7.1.7:
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.5
+      minimatch: 3.0.4
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: false
@@ -1527,14 +1848,27 @@ packages:
     dev: false
     resolution:
       integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
-  /globals/13.12.1:
+  /globals/13.12.0:
     dependencies:
       type-fest: 0.20.2
     dev: false
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==
+      integrity: sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==
+  /globby/11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.2.11
+      ignore: 5.2.0
+      merge2: 1.4.1
+      slash: 3.0.0
+    dev: false
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
   /grammarkdown/3.1.2:
     dependencies:
       '@esfx/async-canceltoken': 1.0.0-pre.30
@@ -1652,7 +1986,7 @@ packages:
   /htmlparser2/6.1.0:
     dependencies:
       domelementtype: 2.2.0
-      domhandler: 4.3.0
+      domhandler: 4.2.2
       domutils: 2.8.0
       entities: 2.2.0
     dev: false
@@ -1661,8 +1995,8 @@ packages:
   /http-signature/1.2.0:
     dependencies:
       assert-plus: 1.0.0
-      jsprim: 1.4.2
-      sshpk: 1.17.0
+      jsprim: 1.4.1
+      sshpk: 1.16.1
     dev: false
     engines:
       node: '>=0.8'
@@ -1687,6 +2021,12 @@ packages:
       node: '>= 4'
     resolution:
       integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+  /ignore/5.2.0:
+    dev: false
+    engines:
+      node: '>= 4'
+    resolution:
+      integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
   /import-fresh/3.3.0:
     dependencies:
       parent-module: 1.0.1
@@ -1725,12 +2065,12 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
-  /is-core-module/2.8.1:
+  /is-core-module/2.8.0:
     dependencies:
       has: 1.0.3
     dev: false
     resolution:
-      integrity: sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
+      integrity: sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
   /is-extglob/2.1.1:
     dev: false
     engines:
@@ -1777,7 +2117,7 @@ packages:
       integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
   /is-reference/1.2.1:
     dependencies:
-      '@types/estree': 0.0.51
+      '@types/estree': 0.0.50
     dev: false
     resolution:
       integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
@@ -1819,7 +2159,7 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==
-  /istanbul-reports/3.1.4:
+  /istanbul-reports/3.1.3:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.0
@@ -1827,7 +2167,7 @@ packages:
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==
+      integrity: sha512-x9LtDVtfm/t1GFiLl3NffC7hz+I1ragvgX1P/Lg1NlIagifZDKUkuuaAxH/qpwj2IuEfD8G2Bs/UKp+sZ/pKkg==
   /js-tokens/4.0.0:
     dev: false
     resolution:
@@ -1890,10 +2230,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
-  /json-schema/0.4.0:
+  /json-schema/0.2.3:
     dev: false
     resolution:
-      integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+      integrity: sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
   /json-stable-stringify-without-jsonify/1.0.1:
     dev: false
     resolution:
@@ -1902,17 +2242,17 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
-  /jsprim/1.4.2:
+  /jsprim/1.4.1:
     dependencies:
       assert-plus: 1.0.0
       extsprintf: 1.3.0
-      json-schema: 0.4.0
+      json-schema: 0.2.3
       verror: 1.10.0
     dev: false
     engines:
-      node: '>=0.6.0'
+      '0': node >=0.6.0
     resolution:
-      integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
+      integrity: sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
   /keytar/7.8.0:
     dependencies:
       node-addon-api: 4.3.0
@@ -2057,7 +2397,7 @@ packages:
   /micromatch/4.0.4:
     dependencies:
       braces: 3.0.2
-      picomatch: 2.3.1
+      picomatch: 2.3.0
     dev: false
     engines:
       node: '>=8.6'
@@ -2096,12 +2436,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
-  /minimatch/3.0.5:
-    dependencies:
-      brace-expansion: 1.1.11
-    dev: false
-    resolution:
-      integrity: sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==
   /minimist/1.2.5:
     dev: false
     resolution:
@@ -2216,12 +2550,12 @@ packages:
       node: ^12.20.0 || ^14.13.1 || >=16.0.0
     resolution:
       integrity: sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==
-  /node-watch/0.7.3:
+  /node-watch/0.7.2:
     dev: false
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==
+      integrity: sha512-g53VjSARRv1JdST0LZRIg8RiuLr1TaBbVPsVvxh0/0Ymvi0xYUjDuoqQQAWtHJQUXhiShowPT/aXKNeHBcyQsw==
   /nomnom/1.8.1:
     dependencies:
       chalk: 0.4.0
@@ -2400,6 +2734,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+  /path-type/4.0.0:
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
   /pend/1.2.0:
     dev: false
     resolution:
@@ -2408,12 +2748,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
-  /picomatch/2.3.1:
+  /picomatch/2.3.0:
     dev: false
     engines:
       node: '>=8.6'
     resolution:
-      integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+      integrity: sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
   /plist/3.0.4:
     dependencies:
       base64-js: 1.5.1
@@ -2429,7 +2769,7 @@ packages:
       integrity: sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
   /prebuild-install/7.0.1:
     dependencies:
-      detect-libc: 2.0.0
+      detect-libc: 2.0.1
       expand-template: 2.0.3
       github-from-package: 0.0.0
       minimist: 1.2.5
@@ -2460,6 +2800,14 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+  /prettier-linter-helpers/1.0.0:
+    dependencies:
+      fast-diff: 1.2.0
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
   /prettier-plugin-organize-imports/2.3.4_prettier@2.5.1+typescript@4.5.5:
     dependencies:
       prettier: 2.5.1
@@ -2532,12 +2880,12 @@ packages:
       node: '>=0.6'
     resolution:
       integrity: sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
-  /qs/6.5.3:
+  /qs/6.5.2:
     dev: false
     engines:
       node: '>=0.6'
     resolution:
-      integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
+      integrity: sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
   /queue-microtask/1.2.3:
     dev: false
     resolution:
@@ -2568,7 +2916,7 @@ packages:
       integrity: sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
   /readable-stream/2.3.7:
     dependencies:
-      core-util-is: 1.0.3
+      core-util-is: 1.0.2
       inherits: 2.0.4
       isarray: 1.0.0
       process-nextick-args: 2.0.1
@@ -2590,7 +2938,7 @@ packages:
       integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
   /readdirp/3.6.0:
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 2.3.0
     dev: false
     engines:
       node: '>=8.10.0'
@@ -2644,7 +2992,7 @@ packages:
       mime-types: 2.1.34
       oauth-sign: 0.9.0
       performance-now: 2.1.0
-      qs: 6.5.3
+      qs: 6.5.2
       safe-buffer: 5.2.1
       tough-cookie: 2.5.0
       tunnel-agent: 0.6.0
@@ -2673,15 +3021,13 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
-  /resolve/1.22.0:
+  /resolve/1.20.0:
     dependencies:
-      is-core-module: 2.8.1
+      is-core-module: 2.8.0
       path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
     dev: false
-    hasBin: true
     resolution:
-      integrity: sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
+      integrity: sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
   /reusify/1.0.4:
     dev: false
     engines:
@@ -2691,7 +3037,7 @@ packages:
       integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
   /rimraf/3.0.2:
     dependencies:
-      glob: 7.2.0
+      glob: 7.1.7
     dev: false
     hasBin: true
     resolution:
@@ -2806,6 +3152,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+  /slash/3.0.0:
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
   /slice-ansi/4.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -2823,13 +3175,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
-  /source-map-support/0.5.21:
+  /source-map-support/0.5.20:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
     dev: false
     resolution:
-      integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+      integrity: sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==
   /source-map/0.6.1:
     dev: false
     engines:
@@ -2850,7 +3202,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
-  /sshpk/1.17.0:
+  /sshpk/1.16.1:
     dependencies:
       asn1: 0.2.6
       assert-plus: 1.0.0
@@ -2866,7 +3218,7 @@ packages:
       node: '>=0.10.0'
     hasBin: true
     resolution:
-      integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==
+      integrity: sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
   /stealthy-require/1.1.1:
     dev: false
     engines:
@@ -2970,17 +3322,11 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  /supports-preserve-symlinks-flag/1.0.0:
-    dev: false
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
   /symbol-tree/3.2.4:
     dev: false
     resolution:
       integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
-  /table/6.8.0:
+  /table/6.7.3:
     dependencies:
       ajv: 8.9.0
       lodash.truncate: 4.4.2
@@ -2991,7 +3337,7 @@ packages:
     engines:
       node: '>=10.0.0'
     resolution:
-      integrity: sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==
+      integrity: sha512-5DkIxeA7XERBqMwJq0aHZOdMadBx4e6eDoFRuyT5VR82J0Ycg2DwM6GfA/EQAhJ+toRTaS1lIdSQCqgrmhPnlw==
   /tar-fs/2.1.1:
     dependencies:
       chownr: 1.1.4
@@ -3016,8 +3362,8 @@ packages:
   /test-exclude/6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.3
-      glob: 7.2.0
-      minimatch: 3.0.5
+      glob: 7.1.7
+      minimatch: 3.0.4
     dev: false
     engines:
       node: '>=8'
@@ -3058,10 +3404,25 @@ packages:
     dev: false
     resolution:
       integrity: sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
+  /tslib/1.14.1:
+    dev: false
+    resolution:
+      integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
   /tslib/2.3.1:
     dev: false
     resolution:
       integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+  /tsutils/3.21.0_typescript@4.5.5:
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.5.5
+    dev: false
+    engines:
+      node: '>= 6'
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    resolution:
+      integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   /tunnel-agent/0.6.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -3195,7 +3556,7 @@ packages:
       leven: 3.1.0
       markdown-it: 12.3.2
       mime: 1.6.0
-      minimatch: 3.0.5
+      minimatch: 3.0.4
       parse-semver: 1.1.1
       read: 1.0.7
       semver: 5.7.1
@@ -3219,7 +3580,7 @@ packages:
       integrity: sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==
   /vscode-languageclient/7.0.0:
     dependencies:
-      minimatch: 3.0.5
+      minimatch: 3.0.4
       semver: 7.3.5
       vscode-languageserver-protocol: 3.16.0
     dev: false
@@ -3234,10 +3595,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==
-  /vscode-languageserver-textdocument/1.0.4:
+  /vscode-languageserver-textdocument/1.0.2:
     dev: false
     resolution:
-      integrity: sha512-/xhqXP/2A2RSs+J8JNXpiiNVvvNM0oTosNVmQnunlKvq9o4mupHOBAnnzH0lwIPKazXKvAKsVp1kr+H/K4lgoQ==
+      integrity: sha512-T7uPC18+f8mYE4lbVZwb3OSmvwTZm3cuFhrdx9Bn2l11lmp3SvSuSVjy2JtvrghzjAo4G6Trqny2m9XGnFnWVA==
   /vscode-languageserver-types/3.16.0:
     dev: false
     resolution:
@@ -3320,7 +3681,7 @@ packages:
       integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   /wide-align/1.1.5:
     dependencies:
-      string-width: 1.0.2
+      string-width: 4.2.3
     dev: false
     resolution:
       integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
@@ -3420,7 +3781,7 @@ packages:
       integrity: sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
   /yargs-unparser/2.0.0:
     dependencies:
-      camelcase: 6.3.0
+      camelcase: 6.2.0
       decamelize: 4.0.0
       flat: 5.0.2
       is-plain-obj: 2.1.0
@@ -3492,6 +3853,7 @@ packages:
       '@types/node': 14.0.27
       '@types/vscode': 1.53.0
       c8: 7.11.0
+      eslint: 8.7.0
       mkdirp: 1.0.4
       mocha: 9.2.0
       rimraf: 3.0.2
@@ -3505,23 +3867,24 @@ packages:
     dev: false
     name: '@rush-temp/cadl-vscode'
     resolution:
-      integrity: sha512-FdJ0JhHpj1Tu+dfGhS7FnUwuAwdtrL0X+y1SNycvT8GzV5z5NJ5r/DnGaVomHsUFCFaG69jiRJL+6h08f1IcXQ==
+      integrity: sha512-wkC0qua+SLJUeN2aaKJxqEXIbd95oGRF8A1PJOpl813MIG1b5+PPIIhoMpJO2UrSYkaE7z0pFRmEjWGCAtqrTA==
       tarball: file:projects/cadl-vscode.tgz
     version: 0.0.0
   file:projects/compiler.tgz:
     dependencies:
       '@types/glob': 7.1.4
-      '@types/js-yaml': 4.0.5
+      '@types/js-yaml': 4.0.4
       '@types/mkdirp': 1.0.2
       '@types/mocha': 9.1.0
       '@types/mustache': 4.1.2
       '@types/node': 14.0.27
-      '@types/prettier': 2.4.3
+      '@types/prettier': 2.4.1
       '@types/prompts': 2.0.14
-      '@types/yargs': 17.0.8
+      '@types/yargs': 17.0.5
       ajv: 8.9.0
       c8: 7.11.0
       change-case: 4.1.2
+      eslint: 8.7.0
       glob: 7.1.7
       grammarkdown: 3.1.2
       js-yaml: 4.1.0
@@ -3529,34 +3892,53 @@ packages:
       mocha: 9.2.0
       mustache: 4.2.0
       node-fetch: 3.2.0
-      node-watch: 0.7.3
+      node-watch: 0.7.2
       prettier: 2.5.1
       prettier-plugin-organize-imports: 2.3.4_prettier@2.5.1+typescript@4.5.5
       prompts: 2.4.2
       rimraf: 3.0.2
-      source-map-support: 0.5.21
+      source-map-support: 0.5.20
       typescript: 4.5.5
       vscode-languageserver: 7.0.0
-      vscode-languageserver-textdocument: 1.0.4
+      vscode-languageserver-textdocument: 1.0.2
       yargs: 17.3.1
     dev: false
     name: '@rush-temp/compiler'
     resolution:
-      integrity: sha512-JGqwcBM6TKcR9FXa0GkT0EvPqPY6rpWF75B6tJ/y2uaaSkURhTwvGop/bIoAMuj0oE9kumZT2X9ua1Ps0eS2vg==
+      integrity: sha512-/rxLXB7+W3PkBgGSsB4Id3xjhdMD3P9ZDNQB6NGxnvEUW/u2nkJGr8xiped9jlVEU7xUna9AGaRumZ1ueY5mOA==
       tarball: file:projects/compiler.tgz
+    version: 0.0.0
+  file:projects/eslint-config-cadl.tgz_prettier@2.5.1:
+    dependencies:
+      '@rushstack/eslint-patch': 1.1.0
+      '@typescript-eslint/eslint-plugin': 5.10.0_706fb07ce74b1db611f19a02ad2ce784
+      '@typescript-eslint/parser': 5.10.0_eslint@8.7.0+typescript@4.5.5
+      eslint: 8.7.0
+      eslint-config-prettier: 8.3.0_eslint@8.7.0
+      eslint-plugin-prettier: 4.0.0_4660519532e4c3b0a9e5bb6623cfedf6
+      typescript: 4.5.5
+    dev: false
+    id: file:projects/eslint-config-cadl.tgz
+    name: '@rush-temp/eslint-config-cadl'
+    peerDependencies:
+      prettier: '*'
+    resolution:
+      integrity: sha512-djZZqlrkfB2H3h/gGEqfGgqZ8YUJ43e5yUDKW+9RnDGLLYXYV2KFr5rnyuEsdnrGfo70lg/NZ36G8pVt7xB1Dg==
+      tarball: file:projects/eslint-config-cadl.tgz
     version: 0.0.0
   file:projects/openapi.tgz:
     dependencies:
       '@types/mocha': 9.1.0
       '@types/node': 14.0.27
       c8: 7.11.0
+      eslint: 8.7.0
       mocha: 9.2.0
       rimraf: 3.0.2
       typescript: 4.5.5
     dev: false
     name: '@rush-temp/openapi'
     resolution:
-      integrity: sha512-Xj2JcCHZ5Ia6VRkEvVpXjGR2fcxooK1nYJg9X5MiZ2TpT0KWm4iOncwDLDVZhJbjU5RhWASJsRRJtXoAjHrbfw==
+      integrity: sha512-HRFXDuYpYnQNpMFfq1TQ7zjwylCXrzkof5fet8KMC1M5MQ3pf9x0/h/4wRFcklCHGajQ2d0/vtKb+eB4afT4OQ==
       tarball: file:projects/openapi.tgz
     version: 0.0.0
   file:projects/openapi3.tgz:
@@ -3564,13 +3946,14 @@ packages:
       '@types/mocha': 9.1.0
       '@types/node': 14.0.27
       c8: 7.11.0
+      eslint: 8.7.0
       mocha: 9.2.0
       rimraf: 3.0.2
       typescript: 4.5.5
     dev: false
     name: '@rush-temp/openapi3'
     resolution:
-      integrity: sha512-2PT1wPF0EH9xMZ9N76UVszE7POSF2+x/6NEP6B6vA6MHpYLciPytqr+ezolqkgRTAg2zwrWhCDRIIueD+K6T6g==
+      integrity: sha512-ELv4Yz/sAViYSfS07nJNisKIdR+GhJt4jDVFo//vNr+VgX4dABKgz8i9ZLgfbmwckVYEp8uAaWTwvzBW3rOs/A==
       tarball: file:projects/openapi3.tgz
     version: 0.0.0
   file:projects/prettier-plugin-cadl.tgz:
@@ -3585,7 +3968,7 @@ packages:
     dev: false
     name: '@rush-temp/prettier-plugin-cadl'
     resolution:
-      integrity: sha512-U1ZnNAl+0XfxfcJcAXtW9CuFYo4yGsh0ZUpnXqk4OxYzOm9A57Y5u1C1E0nV194Zw77QJvmIgz6VaeC7aP2aIg==
+      integrity: sha512-B1u9tB2ojV7InblhLQxA0ygdWv24lQbR/W3qXxbTmEKegTAjVFzcL+wqO9NWKYXfycd1xb+JMkvH2gQ8Us0gAA==
       tarball: file:projects/prettier-plugin-cadl.tgz
     version: 0.0.0
   file:projects/rest.tgz:
@@ -3593,13 +3976,14 @@ packages:
       '@types/mocha': 9.1.0
       '@types/node': 14.0.27
       c8: 7.11.0
+      eslint: 8.7.0
       mocha: 9.2.0
       rimraf: 3.0.2
       typescript: 4.5.5
     dev: false
     name: '@rush-temp/rest'
     resolution:
-      integrity: sha512-UQejwc02NDa37AF2JQ8YRqAu4/2ShfMn1RvVsDffqcnOfBefahr4usodqkk15/oz2PnYAl49Iyk4ZEarhtEhKg==
+      integrity: sha512-XObafHBdbl5emNsC5M8SE5FEGKKTSlIcQwQNi+KqNnAz+3xALX8TF3UgJCh7soersQMFc65GGlTe7kM73hrweA==
       tarball: file:projects/rest.tgz
     version: 0.0.0
   file:projects/samples.tgz:
@@ -3610,11 +3994,12 @@ packages:
     dev: false
     name: '@rush-temp/samples'
     resolution:
-      integrity: sha512-JZL6WXd/5pS0ljO1/rfNQ08z4m7eOcd1RFq7t7bIKpKvWikNgsEmvLHzKbeMSAt4mzZIfFA2KPtP3vrgM8sb8A==
+      integrity: sha512-RVkBNXDmv0ycgohgtkBfdfZGp8dxj20bheCHhBsUf6ZQLFTBd7jaserAmcdHNr+eCCkK8su9CfXOaD/2qrFqAg==
       tarball: file:projects/samples.tgz
     version: 0.0.0
   file:projects/spec.tgz:
     dependencies:
+      '@esfx/cancelable': 1.0.0-pre.30
       '@types/mkdirp': 1.0.2
       '@types/node': 14.0.27
       ecmarkup: 9.8.1
@@ -3629,15 +4014,14 @@ packages:
     dependencies:
       '@types/node': 14.0.27
       '@types/plist': 3.0.2
+      eslint: 8.7.0
       onigasm: 2.2.5
       plist: 3.0.4
       typescript: 4.5.5
-      vscode-oniguruma: 1.6.1
-      vscode-textmate: 6.0.0
     dev: false
     name: '@rush-temp/tmlanguage-generator'
     resolution:
-      integrity: sha512-yJymc2rRukF2UrRtMbe/TfdrmsXxPtbGUG9J3uzL8rbtspflx7337pahxbPGwG9GYI7GQPFP74JHSyCBe+8VAw==
+      integrity: sha512-2je3B5fn3fEHMvKgJSbMMCOJPuKA7z1Hib9zlrHB0pUnU5WzpM+w3FS/RZ7RRtPQ5mHef0Uavmd2xq6k+Zo/xA==
       tarball: file:projects/tmlanguage-generator.tgz
     version: 0.0.0
   file:projects/versioning.tgz:
@@ -3645,13 +4029,14 @@ packages:
       '@types/mocha': 9.1.0
       '@types/node': 14.0.27
       c8: 7.11.0
+      eslint: 8.7.0
       mocha: 9.2.0
       rimraf: 3.0.2
       typescript: 4.5.5
     dev: false
     name: '@rush-temp/versioning'
     resolution:
-      integrity: sha512-wuEVQWSC5wba+e5EEn7XLvYj2DQQJUtkwK9vP5Q40g/8Cs8C1ZmydZkMgDLAX6MY43p3LHAQ7rQuXeGZ8rFYIA==
+      integrity: sha512-IVu/pe8eFl0L0aL4LyRPgmK+XPE5/bHIgyg8avm1df4ryPfzPupWUoJ67NQ25o3y54WTZ3lUYq+HMMg5dXSXUQ==
       tarball: file:projects/versioning.tgz
     version: 0.0.0
 specifiers:
@@ -3662,6 +4047,7 @@ specifiers:
   '@rush-temp/cadl-vs': file:./projects/cadl-vs.tgz
   '@rush-temp/cadl-vscode': file:./projects/cadl-vscode.tgz
   '@rush-temp/compiler': file:./projects/compiler.tgz
+  '@rush-temp/eslint-config-cadl': file:./projects/eslint-config-cadl.tgz
   '@rush-temp/openapi': file:./projects/openapi.tgz
   '@rush-temp/openapi3': file:./projects/openapi3.tgz
   '@rush-temp/prettier-plugin-cadl': file:./projects/prettier-plugin-cadl.tgz
@@ -3670,6 +4056,7 @@ specifiers:
   '@rush-temp/spec': file:./projects/spec.tgz
   '@rush-temp/tmlanguage-generator': file:./projects/tmlanguage-generator.tgz
   '@rush-temp/versioning': file:./projects/versioning.tgz
+  '@rushstack/eslint-patch': '1.1.0 '
   '@types/glob': ~7.1.3
   '@types/js-yaml': ~4.0.1
   '@types/mkdirp': ~1.0.1
@@ -3681,11 +4068,16 @@ specifiers:
   '@types/prompts': ~2.0.14
   '@types/vscode': ~1.53.0
   '@types/yargs': ~17.0.2
+  '@typescript-eslint/eslint-plugin': ^5.10.0
+  '@typescript-eslint/parser': ^5.10.0
   ajv: ~8.9.0
   autorest: ~3.3.2
   c8: ~7.11.0
   change-case: ~4.1.2
   ecmarkup: ~9.8.1
+  eslint: ^8.7.0
+  eslint-config-prettier: ^8.3.0
+  eslint-plugin-prettier: ^4.0.0
   glob: ~7.1.6
   grammarkdown: ~3.1.2
   js-yaml: ~4.1.0

--- a/eng/pipelines/pull-request-common.yml
+++ b/eng/pipelines/pull-request-common.yml
@@ -25,6 +25,9 @@ steps:
   - script: node common/scripts/install-run-rush.js check-format
     displayName: Check Formatting
 
+  - script: node common/scripts/install-run-rush.js lint
+    displayName: Lint
+
   - script: cd packages/samples && npm run regen-samples
     displayName: Regenerate Samples
 

--- a/packages/cadl-vscode/ThirdPartyNotices.txt
+++ b/packages/cadl-vscode/ThirdPartyNotices.txt
@@ -12,7 +12,7 @@ granted herein, whether by implication, estoppel or otherwise.
 2. brace-expansion version 1.1.11 (https://github.com/juliangruber/brace-expansion)
 3. concat-map version 0.0.1 (https://github.com/substack/node-concat-map)
 4. lru-cache version 6.0.0 (https://github.com/isaacs/node-lru-cache)
-5. minimatch version 3.0.5 (https://github.com/isaacs/minimatch)
+5. minimatch version 3.0.4 (https://github.com/isaacs/minimatch)
 6. semver version 7.3.5 (https://github.com/npm/node-semver)
 7. yallist version 4.0.0 (https://github.com/isaacs/yallist)
 

--- a/packages/cadl-vscode/package.json
+++ b/packages/cadl-vscode/package.json
@@ -104,6 +104,8 @@
     "@types/mocha": "~9.1.0",
     "@types/node": "~14.0.27",
     "@types/vscode": "~1.53.0",
+    "@cadl-lang/eslint-config-cadl": "~0.1.0",
+    "eslint": "^8.7.0",
     "c8": "~7.11.0",
     "mkdirp": "~1.0.4",
     "mocha": "~9.2.0",

--- a/packages/compiler/.eslintrc.cjs
+++ b/packages/compiler/.eslintrc.cjs
@@ -1,0 +1,5 @@
+require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
+
+module.exports = {
+  extends: "@cadl-lang/eslint-config-cadl",
+};

--- a/packages/compiler/config/types.ts
+++ b/packages/compiler/config/types.ts
@@ -22,7 +22,7 @@ export interface CadlConfig {
   emitters: Record<string, boolean>;
 }
 
-export type RuleValue = "on" | "off" | {};
+export type RuleValue = "on" | "off" | Record<string, unknown>;
 
 /**
  * Represent the configuration that can be provided in a config file.

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -455,7 +455,7 @@ export function createChecker(program: Program): Checker {
   function getNodeSymId(
     node: ModelStatementNode | AliasStatementNode | InterfaceStatementNode | UnionStatementNode
   ): number {
-    return node.symbol?.id!;
+    return node.symbol!.id!;
   }
 
   function getModelName(model: ModelType) {
@@ -679,7 +679,7 @@ export function createChecker(program: Program): Checker {
   }
 
   function checkUnionExpression(node: UnionExpressionNode): UnionType {
-    const variants: [string | Symbol, UnionTypeVariant][] = node.options.flatMap((o) => {
+    const variants: [string | symbol, UnionTypeVariant][] = node.options.flatMap((o) => {
       const type = getTypeForNode(o);
 
       // The type `A | never` is just `A`
@@ -1509,7 +1509,7 @@ export function createChecker(program: Program): Checker {
     const defaultValue = prop.default && checkDefault(getTypeForNode(prop.default), valueType);
     const name = prop.id.kind === SyntaxKind.Identifier ? prop.id.sv : prop.id.value;
 
-    let type: ModelTypeProperty = createType({
+    const type: ModelTypeProperty = createType({
       kind: "ModelProperty",
       name,
       node: prop,
@@ -1561,7 +1561,6 @@ export function createChecker(program: Program): Checker {
         return checkDefaultTypeIsBoolean(defaultType);
       case "int32":
       case "int64":
-      case "int32":
       case "int16":
       case "int8":
       case "uint64":
@@ -1609,10 +1608,12 @@ export function createChecker(program: Program): Checker {
             if (defaultType.value === (option as StringLiteralType).value) {
               return defaultType;
             }
+            break;
           case "Number":
             if (defaultType.value === (option as NumericLiteralType).value) {
               return defaultType;
             }
+            break;
         }
       }
     }
@@ -2135,7 +2136,7 @@ export function createChecker(program: Program): Checker {
       case "Model":
         clone = finishType({
           ...type,
-          properties: additionalProps.hasOwnProperty("properties")
+          properties: Object.prototype.hasOwnProperty.call(additionalProps, "properties")
             ? undefined
             : new Map(
                 Array.from(type.properties.entries()).map(([key, prop]) => [key, cloneType(prop)])
@@ -2146,7 +2147,7 @@ export function createChecker(program: Program): Checker {
       case "Union":
         clone = finishType({
           ...type,
-          variants: new Map<string | Symbol, UnionTypeVariant>(
+          variants: new Map<string | symbol, UnionTypeVariant>(
             Array.from(type.variants.entries()).map(([key, prop]) => [
               key,
               prop.kind === "UnionVariant" ? cloneType(prop) : prop,
@@ -2506,7 +2507,7 @@ export function createChecker(program: Program): Checker {
   function evalProjectionBlockExpression(node: ProjectionBlockExpressionNode): TypeOrReturnRecord {
     let lastVal: Type = voidType;
     for (const stmt of node.statements) {
-      let stmtValue = evalProjectionNode(stmt);
+      const stmtValue = evalProjectionNode(stmt);
       if (stmtValue.kind === "Return") {
         return stmtValue;
       }
@@ -2566,7 +2567,7 @@ export function createChecker(program: Program): Checker {
         throw new ProjectionError("need argument for parameter " + node.parameters[i]);
       }
 
-      let argVal = args[i];
+      const argVal = args[i];
       let typeVal;
 
       if (typeof argVal === "number" || typeof argVal === "string" || typeof argVal === "boolean") {
@@ -2695,18 +2696,6 @@ export function createChecker(program: Program): Checker {
     } as const);
   }
 
-  function isLiteralType(
-    type: Type
-  ): type is StringLiteralType | NumericLiteralType | BooleanLiteralType {
-    switch (type.kind) {
-      case "String":
-      case "Number":
-      case "Boolean":
-        return true;
-      default:
-        return false;
-    }
-  }
   function literalTypeToValue(type: StringLiteralType): string;
   function literalTypeToValue(type: NumericLiteralType): number;
   function literalTypeToValue(type: BooleanLiteralType): boolean;
@@ -2753,7 +2742,7 @@ export function createChecker(program: Program): Checker {
     return createType({
       kind: "Function",
       call(...args: Type[]): Type {
-        let retval = ref.value!({ program }, ...marshalProjectionArguments(args));
+        ref.value!({ program }, ...marshalProjectionArguments(args));
         return voidType;
       },
     } as const);
@@ -2783,7 +2772,7 @@ export function createChecker(program: Program): Checker {
       const t: FunctionType = createType({
         kind: "Function",
         call(...args: Type[]): Type {
-          let retval = ref.value!(program, ...marshalProjectionArguments(args));
+          const retval = ref.value!(program, ...marshalProjectionArguments(args));
           return marshalProjectionReturn(retval);
         },
       } as const);

--- a/packages/compiler/core/cli.ts
+++ b/packages/compiler/core/cli.ts
@@ -201,12 +201,12 @@ function compileInput(
   let compileRequested: boolean = false;
   let currentCompilePromise: Promise<Program> | undefined = undefined;
 
-  let log = (message?: any, ...optionalParams: any[]) => {
-    let prefix = compilerOptions.watchForChanges ? `[${new Date().toLocaleTimeString()}] ` : "";
+  const log = (message?: any, ...optionalParams: any[]) => {
+    const prefix = compilerOptions.watchForChanges ? `[${new Date().toLocaleTimeString()}] ` : "";
     console.log(`${prefix}${message}`, ...optionalParams);
   };
 
-  let runCompile = () => {
+  const runCompile = () => {
     // Don't run the compiler if it's already running
     if (!currentCompilePromise) {
       // Clear the console before compiling in watch mode
@@ -224,7 +224,7 @@ function compileInput(
     return currentCompilePromise;
   };
 
-  let onCompileFinished = (program: Program) => {
+  const onCompileFinished = (program: Program) => {
     if (program.diagnostics.length > 0) {
       log("Diagnostics were reported during compilation:\n");
       logDiagnostics(program.diagnostics, NodeHost.logSink);
@@ -358,7 +358,7 @@ async function installVsix(pkg: string, install: (vsixPaths: string[]) => void, 
   // locate .vsix
   const dir = joinPaths(temp, "node_modules", pkg);
   const files = await readdir(dir);
-  let vsixPaths: string[] = [];
+  const vsixPaths: string[] = [];
   for (const file of files) {
     if (file.endsWith(".vsix")) {
       vsixPaths.push(joinPaths(dir, file));

--- a/packages/compiler/core/diagnostics.ts
+++ b/packages/compiler/core/diagnostics.ts
@@ -261,8 +261,6 @@ export function compilerAssert(
   message: string,
   target?: DiagnosticTarget
 ): asserts condition {
-  let locationError: Error | undefined;
-
   if (condition) {
     return;
   }
@@ -271,9 +269,7 @@ export function compilerAssert(
     let location: SourceLocation | undefined;
     try {
       location = getSourceLocation(target);
-    } catch (err: any) {
-      locationError = err;
-    }
+    } catch (err: any) {}
 
     if (location) {
       const pos = location.file.getLineAndCharacterOfPosition(location.pos);

--- a/packages/compiler/core/library.ts
+++ b/packages/compiler/core/library.ts
@@ -1,5 +1,11 @@
 import { createDiagnosticCreator } from "./diagnostics.js";
-import { CadlLibrary, CadlLibraryDef, CallableMessage, DiagnosticMessages } from "./types.js";
+import {
+  CadlLibrary,
+  CadlLibraryDef,
+  CallableMessage,
+  DecoratorFunction,
+  DiagnosticMessages,
+} from "./types.js";
 
 /**
  * Create a new Cadl library definition.
@@ -46,6 +52,6 @@ export function paramMessage<T extends string[]>(
   return template;
 }
 
-export function setDecoratorNamespace(namespace: string, ...decorators: Function[]): void {
+export function setDecoratorNamespace(namespace: string, ...decorators: DecoratorFunction[]): void {
   decorators.forEach((c: any) => (c.namespace = namespace));
 }

--- a/packages/compiler/core/module-resolver.ts
+++ b/packages/compiler/core/module-resolver.ts
@@ -51,7 +51,7 @@ export async function resolveModule(
   // Check if the module name is referencing a path(./foo, /foo, file:/foo)
   if (/^(?:\.\.?(?:\/|$)|\/|([A-Za-z]:)?[/\\])/.test(name)) {
     const res = resolvePath(absoluteStart, name);
-    var m = (await loadAsFile(res)) || (await loadAsDirectory(res));
+    const m = (await loadAsFile(res)) || (await loadAsDirectory(res));
     if (m) return host.realpath(m);
   }
 
@@ -86,7 +86,7 @@ export async function resolveModule(
     const dirs = getPackageCandidates(name, baseDir);
     for (const dir of dirs) {
       if (await isDirectory(host, dir)) {
-        var n = loadAsDirectory(dir);
+        const n = loadAsDirectory(dir);
         if (n) return n;
       }
     }

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -122,6 +122,7 @@ interface UndecoratedListKind extends ListKind {
 /**
  * The fixed set of options for each of the kinds of delimited lists in Cadl.
  */
+// eslint-disable-next-line @typescript-eslint/no-namespace
 namespace ListKind {
   const PropertiesBase = {
     allowEmpty: true,
@@ -823,7 +824,7 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
   function parseUnionExpressionOrHigher(): Expression {
     const pos = tokenPos();
     parseOptional(Token.Bar);
-    let node: Expression = parseIntersectionExpressionOrHigher();
+    const node: Expression = parseIntersectionExpressionOrHigher();
 
     if (token() !== Token.Bar) {
       return node;
@@ -845,7 +846,7 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
   function parseIntersectionExpressionOrHigher(): Expression {
     const pos = tokenPos();
     parseOptional(Token.Ampersand);
-    let node: Expression = parseArrayExpressionOrHigher();
+    const node: Expression = parseArrayExpressionOrHigher();
 
     if (token() !== Token.Ampersand) {
       return node;
@@ -2024,7 +2025,7 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
     // position. The code path taken by error recovery after logging an error
     // can otherwise produce redundant and less decipherable errors, which this
     // suppresses.
-    let realPos = report.target?.realPos ?? location.pos;
+    const realPos = report.target?.realPos ?? location.pos;
     if (realPositionOfLastError === realPos) {
       return;
     }
@@ -2298,7 +2299,7 @@ export function visitChildren<T>(node: Node, cb: NodeCb<T>): T | undefined {
       // Dummy const to ensure we handle all node types.
       // If you get an error here, add a case for the new node type
       // you added..
-      const assertNever: never = node;
+      const _assertNever: never = node;
       return;
   }
 }

--- a/packages/compiler/core/program.ts
+++ b/packages/compiler/core/program.ts
@@ -57,10 +57,10 @@ export interface Program {
   evalCadlScript(cadlScript: string): void;
   onValidate(cb: (program: Program) => void): Promise<void> | void;
   getOption(key: string): string | undefined;
-  stateSet(key: Symbol): Set<Type>;
-  stateSets: Map<Symbol, Set<Type>>;
-  stateMap(key: Symbol): Map<Type, any>;
-  stateMaps: Map<Symbol, Map<Type, any>>;
+  stateSet(key: symbol): Set<Type>;
+  stateSets: Map<symbol, Set<Type>>;
+  stateMap(key: symbol): Map<Type, any>;
+  stateMaps: Map<symbol, Map<Type, any>>;
   hasError(): boolean;
   reportDiagnostic(diagnostic: Diagnostic): void;
   reportDiagnostics(diagnostics: readonly Diagnostic[]): void;
@@ -77,7 +77,7 @@ interface EmitterRef {
 
 class StateMap<V> implements Map<Type, V> {
   private internalState = new Map<undefined | Projector, Map<Type, V>>();
-  constructor(public program: Program, public key: Symbol) {}
+  constructor(public program: Program, public key: symbol) {}
 
   has(t: Type) {
     return this.dispatch(t)?.has(t) ?? false;
@@ -138,7 +138,7 @@ class StateMap<V> implements Map<Type, V> {
 }
 class StateSet implements Set<Type> {
   private internalState = new Map<undefined | Projector, Set<Type>>();
-  constructor(public program: Program, public key: Symbol) {}
+  constructor(public program: Program, public key: symbol) {}
 
   has(t: Type) {
     return this.dispatch(t)?.has(t) ?? false;
@@ -200,8 +200,8 @@ export async function createProgram(
   options: CompilerOptions = {}
 ): Promise<Program> {
   const validateCbs: any = [];
-  const stateMaps = new Map<Symbol, StateMap<any>>();
-  const stateSets = new Map<Symbol, StateSet>();
+  const stateMaps = new Map<symbol, StateMap<any>>();
+  const stateSets = new Map<symbol, StateSet>();
   const diagnostics: Diagnostic[] = [];
   const seenSourceFiles = new Set<string>();
   const duplicateSymbols = new Set<Sym>();
@@ -307,7 +307,7 @@ export async function createProgram(
     diagnosticTarget: DiagnosticTarget | typeof NoTarget
   ): Promise<string> {
     const pkgJsonPath = resolvePath(dir, "package.json");
-    let [pkg] = await loadFile(host, pkgJsonPath, JSON.parse, program.reportDiagnostic, {
+    const [pkg] = await loadFile(host, pkgJsonPath, JSON.parse, program.reportDiagnostic, {
       allowFileNotFound: true,
       diagnosticTarget,
     });
@@ -338,7 +338,7 @@ export async function createProgram(
     path: string,
     diagnosticTarget: DiagnosticTarget | typeof NoTarget
   ): Promise<JsSourceFileNode | undefined> {
-    let sourceFile = program.jsSourceFiles.get(path);
+    const sourceFile = program.jsSourceFiles.get(path);
     if (sourceFile !== undefined) {
       return sourceFile;
     }
@@ -644,7 +644,7 @@ export async function createProgram(
     return (options.miscOptions || {})[key];
   }
 
-  function stateMap(key: Symbol): StateMap<any> {
+  function stateMap(key: symbol): StateMap<any> {
     let m = stateMaps.get(key);
 
     if (!m) {
@@ -655,7 +655,7 @@ export async function createProgram(
     return m;
   }
 
-  function stateSet(key: Symbol): StateSet {
+  function stateSet(key: symbol): StateSet {
     let s = stateSets.get(key);
 
     if (!s) {

--- a/packages/compiler/core/projectionMembers.ts
+++ b/packages/compiler/core/projectionMembers.ts
@@ -6,15 +6,8 @@ import { ObjectType, Type, UnionTypeVariant } from "./types.js";
 export function createProjectionMembers(checker: Checker): {
   [TKind in Type["kind"]]?: Record<string, (base: Type & { kind: TKind }) => Type>;
 } {
-  const {
-    voidType,
-    neverType,
-    errorType,
-    createType,
-    createFunctionType,
-    createLiteralType,
-    cloneType,
-  } = checker;
+  const { voidType, neverType, createType, createFunctionType, createLiteralType, cloneType } =
+    checker;
 
   return {
     Array: {

--- a/packages/compiler/core/projector.ts
+++ b/packages/compiler/core/projector.ts
@@ -21,7 +21,6 @@ import {
 
 function foo() {}
 foo();
-type DeclScope = NamespaceType | ModelType | InterfaceType | UnionType | EnumType | OperationType;
 
 /**
  * Creates a projector which returns a projected view of either the global namespace or the
@@ -53,13 +52,13 @@ export function createProjector(
   const projectedTypes = new Map<Type, Type>();
   const checker = program.checker!;
   const neverType = checker.neverType;
-  let scope: Type[] = [];
+  const scope: Type[] = [];
   const projector: Projector = {
     projectedTypes,
     projections,
     projectType,
   };
-  let projectedNamespaces: NamespaceType[] = [];
+  const projectedNamespaces: NamespaceType[] = [];
 
   program.currentProjector = projector;
 
@@ -94,6 +93,7 @@ export function createProjector(
     switch (type.kind) {
       case "Namespace":
         compilerAssert(false, "Namespace should have already been projected.");
+        break;
       case "Model":
         projected = projectModel(type);
         break;
@@ -140,7 +140,7 @@ export function createProjector(
     const childInterfaces = new Map<string, InterfaceType>();
     const childUnions = new Map<string, UnionType>();
     const childEnums = new Map<string, EnumType>();
-    let projectedNs = shallowClone(ns, {
+    const projectedNs = shallowClone(ns, {
       namespaces: childNamespaces,
       models: childModels,
       operations: childOperations,
@@ -218,7 +218,7 @@ export function createProjector(
     const properties = new Map<string, ModelTypeProperty>();
     let templateArguments: Type[] | undefined;
 
-    let projectedModel = shallowClone(model, {
+    const projectedModel = shallowClone(model, {
       properties,
     });
 
@@ -294,7 +294,7 @@ export function createProjector(
     const returnType = projectType(op.returnType);
     const decorators = projectDecorators(op.decorators);
 
-    let projectedOp = shallowClone(op, {
+    const projectedOp = shallowClone(op, {
       decorators,
       parameters,
       returnType,
@@ -313,7 +313,7 @@ export function createProjector(
   function projectInterface(iface: InterfaceType): Type {
     const operations = new Map<string, OperationType>();
     const decorators = projectDecorators(iface.decorators);
-    let projectedIface = shallowClone(iface, {
+    const projectedIface = shallowClone(iface, {
       decorators,
       operations,
     });
@@ -333,10 +333,10 @@ export function createProjector(
   }
 
   function projectUnion(union: UnionType) {
-    const variants = new Map<string | Symbol, UnionTypeVariant>();
+    const variants = new Map<string | symbol, UnionTypeVariant>();
     const decorators = projectDecorators(union.decorators);
 
-    let projectedUnion = shallowClone(union, {
+    const projectedUnion = shallowClone(union, {
       decorators,
       variants,
     });
@@ -505,7 +505,7 @@ export function createProjector(
     for (const projectionApplication of inScopeProjections) {
       const projectionsByName = baseType.projectionsByName(projectionApplication.projectionName);
       if (projectionsByName.length === 0) continue;
-      let targetNode =
+      const targetNode =
         projectionApplication.direction === "from"
           ? projectionsByName[0].from!
           : projectionsByName[0].to!;

--- a/packages/compiler/core/scanner.ts
+++ b/packages/compiler/core/scanner.ts
@@ -545,7 +545,7 @@ export function createScanner(
       return scanWhitespace();
     }
 
-    let cp = input.codePointAt(position)!;
+    const cp = input.codePointAt(position)!;
     if (isNonAsciiIdentifierCharacter(cp)) {
       return scanNonAsciiIdentifier(cp);
     }
@@ -854,7 +854,7 @@ export function createScanner(
     let pos = start;
 
     while (pos < end) {
-      let ch = input.charCodeAt(pos);
+      const ch = input.charCodeAt(pos);
       if (ch !== CharCode.Backslash) {
         pos++;
         continue;
@@ -948,7 +948,7 @@ export function createScanner(
     } while (isAsciiIdentifierContinue((ch = input.charCodeAt(position))));
 
     if (ch > CharCode.MaxAscii) {
-      let cp = input.codePointAt(position)!;
+      const cp = input.codePointAt(position)!;
       if (isNonAsciiIdentifierCharacter(cp)) {
         return scanNonAsciiIdentifier(cp);
       }
@@ -970,7 +970,7 @@ export function createScanner(
 
 export function skipTrivia(input: string, position: number): number {
   while (position < input.length) {
-    let ch = input.charCodeAt(position);
+    const ch = input.charCodeAt(position);
 
     if (isWhiteSpace(ch)) {
       position++;

--- a/packages/compiler/core/semantic-walker.ts
+++ b/packages/compiler/core/semantic-walker.ts
@@ -247,7 +247,7 @@ function navigateType(
     default:
       // Dummy const to ensure we handle all types.
       // If you get an error here, add a case for the new type you added
-      const assertNever: never = type;
+      const _assertNever: never = type;
       return;
   }
 }

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -241,14 +241,14 @@ export interface UnionType extends BaseType, DecoratedType, TemplatedType {
   name?: string;
   node: UnionExpressionNode | UnionStatementNode;
   namespace?: NamespaceType;
-  variants: Map<string | Symbol, UnionTypeVariant>;
+  variants: Map<string | symbol, UnionTypeVariant>;
   expression: boolean;
   readonly options: Type[];
 }
 
 export interface UnionTypeVariant extends BaseType, DecoratedType {
   kind: "UnionVariant";
-  name: string | Symbol;
+  name: string | symbol;
   node: UnionVariantNode | undefined;
   type: Type;
 }
@@ -1156,7 +1156,9 @@ export type DiagnosticFormat<
   T extends { [code: string]: DiagnosticMessages },
   C extends keyof T,
   M extends keyof T[C] = "default"
-> = T[C][M] extends CallableMessage<infer A> ? { format: Record<A[number], string> } : {};
+> = T[C][M] extends CallableMessage<infer A>
+  ? { format: Record<A[number], string> }
+  : Record<string, unknown>;
 
 export interface DiagnosticDefinition<M extends DiagnosticMessages> {
   readonly severity: "warning" | "error";
@@ -1236,7 +1238,7 @@ export interface CadlLibrary<
 /**
  * Get the options for the onEmit of this library.
  */
-export type EmitOptionsFor<C> = C extends CadlLibrary<infer T, infer E> ? EmitOptions<E> : never;
+export type EmitOptionsFor<C> = C extends CadlLibrary<infer _T, infer E> ? EmitOptions<E> : never;
 
 export interface EmitOptions<E extends string> {
   name?: E;

--- a/packages/compiler/core/util.ts
+++ b/packages/compiler/core/util.ts
@@ -176,6 +176,7 @@ export function resolveRelativeUrlOrPath(base: string, relativeOrAbsolute: strin
  * A specially typed version of `Array.isArray` to work around [this issue](https://github.com/microsoft/TypeScript/issues/17002).
  */
 export function isArray<T>(
+  // eslint-disable-next-line @typescript-eslint/ban-types
   arg: T | {}
 ): arg is T extends readonly any[] ? (unknown extends T ? never : readonly any[]) : any[] {
   return Array.isArray(arg);

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -33,7 +33,7 @@ import { isArray } from "../../core/util.js";
 import { commentHandler } from "./comment-handler.js";
 import { CadlPrettierOptions, DecorableNode, PrettierChildPrint } from "./types.js";
 
-const { align, breakParent, concat, group, hardline, ifBreak, indent, join, line, softline } =
+const { align, breakParent, group, hardline, ifBreak, indent, join, line, softline } =
   prettier.doc.builders;
 
 const { isNextLineEmpty } = prettier.util;

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -45,7 +45,9 @@
     "test": "mocha",
     "test-official": "c8 mocha --forbid-only",
     "regen-nonascii": "node scripts/regen-nonascii.js",
-    "fuzz": "node dist/test/manual/fuzz.js run"
+    "fuzz": "node dist/test/manual/fuzz.js run",
+    "lint": "eslint . --ext .ts --max-warnings=0",
+    "lint:fix": "eslint . --fix --ext .ts"
   },
   "dependencies": {
     "ajv": "~8.9.0",
@@ -72,6 +74,8 @@
     "@types/prettier": "^2.0.2",
     "@types/prompts": "~2.0.14",
     "@types/yargs": "~17.0.2",
+    "@cadl-lang/eslint-config-cadl": "~0.1.0",
+    "eslint": "^8.7.0",
     "grammarkdown": "~3.1.2",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",

--- a/packages/compiler/test/checker/interface.ts
+++ b/packages/compiler/test/checker/interface.ts
@@ -232,7 +232,7 @@ describe("compiler: interfaces", () => {
   });
 
   it("doesn't invoke decorators on uninstantiated templates", async () => {
-    let blues = new WeakSet();
+    const blues = new WeakSet();
     let calls = 0;
     testHost.addJsFile("dec.js", {
       $blue(p: any, t: Type) {

--- a/packages/compiler/test/checker/model.ts
+++ b/packages/compiler/test/checker/model.ts
@@ -54,7 +54,7 @@ describe("compiler: models", () => {
   });
 
   it("doesn't invoke decorators on uninstantiated templates", async () => {
-    let blues = new WeakSet();
+    const blues = new WeakSet();
     let calls = 0;
     testHost.addJsFile("dec.js", {
       $blue(p: any, t: Type) {
@@ -159,8 +159,8 @@ describe("compiler: models", () => {
 
   describe("with is", () => {
     let testHost: TestHost;
-    let blues = new WeakSet();
-    let reds = new WeakSet();
+    const blues = new WeakSet();
+    const reds = new WeakSet();
     beforeEach(async () => {
       testHost = await createTestHost();
       testHost.addJsFile("dec.js", {

--- a/packages/compiler/test/checker/projection.ts
+++ b/packages/compiler/test/checker/projection.ts
@@ -45,10 +45,10 @@ describe("cadl: projections", () => {
       }
     `;
 
-    let result = (await testProjection(code, [projection("v", 1)])) as ModelType;
+    const result = (await testProjection(code, [projection("v", 1)])) as ModelType;
     strictEqual(result.properties.size, 1);
 
-    let result2 = (await testProjection(code, [projection("v", 2)])) as ModelType;
+    const result2 = (await testProjection(code, [projection("v", 2)])) as ModelType;
     strictEqual(result2.properties.size, 2);
   });
 
@@ -195,14 +195,14 @@ describe("cadl: projections", () => {
         }
       `;
 
-      let result = (await testProjection(code, [projection("v", 1)])) as ModelType;
+      const result = (await testProjection(code, [projection("v", 1)])) as ModelType;
       strictEqual(result.properties.size, 4);
-      let resultNested = result.properties.get("e")!.type as ModelType;
+      const resultNested = result.properties.get("e")!.type as ModelType;
       strictEqual(resultNested.properties.size, 1);
 
-      let result2 = (await testProjection(code, [projection("v", 2)])) as ModelType;
+      const result2 = (await testProjection(code, [projection("v", 2)])) as ModelType;
       strictEqual(result2.properties.size, 4);
-      let resultNested2 = result2.properties.get("e")!.type as ModelType;
+      const resultNested2 = result2.properties.get("e")!.type as ModelType;
       strictEqual(resultNested2.properties.size, 2);
     });
 

--- a/packages/compiler/test/checker/union.ts
+++ b/packages/compiler/test/checker/union.ts
@@ -10,7 +10,7 @@ describe("compiler: union declarations", () => {
   });
 
   it("can be declared and decorated", async () => {
-    let blues = new WeakSet();
+    const blues = new WeakSet();
     testHost.addJsFile("test.js", {
       $blue(p: any, t: UnionType | UnionTypeVariant) {
         blues.add(t);

--- a/packages/compiler/test/manual/fuzz.ts
+++ b/packages/compiler/test/manual/fuzz.ts
@@ -186,7 +186,7 @@ function fuzzTest(iterations: number) {
       return contents;
     }
 
-    function repeatBinomial(fn: Function, p: number, opts: { atLeastOnce?: boolean } = {}) {
+    function repeatBinomial(fn: () => any, p: number, opts: { atLeastOnce?: boolean } = {}) {
       if (opts.atLeastOnce) {
         fn();
       }
@@ -196,7 +196,7 @@ function fuzzTest(iterations: number) {
       }
     }
 
-    function roll<T>(opts: Record<keyof T, Function>, weights: Record<keyof T, number>): void {
+    function roll<T>(opts: Record<keyof T, () => any>, weights: Record<keyof T, number>): void {
       let sum = 0;
       for (const w of Object.values<number>(weights)) {
         sum += w;
@@ -217,7 +217,7 @@ function fuzzTest(iterations: number) {
       return arr[index];
     }
 
-    function maybe(fn: Function, p: number) {
+    function maybe(fn: () => any, p: number) {
       if (Math.random() < p) {
         fn();
       }

--- a/packages/compiler/test/test-parser.ts
+++ b/packages/compiler/test/test-parser.ts
@@ -117,7 +117,7 @@ describe("compiler: syntax", () => {
     ]);
     parseErrorEach([
       ["model foo extends { }", [/Identifier expected/]],
-      ["model foo extends bar, baz { }", [/\'{' expected/]],
+      ["model foo extends bar, baz { }", [/'{' expected/]],
       ["model foo extends = { }", [/Identifier expected/]],
       ["model foo extends bar = { }", [/'{' expected/]],
     ]);

--- a/packages/eslint-config-cadl/index.js
+++ b/packages/eslint-config-cadl/index.js
@@ -1,0 +1,47 @@
+module.exports = {
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint/eslint-plugin", "prettier"],
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
+  env: {
+    node: true,
+    es2021: true,
+  },
+  rules: {
+    /**
+     * Typescript plugin overrides
+     */
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-inferrable-types": "off",
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-empty-interface": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      { varsIgnorePattern: "^_", argsIgnorePattern: ".*", ignoreRestSiblings: true },
+    ],
+
+    /**
+     * Core
+     */
+    "no-inner-declarations": "off",
+    "no-empty": "off",
+    "no-constant-condition": "off",
+    "no-case-declarations": "off",
+    "no-ex-assign": "off",
+    "prefer-const": [
+      "warn",
+      {
+        destructuring: "all",
+      },
+    ],
+  },
+  ignorePatterns: ["dist/**/*", "dist-dev/**/*"],
+  overrides: [
+    {
+      files: ["test/**/*"],
+      rules: {
+        "@typescript-eslint/no-non-null-asserted-optional-chain": "off",
+      },
+    },
+  ],
+};

--- a/packages/eslint-config-cadl/package.json
+++ b/packages/eslint-config-cadl/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@cadl-lang/eslint-config-cadl",
+  "version": "0.1.0",
+  "description": "ESLint config for cadl packages",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Microsoft/cadl.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Microsoft/cadl/issues"
+  },
+  "scripts": {
+    "build": "echo 'No build.'"
+  },
+  "dependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.10.0",
+    "@typescript-eslint/parser": "^5.10.0",
+    "@rushstack/eslint-patch": "1.1.0 ",
+    "eslint": "^8.7.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-prettier": "^4.0.0",
+    "typescript": "~4.5.5"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/packages/eslint-config-cadl/patch/modern-module-resolution.js
+++ b/packages/eslint-config-cadl/patch/modern-module-resolution.js
@@ -1,0 +1,1 @@
+require("@rushstack/eslint-patch/modern-module-resolution");

--- a/packages/openapi/.eslintrc.cjs
+++ b/packages/openapi/.eslintrc.cjs
@@ -1,0 +1,5 @@
+require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
+
+module.exports = {
+  extends: "@cadl-lang/eslint-config-cadl",
+};

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -41,7 +41,9 @@
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",
     "test": "mocha",
-    "test-official": "c8 mocha --forbid-only"
+    "test-official": "c8 mocha --forbid-only",
+    "lint": "eslint . --ext .ts --max-warnings=0",
+    "lint:fix": "eslint . --fix --ext .ts"
   },
   "files": [
     "lib/*.cadl",
@@ -57,6 +59,8 @@
     "@types/node": "~14.0.27",
     "@cadl-lang/compiler": "~0.28.0",
     "@cadl-lang/rest": "~0.11.0",
+    "@cadl-lang/eslint-config-cadl": "~0.1.0",
+    "eslint": "^8.7.0",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",
     "rimraf": "~3.0.2",

--- a/packages/openapi3/.eslintrc.cjs
+++ b/packages/openapi3/.eslintrc.cjs
@@ -1,0 +1,5 @@
+require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
+
+module.exports = {
+  extends: "@cadl-lang/eslint-config-cadl",
+};

--- a/packages/openapi3/package.json
+++ b/packages/openapi3/package.json
@@ -27,7 +27,9 @@
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",
     "test": "mocha",
-    "test-official": "c8 mocha --forbid-only"
+    "test-official": "c8 mocha --forbid-only",
+    "lint": "eslint . --ext .ts --max-warnings=0",
+    "lint:fix": "eslint . --fix --ext .ts"
   },
   "files": [
     "lib/*.cadl",
@@ -47,6 +49,8 @@
     "@cadl-lang/rest": "~0.11.0",
     "@cadl-lang/openapi": "~0.6.1",
     "@cadl-lang/versioning": "~0.3.1",
+    "@cadl-lang/eslint-config-cadl": "~0.1.0",
+    "eslint": "^8.7.0",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",
     "rimraf": "~3.0.2",

--- a/packages/rest/.eslintrc.cjs
+++ b/packages/rest/.eslintrc.cjs
@@ -1,0 +1,5 @@
+require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
+
+module.exports = {
+  extends: "@cadl-lang/eslint-config-cadl",
+};

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -41,7 +41,9 @@
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",
     "test": "mocha",
-    "test-official": "c8 mocha --forbid-only"
+    "test-official": "c8 mocha --forbid-only",
+    "lint": "eslint . --ext .ts --max-warnings=0",
+    "lint:fix": "eslint . --fix --ext .ts"
   },
   "files": [
     "lib/*.cadl",
@@ -55,6 +57,8 @@
     "@types/mocha": "~9.1.0",
     "@types/node": "~14.0.27",
     "@cadl-lang/compiler": "~0.28.0",
+    "@cadl-lang/eslint-config-cadl": "~0.1.0",
+    "eslint": "^8.7.0",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",
     "rimraf": "~3.0.2",

--- a/packages/rest/src/route.ts
+++ b/packages/rest/src/route.ts
@@ -65,7 +65,7 @@ export function $routeReset({ program }: DecoratorContext, entity: Type, path: s
 
 const routeContainerKey = Symbol();
 function addRouteContainer(program: Program, entity: Type): void {
-  let container = entity.kind === "Operation" ? entity.interface || entity.namespace : entity;
+  const container = entity.kind === "Operation" ? entity.interface || entity.namespace : entity;
   if (!container) {
     // Somehow the entity doesn't have a container.  This should only happen
     // when a type was created manually and not by the checker.
@@ -358,7 +358,7 @@ function buildRoutes(
   // Build all child routes and append them to the list, but don't recurse in
   // the global scope because that could pull in unwanted operations
   if (container.kind === "Namespace" && container.name !== "") {
-    let children: OperationContainer[] = [
+    const children: OperationContainer[] = [
       ...container.namespaces.values(),
       ...container.interfaces.values(),
     ];
@@ -366,7 +366,7 @@ function buildRoutes(
     const childRoutes = children.flatMap((child) =>
       buildRoutes(program, child, parentFragments, visitedOperations)
     );
-    operations.push.apply(operations, childRoutes);
+    for (const child of childRoutes) [operations.push(child)];
   }
 
   return operations;

--- a/packages/tmlanguage-generator/.eslintrc.cjs
+++ b/packages/tmlanguage-generator/.eslintrc.cjs
@@ -1,0 +1,5 @@
+require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
+
+module.exports = {
+  extends: "@cadl-lang/eslint-config-cadl",
+};

--- a/packages/tmlanguage-generator/package.json
+++ b/packages/tmlanguage-generator/package.json
@@ -23,7 +23,9 @@
   },
   "scripts": {
     "build": "tsc -p .",
-    "watch": "tsc -p . --watch"
+    "watch": "tsc -p . --watch",
+    "lint": "eslint . --ext .ts --max-warnings=0",
+    "lint:fix": "eslint . --fix --ext .ts"
   },
   "files": [
     "dist/**",
@@ -36,6 +38,8 @@
   "devDependencies": {
     "@types/node": "~14.0.27",
     "@types/plist": "~3.0.2",
+    "@cadl-lang/eslint-config-cadl": "~0.1.0",
+    "eslint": "^8.7.0",
     "typescript": "~4.5.5"
   }
 }

--- a/packages/versioning/.eslintrc.cjs
+++ b/packages/versioning/.eslintrc.cjs
@@ -1,0 +1,5 @@
+require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
+
+module.exports = {
+  extends: "@cadl-lang/eslint-config-cadl",
+};

--- a/packages/versioning/package.json
+++ b/packages/versioning/package.json
@@ -41,7 +41,9 @@
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",
     "test": "mocha",
-    "test-official": "c8 mocha --forbid-only"
+    "test-official": "c8 mocha --forbid-only",
+    "lint": "eslint . --ext .ts --max-warnings=0",
+    "lint:fix": "eslint . --fix --ext .ts"
   },
   "files": [
     "lib/*.cadl",
@@ -54,6 +56,8 @@
   "devDependencies": {
     "@types/mocha": "~9.1.0",
     "@types/node": "~14.0.27",
+    "@cadl-lang/eslint-config-cadl": "~0.1.0",
+    "eslint": "^8.7.0",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",
     "rimraf": "~3.0.2",

--- a/packages/versioning/test/testVersioning.ts
+++ b/packages/versioning/test/testVersioning.ts
@@ -165,7 +165,6 @@ describe("cadl: versioning", () => {
 
     it("can make properties optional", async () => {
       const {
-        source,
         projections: [v1, v2],
       } = await versionedModel(
         ["1", "2"],

--- a/rush.json
+++ b/rush.json
@@ -91,6 +91,12 @@
       "shouldPublish": true
     },
     {
+      "packageName": "@cadl-lang/eslint-config-cadl",
+      "projectFolder": "packages/eslint-config-cadl",
+      "reviewCategory": "production",
+      "shouldPublish": true
+    },
+    {
       "packageName": "@cadl-lang/spec",
       "projectFolder": "packages/spec",
       "reviewCategory": "production",


### PR DESCRIPTION
Part of https://github.com/Azure/cadl-azure/issues/1147

Configure eslint for linting in the packages. This create a new package meant to contain the shared config.
There is a bunch of rules that can be autofixed with `npm run lint:fix` or `rush lint:fix`

Rules auto fixed:
- prefer-const(Replace let and var with const when possible)
- replace `Symbol` with `symbol`

There is some others that will need to be fixed manually:
- `@typescript-eslint/no-unused-vars`: Scan for unused local variables
- `no-fallthrough` makes sure you always break/return in switch statement to prevent bugs
- `no-duplicate-case` duplicate switch case

I am thinking to wait until the projection PR is done so reduce the merge problems there