### PR TITLE
Fix issue with casing in cadl path on case insensitive fs

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-windows-case-import-issues_2022-01-22-23-53.json
+++ b/common/changes/@cadl-lang/compiler/fix-windows-case-import-issues_2022-01-22-23-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Fix** issue when loading cadl using a different casing than the actual casing in a case insenstivie file system",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/cmd/runner.ts
+++ b/packages/compiler/cmd/runner.ts
@@ -1,5 +1,5 @@
+import { realpath } from "fs/promises";
 import path from "path";
-import {realpath} from "fs/promises";
 import url from "url";
 import { resolveModule } from "../core/module-resolver.js";
 import { NodeHost } from "../core/util.js";
@@ -19,7 +19,6 @@ export async function runScript(relativePath: string): Promise<void> {
     packageRoot = path.resolve(resolved, "../../..");
   } catch (err: any) {
     if (err.code === "MODULE_NOT_FOUND") {
-      console.log("MADe it here", import.meta.url);
       // Resolution from cwd failed: use current package.
       packageRoot = path.resolve(await realpath(url.fileURLToPath(import.meta.url)), "../../..");
     } else {

--- a/packages/compiler/cmd/runner.ts
+++ b/packages/compiler/cmd/runner.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import {realpath} from "fs/promises";
 import url from "url";
 import { resolveModule } from "../core/module-resolver.js";
 import { NodeHost } from "../core/util.js";
@@ -18,8 +19,9 @@ export async function runScript(relativePath: string): Promise<void> {
     packageRoot = path.resolve(resolved, "../../..");
   } catch (err: any) {
     if (err.code === "MODULE_NOT_FOUND") {
+      console.log("MADe it here", import.meta.url);
       // Resolution from cwd failed: use current package.
-      packageRoot = path.resolve(url.fileURLToPath(import.meta.url), "../../..");
+      packageRoot = path.resolve(await realpath(url.fileURLToPath(import.meta.url)), "../../..");
     } else {
       throw err;
     }
@@ -28,6 +30,7 @@ export async function runScript(relativePath: string): Promise<void> {
   if (packageRoot) {
     const script = path.join(packageRoot, relativePath);
     const scriptUrl = url.pathToFileURL(script).toString();
+    console.error("Will load", scriptUrl);
     import(scriptUrl);
   } else {
     throw new Error(

--- a/packages/compiler/cmd/runner.ts
+++ b/packages/compiler/cmd/runner.ts
@@ -29,7 +29,6 @@ export async function runScript(relativePath: string): Promise<void> {
   if (packageRoot) {
     const script = path.join(packageRoot, relativePath);
     const scriptUrl = url.pathToFileURL(script).toString();
-    console.error("Will load", scriptUrl);
     import(scriptUrl);
   } else {
     throw new Error(


### PR DESCRIPTION
Emitter PR https://github.com/microsoft/cadl/pull/41 uncovered an issue by reenabling the IDE support for emitter.

The resulting issue was the openapi emitter not able to call `isIntrinsic` correctly. This was cause by the libraries loading a different version of `decorators.js` than the standard library loaded.
The issue here was due to the path import case.

NodeJs import on the other side are case sensitive
```
// Foo is loaded only once
import "./foo.js";
import "./foo.js";

// Foo is loaded twice on a case insensitive file system and doesn't work on case sensitive ones
import "./foo.js";
import "./foO.js";
```

And this was basically the issue. In the IDE the `${workspaceRoot}` was replaced with a different casing than the actual system one(everything lowercased). This caused the compiler to be loaded initially with the wrong casing but then later with the correct one when node load path comes into play.
This result in decorators.js loaded twice and then not sharing the `Symbols`


This fix fixes it for the compiler instead of fixing the `workspaceRoot` in the IDE.

Todo: 
- Add e2e test for this in the e2e tests pr #163