### PR TITLE
Fix status code validation and other minor cleanup

### DIFF
--- a/common/changes/@cadl-lang/openapi3/minor-fixes_2022-01-23-15-34.json
+++ b/common/changes/@cadl-lang/openapi3/minor-fixes_2022-01-23-15-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Fix status code validation and other minor cleanup",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -476,7 +476,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     // regex for three character status codes:
     // - starts with 1-5
     // - last two digits are numeric or "X"
-    const statusCodePatten = /[1-5][-09X][0-9X]/;
+    const statusCodePatten = /[1-5][0-9X][0-9X]/;
     if (code.match(statusCodePatten) || code === "default") {
       return true;
     }
@@ -503,6 +503,10 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
         return "No Content";
       case "3XX":
         return "Redirection";
+      case "301":
+        return "Moved Permanently";
+      case "304":
+        return "Not Modified";
       case "4XX":
         return "Client Error";
       case "400":
@@ -513,6 +517,10 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
         return "Forbidden";
       case "404":
         return "Not Found";
+      case "409":
+        return "Conflict";
+      case "412":
+        return "Precondition Failed";
       case "5XX":
         return "Server Error";
       case "default":
@@ -528,7 +536,6 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       return desc;
     }
 
-    // We might want to throw here -- rather than giving some default
     return getDescriptionForStatusCode(statusCode);
   }
 

--- a/packages/openapi3/test/test-openapi-output.ts
+++ b/packages/openapi3/test/test-openapi-output.ts
@@ -461,7 +461,7 @@ describe("openapi3: definitions", () => {
       }
       @route("/")
       namespace root {
-        @post op create(@body body: Cat | Dog): OkResponse<{}>;
+        @post op create(@body body: Cat | Dog): { ...Response<200> };
       }
       `);
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
@@ -479,7 +479,7 @@ describe("openapi3: definitions", () => {
       }
       @route("/")
       namespace root {
-        @post op create(@body body: Cat | string): OkResponse<{}>;
+        @post op create(@body body: Cat | string): { ...Response<200> };
       }
       `);
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
@@ -500,7 +500,7 @@ describe("openapi3: definitions", () => {
     alias Pet = Cat | Dog;
     @route("/")
     namespace root {
-      @post op create(@body body: Pet): OkResponse<{}>;
+      @post op create(@body body: Pet): { ...Response<200> };
     }
     `);
     ok(openApi.components.schemas.Cat, "expected definition named Cat");

--- a/packages/samples/petstore/petstore.cadl
+++ b/packages/samples/petstore/petstore.cadl
@@ -50,7 +50,9 @@ model PetId {
 namespace Pets {
   @doc("Delete a pet.")
   @delete
-  op delete(...PetId): OkResponse<{}> | Error;
+  op delete(...PetId): {
+    ...Response<200>;
+  } | Error;
 
   @fancyDoc("List pets.")
   @pageable

--- a/packages/samples/test/output/petstore/openapi.json
+++ b/packages/samples/test/output/petstore/openapi.json
@@ -17,16 +17,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",

--- a/packages/samples/test/output/testserver/body-boolean/openapi.json
+++ b/packages/samples/test/output/testserver/body-boolean/openapi.json
@@ -43,16 +43,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",

--- a/packages/samples/test/output/testserver/body-complex/openapi.json
+++ b/packages/samples/test/output/testserver/body-complex/openapi.json
@@ -40,16 +40,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -107,16 +98,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -174,16 +156,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -241,16 +214,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -308,16 +272,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -375,16 +330,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -442,16 +388,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -509,16 +446,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -576,16 +504,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -643,16 +562,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -710,16 +620,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -777,16 +678,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -844,16 +736,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",

--- a/packages/samples/test/output/testserver/body-string/openapi.json
+++ b/packages/samples/test/output/testserver/body-string/openapi.json
@@ -49,16 +49,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -127,16 +118,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -206,16 +188,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -285,16 +258,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -362,16 +326,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -436,16 +391,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",
@@ -509,16 +455,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",

--- a/packages/samples/test/output/testserver/body-time/openapi.json
+++ b/packages/samples/test/output/testserver/body-time/openapi.json
@@ -41,16 +41,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {},
-                  "x-cadl-name": "(anonymous model)"
-                }
-              }
-            }
+            "description": "Ok"
           },
           "default": {
             "description": "Error",

--- a/packages/samples/testserver/body-boolean/body-boolean.cadl
+++ b/packages/samples/testserver/body-boolean/body-boolean.cadl
@@ -22,7 +22,9 @@ namespace BoolsTrue {
   @doc("Set Boolean value true")
   @operationId("bool_putTrue")
   @put
-  op setTrue(@body value: true): OkResponse<{}> | Error;
+  op setTrue(@body value: true): {
+    ...Response<200>;
+  } | Error;
 }
 
 @doc("AutoRest Bool Test Service")

--- a/packages/samples/testserver/body-complex/body-complex.cadl
+++ b/packages/samples/testserver/body-complex/body-complex.cadl
@@ -102,7 +102,9 @@ namespace Complex {
   @doc("Please put {id: 2, name: 'abc', color: 'Magenta'}")
   @route("/basic/valid")
   @put
-  op putValid(@body value: Basic): OkResponse<{}> | Error;
+  op putValid(@body value: Basic): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get complex types with integer properties")
   @route("/primitive/integer")
@@ -111,7 +113,9 @@ namespace Complex {
   @doc("Put complex types with integer properties")
   @route("/primitive/integer")
   @put
-  op putInt(@body value: IntWrapper): OkResponse<{}> | Error;
+  op putInt(@body value: IntWrapper): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get complex types with long properties")
   @route("/primitive/long")
@@ -121,7 +125,9 @@ namespace Complex {
   @doc("Put complex types with long properties")
   @route("/primitive/long")
   @put
-  op putLong(@body value: LongWrapper): OkResponse<{}> | Error;
+  op putLong(@body value: LongWrapper): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get complex types with float properties")
   @route("/primitive/float")
@@ -131,7 +137,9 @@ namespace Complex {
   @doc("Put complex types with float properties")
   @route("/primitive/float")
   @put
-  op putFloat(@body value: FloatWrapper): OkResponse<{}> | Error;
+  op putFloat(@body value: FloatWrapper): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get complex types with double properties")
   @route("/primitive/double")
@@ -141,7 +149,9 @@ namespace Complex {
   @doc("Put complex types with double properties")
   @route("/primitive/double")
   @put
-  op putDouble(@body value: DoubleWrapper): OkResponse<{}> | Error;
+  op putDouble(@body value: DoubleWrapper): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get complex types with bool properties")
   @route("/primitive/bool")
@@ -151,7 +161,9 @@ namespace Complex {
   @doc("Put complex types with bool properties")
   @route("/primitive/bool")
   @put
-  op putBool(@body value: BooleanWrapper): OkResponse<{}> | Error;
+  op putBool(@body value: BooleanWrapper): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get complex types with string properties")
   @route("/primitive/string")
@@ -161,7 +173,9 @@ namespace Complex {
   @doc("Put complex types with string properties")
   @route("/primitive/string")
   @put
-  op putString(@body value: StringWrapper): OkResponse<{}> | Error;
+  op putString(@body value: StringWrapper): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get complex types with date properties")
   @route("/primitive/date")
@@ -171,7 +185,9 @@ namespace Complex {
   @doc("Put complex types with date properties")
   @route("/primitive/date")
   @put
-  op putPlainDate(@body value: PlainDateWrapper): OkResponse<{}> | Error;
+  op putPlainDate(@body value: PlainDateWrapper): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get complex types with DateTime properties")
   @route("/primitive/datetime")
@@ -181,7 +197,9 @@ namespace Complex {
   @doc("Put complex types with DateTime properties")
   @route("/primitive/datetime")
   @put
-  op putZonedDateTime(@body value: DateTimeWrapper): OkResponse<{}> | Error;
+  op putZonedDateTime(@body value: DateTimeWrapper): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get complex types with Duration properties")
   @route("/primitive/duration")
@@ -191,7 +209,9 @@ namespace Complex {
   @doc("Put complex types with Duration properties")
   @route("/primitive/duration")
   @put
-  op putZonedDuration(@body value: DurationWrapper): OkResponse<{}> | Error;
+  op putZonedDuration(@body value: DurationWrapper): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get complex types with bytes properties")
   @route("/primitive/bytes")
@@ -201,7 +221,9 @@ namespace Complex {
   @doc("Put complex types with bytes properties")
   @route("/primitive/bytes")
   @put
-  op putBytes(@body value: BytesWrapper): OkResponse<{}> | Error;
+  op putBytes(@body value: BytesWrapper): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get complex types with array properties")
   @route("/array/valid")
@@ -210,7 +232,9 @@ namespace Complex {
   @doc("Put complex types with array properties")
   @route("/array/valid")
   @put
-  op putArray(@body value: ArrayWrapper): OkResponse<{}> | Error;
+  op putArray(@body value: ArrayWrapper): {
+    ...Response<200>;
+  } | Error;
 
   @route("/dictionary")
   namespace Dictionary {
@@ -222,6 +246,8 @@ namespace Complex {
     @doc("Put complex types with dictionary property")
     @route("/typed/valid")
     @put
-    op putArray(@body value: DictionaryWrapper): OkResponse<{}> | Error;
+    op putArray(@body value: DictionaryWrapper): {
+      ...Response<200>;
+    } | Error;
   }
 }

--- a/packages/samples/testserver/body-string/body-string.cadl
+++ b/packages/samples/testserver/body-string/body-string.cadl
@@ -21,7 +21,9 @@ namespace String {
   @doc("Put null string value")
   @route("null")
   @put
-  op putNull(@body value: string | null): OkResponse<{}> | Error;
+  op putNull(@body value: string | null): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get empty string value")
   @route("empty")
@@ -31,7 +33,9 @@ namespace String {
   @doc("Put empty string value")
   @route("empty")
   @put
-  op putEmpty(@body value: ""): OkResponse<{}> | Error;
+  op putEmpty(@body value: ""): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'")
   @route("mbcs")
@@ -45,7 +49,9 @@ namespace String {
   op putMbCs(
     @body
     value: "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€"
-  ): OkResponse<{}> | Error;
+  ): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'")
   @route("whitespace")
@@ -58,7 +64,9 @@ namespace String {
   @put
   op putWhitespace(
     @body value: "   Now is the time for all good men to come to the aid of their country    "
-  ): OkResponse<{}> | Error;
+  ): {
+    ...Response<200>;
+  } | Error;
 
   @doc("Get value that is base64 encoded")
   @route("base64Encoding")
@@ -68,7 +76,9 @@ namespace String {
   @doc("Put value that is base64 encoded")
   @route("base64Encoding")
   @put
-  op putBase64Encoding(@body value: bytes): OkResponse<{}> | Error;
+  op putBase64Encoding(@body value: bytes): {
+    ...Response<200>;
+  } | Error;
 
   @route("enum")
   namespace Enums {
@@ -80,7 +90,9 @@ namespace String {
     @doc("Put non expandable string enum value")
     @route("empty")
     @put
-    op putNotExpandable(@body value: Colors): OkResponse<{}> | Error;
+    op putNotExpandable(@body value: Colors): {
+      ...Response<200>;
+    } | Error;
 
     @doc("Gets value 'green-color' from a constant")
     @route("constant")
@@ -90,7 +102,9 @@ namespace String {
     @doc("Sends value 'green-color' from a constant")
     @route("constant")
     @put
-    op putConstant(@body value: Colors): OkResponse<{}> | Error;
+    op putConstant(@body value: Colors): {
+      ...Response<200>;
+    } | Error;
   }
 }
 

--- a/packages/samples/testserver/body-time/body-time.cadl
+++ b/packages/samples/testserver/body-time/body-time.cadl
@@ -18,5 +18,7 @@ namespace Time {
 
   @doc("Put time value \"08:07:56\"")
   @put
-  op put(@body value: plainTime): OkResponse<{}> | Error;
+  op put(@body value: plainTime): {
+    ...Response<200>;
+  } | Error;
 }


### PR DESCRIPTION
This PR fixes a bug in the regex for validating status codes. I also folded in a few other minor fixes. Most notably is that I removed all occurrences of `OkResponse<{}>`, generally replacing them with `{ ...Response<200> }`, to avoid the generation of an empty object body schema.