### PR TITLE
Feature: Validate operation have a unique verb&path combination

### DIFF
--- a/common/changes/@cadl-lang/rest/feature-validate-path-unique_2022-01-25-01-08.json
+++ b/common/changes/@cadl-lang/rest/feature-validate-path-unique_2022-01-25-01-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "**Added** Validation for uniquness of operation by verb and path",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/src/diagnostics.ts
+++ b/packages/rest/src/diagnostics.ts
@@ -79,6 +79,12 @@ const libDefinition = {
         default: paramMessage`Param ${"paramName"} has multiple types: [${"types"}]`,
       },
     },
+    "duplicate-operation": {
+      severity: "error",
+      messages: {
+        default: paramMessage`Duplicate operation routed at "${"verb"} ${"path"}".`,
+      },
+    },
   },
 } as const;
 

--- a/packages/rest/src/diagnostics.ts
+++ b/packages/rest/src/diagnostics.ts
@@ -82,7 +82,7 @@ const libDefinition = {
     "duplicate-operation": {
       severity: "error",
       messages: {
-        default: paramMessage`Duplicate operation routed at "${"verb"} ${"path"}".`,
+        default: paramMessage`Duplicate operation "${"operationName"}" routed at "${"verb"} ${"path"}".`,
       },
     },
   },

--- a/packages/rest/src/route.ts
+++ b/packages/rest/src/route.ts
@@ -412,7 +412,6 @@ function validateRouteUnique(program: Program, operations: OperationDetails[]) {
     list.push(operation);
   }
 
-  console.log("Look for dups");
   for (const [path, map] of grouped) {
     for (const [verb, routes] of map) {
       if (routes.length >= 2) {

--- a/packages/rest/src/route.ts
+++ b/packages/rest/src/route.ts
@@ -418,7 +418,7 @@ function validateRouteUnique(program: Program, operations: OperationDetails[]) {
         for (const route of routes) {
           reportDiagnostic(program, {
             code: "duplicate-operation",
-            format: { path, verb },
+            format: { path, verb, operationName: route.operation.name },
             target: route.operation,
           });
         }

--- a/packages/rest/src/route.ts
+++ b/packages/rest/src/route.ts
@@ -388,7 +388,44 @@ export function getAllRoutes(program: Program): OperationDetails[] {
     operations = [...operations, ...newOps];
   }
 
+  validateRouteUnique(program, operations);
   return operations;
+}
+
+function validateRouteUnique(program: Program, operations: OperationDetails[]) {
+  const grouped = new Map<string, Map<HttpVerb, OperationDetails[]>>();
+
+  for (const operation of operations) {
+    const { verb, path } = operation;
+    let map = grouped.get(path);
+    if (map === undefined) {
+      map = new Map<HttpVerb, OperationDetails[]>();
+      grouped.set(path, map);
+    }
+
+    let list = map.get(verb);
+    if (list === undefined) {
+      list = [];
+      map.set(verb, list);
+    }
+
+    list.push(operation);
+  }
+
+  console.log("Look for dups");
+  for (const [path, map] of grouped) {
+    for (const [verb, routes] of map) {
+      if (routes.length >= 2) {
+        for (const route of routes) {
+          reportDiagnostic(program, {
+            code: "duplicate-operation",
+            format: { path, verb },
+            target: route.operation,
+          });
+        }
+      }
+    }
+  }
 }
 
 // TODO: Make this overridable by libraries

--- a/packages/rest/test/test-routes.ts
+++ b/packages/rest/test/test-routes.ts
@@ -180,6 +180,23 @@ describe("rest: routes", () => {
     strictEqual(diagnostics[0].message, "Operation get has a body but doesn't specify a verb.");
   });
 
+  it("emit diagnostics if 2 operation have the same path and verb", async () => {
+    const [_, diagnostics] = await compileOperations(`
+        @route("/test")
+        op get1(): string;
+
+        @route("/test")
+        op get2(): string;
+    `);
+
+    // Has one diagnostic per duplicate operation
+    strictEqual(diagnostics.length, 2);
+    strictEqual(diagnostics[0].code, "@cadl-lang/rest/duplicate-operation");
+    strictEqual(diagnostics[0].message, `Duplicate operation routed at "get /test".`);
+    strictEqual(diagnostics[1].code, "@cadl-lang/rest/duplicate-operation");
+    strictEqual(diagnostics[1].message, `Duplicate operation routed at "get /test".`);
+  });
+
   describe("operation parameters", () => {
     it("emit diagnostic for parameters with multiple http request annotations", async () => {
       const [_, diagnostics] = await compileOperations(`

--- a/packages/rest/test/test-routes.ts
+++ b/packages/rest/test/test-routes.ts
@@ -192,9 +192,9 @@ describe("rest: routes", () => {
     // Has one diagnostic per duplicate operation
     strictEqual(diagnostics.length, 2);
     strictEqual(diagnostics[0].code, "@cadl-lang/rest/duplicate-operation");
-    strictEqual(diagnostics[0].message, `Duplicate operation routed at "get /test".`);
+    strictEqual(diagnostics[0].message, `Duplicate operation "get1" routed at "get /test".`);
     strictEqual(diagnostics[1].code, "@cadl-lang/rest/duplicate-operation");
-    strictEqual(diagnostics[1].message, `Duplicate operation routed at "get /test".`);
+    strictEqual(diagnostics[1].message, `Duplicate operation "get2" routed at "get /test".`);
   });
 
   describe("operation parameters", () => {


### PR DESCRIPTION
fix #103

Emit a diagnostic if there is 2 operations that have the same path and verb combination

![image](https://user-images.githubusercontent.com/1031227/150891812-41e204d4-cfb5-4deb-ab91-3c783f35d764.png)
