### PR TITLE
Rework status codes

### DIFF
--- a/common/changes/@cadl-lang/openapi/2022-02-05-17-17.json
+++ b/common/changes/@cadl-lang/openapi/2022-02-05-17-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "refactor status code handling to http library",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/openapi3/2022-02-05-17-17.json
+++ b/common/changes/@cadl-lang/openapi3/2022-02-05-17-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "refactor status code handling to http library",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/2022-02-05-17-17.json
+++ b/common/changes/@cadl-lang/rest/2022-02-05-17-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "refactor status code handling to http library",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -52,3 +52,22 @@ export function getExtensions(program: Program, entity: Type): ReadonlyMap<Exten
 function isOpenAPIExtensionKey(key: string): key is ExtensionKey {
   return key.startsWith("x-");
 }
+
+// The @defaultResponse decorator can be applied to a model. When that model is used
+// as the return type of an operation, this return type will be the default response.
+const defaultResponseKey = Symbol();
+export function $defaultResponse({ program }: DecoratorContext, entity: Type) {
+  if (entity.kind !== "Model") {
+    reportDiagnostic(program, {
+      code: "decorator-wrong-type",
+      format: { decorator: "default", entityKind: entity.kind },
+      target: entity,
+    });
+    return;
+  }
+  program.stateSet(defaultResponseKey).add(entity);
+}
+
+export function isDefaultResponse(program: Program, entity: Type): boolean {
+  return program.stateSet(defaultResponseKey).has(entity);
+}

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -52,12 +52,10 @@ export const libDef = {
         default: "contentType parameter must be a string literal or union of string literals",
       },
     },
-    "status-code-invalid": {
+    "status-code-in-default-response": {
       severity: "error",
       messages: {
-        default:
-          "status-code header must be a numeric or string literal or union of numeric or string literals",
-        value: "status-code value must be a specific code between 100 and 599, or nXX, or default",
+        default: "a default response should not have an explicit status code",
       },
     },
     "invalid-schema": {

--- a/packages/rest/src/diagnostics.ts
+++ b/packages/rest/src/diagnostics.ts
@@ -93,6 +93,14 @@ const libDefinition = {
         default: paramMessage`Duplicate operation "${"operationName"}" routed at "${"verb"} ${"path"}".`,
       },
     },
+    "status-code-invalid": {
+      severity: "error",
+      messages: {
+        default:
+          "statusCode value must be a numeric or string literal or union of numeric or string literals",
+        value: "statusCode value must be a three digit code between 100 and 599",
+      },
+    },
   },
 } as const;
 

--- a/packages/samples/documentation/docs.cadl
+++ b/packages/samples/documentation/docs.cadl
@@ -24,14 +24,14 @@ model RespWithDocs {
   value: int32;
 }
 
+@error
 model Error {
-  @statusCode _: "default";
   code: int32;
 }
 
 @doc("Error from @doc")
+@error
 model ErrorWithDocs {
-  @statusCode _: "default";
   code: int32;
 }
 

--- a/packages/samples/grpc-kiosk-example/types.cadl
+++ b/packages/samples/grpc-kiosk-example/types.cadl
@@ -1,3 +1,5 @@
+import "@cadl-lang/openapi";
+
 using Cadl.Http;
 
 //
@@ -30,8 +32,8 @@ model LatLng {
 model Empty {}
 
 @doc("An unexpected error response.")
+@error
 model RpcStatus {
-  @statusCode _: "default";
   code?: int32;
   message?: string;
   details?: ProtobufAny[];

--- a/packages/samples/grpc-library-example/library.cadl
+++ b/packages/samples/grpc-library-example/library.cadl
@@ -267,8 +267,8 @@ page of results.
 model Empty {}
 
 @doc("An unexpected error response.")
+@error
 model RpcStatus {
-  @statusCode _: "default";
   code?: int32;
   message?: string;
   details?: ProtobufAny[];

--- a/packages/samples/petstore/petstore.cadl
+++ b/packages/samples/petstore/petstore.cadl
@@ -25,8 +25,8 @@ model Toy {
 }
 
 @doc("Error")
+@error
 model Error {
-  @statusCode _: "default";
   code: int32;
   message: string;
 }

--- a/packages/samples/rest/petstore/petstore.cadl
+++ b/packages/samples/rest/petstore/petstore.cadl
@@ -1,4 +1,5 @@
 import "@cadl-lang/rest";
+import "@cadl-lang/openapi";
 
 @autoRoute
 @serviceTitle("Pet Store Service")
@@ -9,8 +10,8 @@ using Cadl.Http;
 using Cadl.Rest;
 using Cadl.Rest.Resource;
 
+@error
 model PetStoreError {
-  @statusCode _: "default";
   code: int32;
   message: string;
 }

--- a/packages/samples/testserver/body-boolean/body-boolean.cadl
+++ b/packages/samples/testserver/body-boolean/body-boolean.cadl
@@ -4,8 +4,8 @@ import "@cadl-lang/openapi";
 using Cadl.Http;
 
 @doc("Error")
+@error
 model Error {
-  @statusCode _: "default";
   code: int32;
   message: string;
 }

--- a/packages/samples/testserver/body-complex/body-complex.cadl
+++ b/packages/samples/testserver/body-complex/body-complex.cadl
@@ -1,10 +1,11 @@
 import "@cadl-lang/rest";
+import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
 @doc("Error")
+@error
 model Error {
-  @statusCode status: "default";
   message: string;
 }
 

--- a/packages/samples/testserver/body-string/body-string.cadl
+++ b/packages/samples/testserver/body-string/body-string.cadl
@@ -1,10 +1,11 @@
 import "@cadl-lang/rest";
+import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
 @doc("Error")
+@error
 model Error {
-  @statusCode _: "default";
   status: int32;
   message: string;
 }

--- a/packages/samples/testserver/body-time/body-time.cadl
+++ b/packages/samples/testserver/body-time/body-time.cadl
@@ -1,10 +1,11 @@
 import "@cadl-lang/rest";
+import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
 @doc("Error")
+@error
 model Error {
-  @statusCode _: "default";
   status: int32;
   message: string;
 }

--- a/packages/samples/testserver/multiple-inheritance/multiple-inheritance.cadl
+++ b/packages/samples/testserver/multiple-inheritance/multiple-inheritance.cadl
@@ -1,4 +1,5 @@
 import "@cadl-lang/rest";
+import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
@@ -24,8 +25,8 @@ model Horse extends Pet {
 }
 
 @doc("Unexpected error")
+@error
 model ErrorResponse {
-  @statusCode _: "default";
   @body body: string;
 }
 


### PR DESCRIPTION
This PR illustrates the change I am proposing in #197.  Some work is still needed to polish this up but I think the key features are there -- enough to illustrate the proposal.

Key elements:
- the http library now validates and processes the target property of the `@statusCode` decorator.  The property value must be a numeric or string literal or union of numeric or string literals which are three digit codes starting with 1-5.
- the openapi library implements a new decorator `@default` (might want a different name) to specify that the decorated model should be the "default" response of an operation.

I did not implement decorators for "2XX", "4XX", or "5XX" response codes, but these would be very similar to the `@default` decorator.