### PR TITLE
Add `friendlyName` decorator to customize model names for emitters

### DIFF
--- a/common/changes/@cadl-lang/compiler/friendly-names_2022-01-28-14-46.json
+++ b/common/changes/@cadl-lang/compiler/friendly-names_2022-01-28-14-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add @friendlyName decorator to customize model names for emitters",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi3/friendly-names_2022-01-28-14-46.json
+++ b/common/changes/@cadl-lang/openapi3/friendly-names_2022-01-28-14-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Use assigned @friendlyName on model types when emitting schema definitions and refs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/compiler/test/decorators/decorators.ts
+++ b/packages/compiler/test/decorators/decorators.ts
@@ -1,5 +1,5 @@
 import { strictEqual } from "assert";
-import { getDoc } from "../../lib/decorators.js";
+import { getDoc, getFriendlyName } from "../../lib/decorators.js";
 import { createTestHost, TestHost } from "../test-host.js";
 
 describe("compiler: built-in decorators", () => {
@@ -64,6 +64,36 @@ describe("compiler: built-in decorators", () => {
         diagnostics[0].message,
         `Argument 'foo | bar' of type 'object' is not assignable to parameter of type 'string'`
       );
+    });
+  });
+
+  describe("@friendlyName", () => {
+    it("applies @doc on model", async () => {
+      testHost.addCadlFile(
+        "main.cadl",
+        `
+        @test
+        @friendlyName("MyNameIsA")
+        model A { }
+
+        @test
+        @friendlyName("{name}Model", B)
+        model B { }
+
+        @friendlyName("Templated{name}", T)
+        model Templated<T> {
+          prop: T;
+        }
+
+        @test
+        model C is Templated<B>{};
+        `
+      );
+
+      const { A, B, C } = await testHost.compile("./");
+      strictEqual(getFriendlyName(testHost.program, A), "MyNameIsA");
+      strictEqual(getFriendlyName(testHost.program, B), "BModel");
+      strictEqual(getFriendlyName(testHost.program, C), "TemplatedB");
     });
   });
 });

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -7,6 +7,7 @@ import {
   getAllTags,
   getDoc,
   getFormat,
+  getFriendlyName,
   getMaxLength,
   getMaxValue,
   getMinLength,
@@ -1248,8 +1249,14 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
   }
 
   function getTypeNameForSchemaProperties(type: Type) {
+    // If there's a friendly name for the type, use that instead
+    let typeName = getFriendlyName(program, type);
+    if (typeName) {
+      return typeName;
+    }
+
     // Try to shorten the type name to exclude the top-level service namespace
-    let typeName = program!.checker!.getTypeName(type).replace(/<([\w\.]+)>/, "_$1");
+    typeName = program!.checker!.getTypeName(type).replace(/<([\w\.]+)>/, "_$1");
 
     if (isRefSafeName(typeName)) {
       if (serviceNamespace) {

--- a/packages/samples/petstore/petstore.cadl
+++ b/packages/samples/petstore/petstore.cadl
@@ -36,6 +36,7 @@ model NotModified<T> {
   @body body: T;
 }
 
+@friendlyName("{name}ListResults", T)
 model ResponsePage<T> {
   items: T[];
   nextLink?: string;

--- a/packages/samples/test/output/petstore/openapi.json
+++ b/packages/samples/test/output/petstore/openapi.json
@@ -102,7 +102,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ResponsePage_Pet"
+                  "$ref": "#/components/schemas/PetListResults"
                 }
               }
             }
@@ -182,7 +182,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ResponsePage_Toy"
+                  "$ref": "#/components/schemas/ToyListResults"
                 }
               }
             }
@@ -231,7 +231,7 @@
           "message"
         ]
       },
-      "ResponsePage_Pet": {
+      "PetListResults": {
         "type": "object",
         "properties": {
           "items": {
@@ -270,7 +270,7 @@
           "age"
         ]
       },
-      "ResponsePage_Toy": {
+      "ToyListResults": {
         "type": "object",
         "properties": {
           "items": {


### PR DESCRIPTION
This change adds a new `@friendlyName` decorator that makes it possible to customize the names of models when they pass through an emitter.  Emitters will (for now) need to know to look up the friendly name with `getFriendlyName`.

This is particularly useful for templated types where the names come out mangled in OpenAPI, you can now use `@friendlyName("{name}SomePrefix", T)` to customize a templated model's name based on the name of the template parameter type.

Check out the updated PetStore spec output for an example of how this looks in practice:

- Input: https://github.com/microsoft/cadl/pull/209/files#diff-8e44034bc2de16013fd4a43f1a85b3d5af3072fe215f420a220dafa166dbeba4
- Output: https://github.com/microsoft/cadl/pull/209/files#diff-62f1e41e23375bad5693b79a8b254ed2dbd68dc4cf8d4ed75c6be90833cc5f7b