### PR TITLE
Add @error decorator and openapi3 support

### DIFF
--- a/common/changes/@cadl-lang/compiler/error-decorator_2022-01-28-17-00.json
+++ b/common/changes/@cadl-lang/compiler/error-decorator_2022-01-28-17-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add @error decorator in core",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi3/error-decorator_2022-01-28-22-09.json
+++ b/common/changes/@cadl-lang/openapi3/error-decorator_2022-01-28-22-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "openapi3 emitter support for @error decorator",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -130,6 +130,30 @@ export function isNumericType(program: Program, target: Type): boolean {
   return intrinsicType !== undefined && program.stateSet(numericTypesKey).has(intrinsicType);
 }
 
+// -- @error decorator ----------------------
+
+const errorKey = Symbol();
+
+export function $error(program: Program, target: Type) {
+  if (target.kind !== "Model") {
+    program.reportDiagnostic(
+      createDiagnostic({
+        code: "decorator-wrong-target",
+        messageId: "model",
+        format: { decorator: "@error" },
+        target,
+      })
+    );
+    return;
+  }
+
+  program.stateSet(errorKey).add(target);
+}
+
+export function isErrorModel(program: Program, target: Type): boolean {
+  return program.stateSet(errorKey).has(target);
+}
+
 // -- @format decorator ---------------------
 
 const formatValuesKey = Symbol();

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -19,6 +19,7 @@ import {
   getServiceTitle,
   getServiceVersion,
   getVisibility,
+  isErrorModel,
   isErrorType,
   isIntrinsic,
   isNumericType,
@@ -384,8 +385,12 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
 
     // If there is no explicit status code, set the default
     if (statusCodes.length === 0) {
-      const defaultStatusCode = bodyModel ? "200" : "204";
-      statusCodes.push(defaultStatusCode);
+      if (bodyModel) {
+        const defaultStatusCode = isErrorModel(program, bodyModel) ? "default" : "200";
+        statusCodes.push(defaultStatusCode);
+      } else {
+        statusCodes.push("204");
+      }
     }
 
     // If there is a body but no explicit content types, use application/json


### PR DESCRIPTION
This PR adds the @error decorator in the core and also support in the openapi3 emitter to set an @error-decorated model as the "default" response if no explicit status code is defined.