### PR TITLE
Also configure code coverage upload in CI

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -30,6 +30,8 @@ jobs:
       - script: node common/scripts/install-run-rush.js test-official
         displayName: Test
 
+      - template: ./upload-coverage.yml
+
       - script: |
           set NPM_AUTH_TOKEN=$(azure-sdk-npm-token)
           node common/scripts/install-run-rush.js publish --publish --include-all --set-access-level public

--- a/eng/pipelines/pull-request-common.yml
+++ b/eng/pipelines/pull-request-common.yml
@@ -24,14 +24,7 @@ steps:
   - script: node common/scripts/install-run-rush.js test-official
     displayName: Test
 
-  - script: node common/scripts/install-run-rush.js merge-coverage
-    displayName: Merge code coverage
-
-  - task: PublishCodeCoverageResults@1
-    inputs:
-      codeCoverageTool: "Cobertura"
-      summaryFileLocation: $(Build.SourcesDirectory)/coverage/cobertura-coverage.xml
-    displayName: Publish code coverage
+  - template: ./upload-coverage.yml
 
   - script: node common/scripts/install-run-rush.js check-format
     displayName: Check Formatting

--- a/eng/pipelines/upload-coverage.yml
+++ b/eng/pipelines/upload-coverage.yml
@@ -1,0 +1,9 @@
+steps:
+  - script: node common/scripts/install-run-rush.js merge-coverage
+    displayName: Merge code coverage
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: "Cobertura"
+      summaryFileLocation: $(Build.SourcesDirectory)/coverage/cobertura-coverage.xml
+    displayName: Publish code coverage


### PR DESCRIPTION
In #208 Only did it for the pull request so we won't really be able to keep track of the current coverage in `main` without this