### PR TITLE
Allow CLI array options to come before positional arguments

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-array-options-before-args_2022-02-03-22-47.json
+++ b/common/changes/@cadl-lang/compiler/fix-array-options-before-args_2022-02-03-22-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Allow CLI array options to come before positional arguments",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/cli.ts
+++ b/packages/compiler/core/cli.ts
@@ -24,6 +24,9 @@ async function main() {
     .scriptName("cadl")
     .help()
     .strict()
+    .parserConfiguration({
+      "greedy-arrays": false,
+    })
     .option("debug", {
       type: "boolean",
       description: "Output debug log messages.",


### PR DESCRIPTION
You could not do `cadl compile --import X main.cadl` or `cadl --emit X main.cadl` because this would be interpreted as importing X and main.cadl or emitting using X and main.cadl.

The fix is to disable this "greedy array" behavior in yargs. It means that you have to repeat --import or --emit to specify multiple options, but that seems fine.