### PR TITLE
Fix bugs with projections, decorators and merged namespaces

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-dec-ns-merge_2022-02-08-00-55.json
+++ b/common/changes/@cadl-lang/compiler/fix-dec-ns-merge_2022-02-08-00-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix bugs involving merged decorators",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/binder.ts
+++ b/packages/compiler/core/binder.ts
@@ -402,6 +402,11 @@ export function createBinder(program: Program, options: BinderOptions = {}): Bin
 
       // todo: don't merge exports
       statement.exports = (existingBinding.node as NamespaceStatementNode).exports;
+      if (!existingBinding.merged) {
+        existingBinding.merged = true;
+        existingBinding.nodes = [existingBinding.node];
+      }
+      existingBinding.nodes?.push(statement);
     } else {
       declareSymbol(getContainingSymbolTable(), statement, statement.name.sv);
 

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -285,6 +285,10 @@ export interface TypeSymbol {
   kind: "type";
   node: Node;
   name: string;
+  merged?: boolean;
+  // for merged nodes, this lists all the nodes
+  // that contribute to this symbol.
+  nodes?: Node[];
   id?: number;
 }
 

--- a/packages/compiler/test/checker/namespaces.ts
+++ b/packages/compiler/test/checker/namespaces.ts
@@ -133,6 +133,106 @@ describe("compiler: namespaces with blocks", () => {
     strictEqual(Z.properties.size, 2, "has two properties");
   });
 
+  it("runs all decorators on merged namespaces", async () => {
+    const reds = new WeakSet();
+    let isRedDuringRef = false;
+    let isBlueDuringRef = false;
+    testHost.addJsFile("red.js", {
+      $red(p: Program, t: Type) {
+        reds.add(t);
+      },
+      $ref(p: Program, t: Type, arg: Type) {
+        isRedDuringRef = reds.has(arg);
+        isBlueDuringRef = blues.has(arg);
+      },
+    });
+
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+      import "./blue.js";
+      import "./red.js";
+
+      @ref(N)
+      namespace A { }
+      
+      @red
+      @test
+      namespace N {}
+
+      @blue
+      namespace N {}
+      `
+    );
+
+    const { N } = (await testHost.compile("./")) as {
+      N: NamespaceType;
+    };
+
+    ok(reds.has(N), "is ultimately red"); // passes
+    ok(blues.has(N), "is ultimately blue"); // passes
+
+    ok(isRedDuringRef, "red at ref point");
+    ok(isBlueDuringRef, "blue at ref point"); // fails
+  });
+
+  it("runs all decorators on merged namespaces across files", async () => {
+    const reds = new WeakSet();
+    let isRedDuringRef = false;
+    let isBlueDuringRef = false;
+    testHost.addJsFile("red.js", {
+      $red(p: Program, t: Type) {
+        reds.add(t);
+      },
+      $ref(p: Program, t: Type, arg: Type) {
+        isRedDuringRef = reds.has(arg);
+        isBlueDuringRef = blues.has(arg);
+      },
+    });
+
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+      import "./blue.js";
+      import "./red.js";
+      import "./one.cadl";
+      import "./two.cadl";
+      
+      @ref(N)
+      namespace A { }
+    
+      `
+    );
+
+    testHost.addCadlFile(
+      "one.cadl",
+      `
+      @red
+      @test
+      namespace N {}
+    
+      `
+    );
+
+    testHost.addCadlFile(
+      "two.cadl",
+      `
+      @blue
+      namespace N {}
+      `
+    );
+
+    const { N } = (await testHost.compile("./")) as {
+      N: NamespaceType;
+    };
+
+    ok(reds.has(N), "is ultimately red"); // passes
+    ok(blues.has(N), "is ultimately blue"); // passes
+
+    ok(isRedDuringRef, "red at ref point");
+    ok(isBlueDuringRef, "blue at ref point"); // fails
+  });
+
   it("can see things in outer scope same file", async () => {
     testHost.addCadlFile(
       "main.cadl",


### PR DESCRIPTION
There were a few bugs with how we were handling executing decorators on merged namespaces. Previously, if we came across a node for a namespace we had already checked, we would run the decorators on that node. This worked for simple cases, but the problem arose when a decorator had a forward reference to a namespace that hadn't been checked. In that case, we would run decorators only on the first namespace node that contributed to the namespace (and then run the decorators on that node again when we got to that node in `checkProgram`, along with the rest of the nodes). Because of this, the view of the namespace from the perspective of the decorator receiving it as an argument wouldn't include all the decorators on it (or no decorators at all if the first node was a synthetic namespace node from a JS file import).

The fix is to track all the nodes that contribute to a binding in the symbol. Then, in `initializeTypeForNamespace` we can make sure to iterate over all the nodes and capture all the decorators.

Additionally, the check for duplicate usings was keying off of the namespace name, which had the effect of kicking of type checking for certain namespaces far earlier than intended. While I didn't find any bugs associated with this, it is best to make sure things happen in a predictable order that is unaffected by usings. The new approach checks for duplicates using symbols. And as a result I think the error will be more useful (e.g. previously we would report an error on using `A.B.C` even though the user had only typed `using C` as they were already in namespace `B`).

Lastly, projections did not initialize namespaces upfront like the checker does. While I believe this approach was likely fine with projections, since we would never "see" a namespace without first projecting it and therefore running decorators on it, the new approach tracks the checker's order of operations and so should be less likely to suffer weirdness due to decorators executing in a different order from the checker.