### PR TITLE
Update decorators to take in `DecoratorContext` instead of `Program`

### DIFF
--- a/common/changes/@cadl-lang/compiler/refactor-decorator-context_2022-02-08-23-48.json
+++ b/common/changes/@cadl-lang/compiler/refactor-decorator-context_2022-02-08-23-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Update api for decorator taking `DecoratorContext` instead of `Program`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi/refactor-decorator-context_2022-02-08-23-48.json
+++ b/common/changes/@cadl-lang/openapi/refactor-decorator-context_2022-02-08-23-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "Update decorators to take in api change",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/openapi3/refactor-decorator-context_2022-02-08-23-48.json
+++ b/common/changes/@cadl-lang/openapi3/refactor-decorator-context_2022-02-08-23-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Update decorators to take in api change",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/refactor-decorator-context_2022-02-08-23-48.json
+++ b/common/changes/@cadl-lang/rest/refactor-decorator-context_2022-02-08-23-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Update decorators to take in api change",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/versioning/refactor-decorator-context_2022-02-09-17-34.json
+++ b/common/changes/@cadl-lang/versioning/refactor-decorator-context_2022-02-09-17-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "Update decorators to take in api change",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -2,6 +2,7 @@ import { inspect } from "util";
 import { createSymbolTable } from "./binder.js";
 import { compilerAssert, ProjectionError } from "./diagnostics.js";
 import {
+  DecoratorContext,
   ProjectionModelExpressionNode,
   ProjectionModelPropertyNode,
   ProjectionModelSpreadPropertyNode,
@@ -2001,7 +2002,8 @@ export function createChecker(program: Program): Checker {
 
     try {
       const fn = decApp.decorator;
-      fn(program, target, ...decApp.args);
+      const context: DecoratorContext = { program };
+      fn(context, target, ...decApp.args);
     } catch (error: any) {
       // do not fail the language server for exceptions in decorators
       if (program.compilerOptions.designTimeBuild) {

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -2795,7 +2795,7 @@ export function createChecker(program: Program): Checker {
     return createType({
       kind: "Function",
       call(...args: Type[]): Type {
-        let retval = ref.value(program, ...marshalProjectionArguments(args));
+        let retval = ref.value({ program }, ...marshalProjectionArguments(args));
         return voidType;
       },
     } as const);

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -13,7 +13,7 @@ export interface DecoratorApplication {
 }
 
 export interface DecoratorFunction {
-  (program: Program, target: Type, ...customArgs: any[]): void;
+  (program: DecoratorContext, target: Type, ...customArgs: any[]): void;
   namespace?: string;
 }
 
@@ -1226,6 +1226,10 @@ export type EmitOptionsFor<C> = C extends CadlLibrary<infer T, infer E> ? EmitOp
 
 export interface EmitOptions<E extends string> {
   name?: E;
+}
+
+export interface DecoratorContext {
+  program: Program;
 }
 
 export type LogLevel = "debug" | "verbose" | "info" | "warning" | "error";

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -1,6 +1,7 @@
 import { createDiagnostic, reportDiagnostic } from "../core/messages.js";
 import { Program } from "../core/program.js";
 import {
+  DecoratorContext,
   InterfaceType,
   ModelType,
   ModelTypeProperty,
@@ -23,7 +24,12 @@ function replaceTemplatedStringFromProperties(formatString: string, sourceObject
 }
 
 const docsKey = Symbol();
-export function $doc(program: Program, target: Type, text: string, sourceObject: Type) {
+export function $doc(
+  { program }: DecoratorContext,
+  target: Type,
+  text: string,
+  sourceObject: Type
+) {
   // TODO: replace with built-in decorator validation https://github.com/Azure/cadl-azure/issues/1022
   if (!validateDecoratorParamType(program, target, text, "string")) {
     return;
@@ -52,7 +58,7 @@ export function inspectTypeName(program: Program, target: Type, text: string) {
 }
 
 const intrinsicsKey = Symbol();
-export function $intrinsic(program: Program, target: Type) {
+export function $intrinsic({ program }: DecoratorContext, target: Type) {
   program.stateSet(intrinsicsKey).add(target);
 }
 
@@ -95,7 +101,7 @@ export function isErrorType(type: Type): boolean {
 }
 
 const numericTypesKey = Symbol();
-export function $numeric(program: Program, target: Type) {
+export function $numeric({ program }: DecoratorContext, target: Type) {
   if (!isIntrinsic(program, target)) {
     program.reportDiagnostic(
       createDiagnostic({
@@ -128,7 +134,7 @@ export function isNumericType(program: Program, target: Type): boolean {
 
 const errorKey = Symbol();
 
-export function $error(program: Program, target: Type) {
+export function $error({ program }: DecoratorContext, target: Type) {
   if (target.kind !== "Model") {
     program.reportDiagnostic(
       createDiagnostic({
@@ -152,7 +158,7 @@ export function isErrorModel(program: Program, target: Type): boolean {
 
 const formatValuesKey = Symbol();
 
-export function $format(program: Program, target: Type, format: string) {
+export function $format({ program }: DecoratorContext, target: Type, format: string) {
   if (target.kind !== "Model" && target.kind !== "ModelProperty") {
     program.reportDiagnostic(
       createDiagnostic({
@@ -186,7 +192,7 @@ export function getFormat(program: Program, target: Type): string | undefined {
 
 const patternValuesKey = Symbol();
 
-export function $pattern(program: Program, target: Type, pattern: string) {
+export function $pattern({ program }: DecoratorContext, target: Type, pattern: string) {
   if (target.kind !== "Model" && target.kind !== "ModelProperty") {
     program.reportDiagnostic(
       createDiagnostic({
@@ -220,7 +226,7 @@ export function getPattern(program: Program, target: Type): string | undefined {
 
 const minLengthValuesKey = Symbol();
 
-export function $minLength(program: Program, target: Type, minLength: number) {
+export function $minLength({ program }: DecoratorContext, target: Type, minLength: number) {
   if (target.kind !== "Model" && target.kind !== "ModelProperty") {
     program.reportDiagnostic(
       createDiagnostic({
@@ -254,7 +260,7 @@ export function getMinLength(program: Program, target: Type): number | undefined
 
 const maxLengthValuesKey = Symbol();
 
-export function $maxLength(program: Program, target: Type, maxLength: number) {
+export function $maxLength({ program }: DecoratorContext, target: Type, maxLength: number) {
   if (target.kind !== "Model" && target.kind !== "ModelProperty") {
     program.reportDiagnostic(
       createDiagnostic({
@@ -287,7 +293,7 @@ export function getMaxLength(program: Program, target: Type): number | undefined
 
 const minValuesKey = Symbol();
 
-export function $minValue(program: Program, target: Type, minValue: number) {
+export function $minValue({ program }: DecoratorContext, target: Type, minValue: number) {
   if (target.kind !== "Model" && target.kind !== "ModelProperty") {
     program.reportDiagnostic(
       createDiagnostic({
@@ -318,7 +324,7 @@ export function getMinValue(program: Program, target: Type): number | undefined 
 
 const maxValuesKey = Symbol();
 
-export function $maxValue(program: Program, target: Type, maxValue: number) {
+export function $maxValue({ program }: DecoratorContext, target: Type, maxValue: number) {
   if (target.kind !== "Model" && target.kind !== "ModelProperty") {
     program.reportDiagnostic(
       createDiagnostic({
@@ -350,7 +356,7 @@ export function getMaxValue(program: Program, target: Type): number | undefined 
 
 const secretTypesKey = Symbol();
 
-export function $secret(program: Program, target: Type) {
+export function $secret({ program }: DecoratorContext, target: Type) {
   if (target.kind !== "Model") {
     program.reportDiagnostic(
       createDiagnostic({
@@ -381,7 +387,11 @@ export function isSecret(program: Program, target: Type): boolean | undefined {
 
 const visibilitySettingsKey = Symbol();
 
-export function $visibility(program: Program, target: Type, ...visibilities: string[]) {
+export function $visibility(
+  { program }: DecoratorContext,
+  target: Type,
+  ...visibilities: string[]
+) {
   if (target.kind !== "ModelProperty") {
     program.reportDiagnostic(
       createDiagnostic({
@@ -399,7 +409,11 @@ export function getVisibility(program: Program, target: Type): string[] | undefi
   return program.stateMap(visibilitySettingsKey).get(target);
 }
 
-export function $withVisibility(program: Program, target: Type, ...visibilities: string[]) {
+export function $withVisibility(
+  { program }: DecoratorContext,
+  target: Type,
+  ...visibilities: string[]
+) {
   if (target.kind !== "Model") {
     program.reportDiagnostic(
       createDiagnostic({
@@ -433,7 +447,7 @@ function mapFilterOut(
 
 // -- @withOptionalProperties decorator ---------------------
 
-export function $withOptionalProperties(program: Program, target: Type) {
+export function $withOptionalProperties({ program }: DecoratorContext, target: Type) {
   if (target.kind !== "Model") {
     program.reportDiagnostic(
       createDiagnostic({
@@ -452,7 +466,7 @@ export function $withOptionalProperties(program: Program, target: Type) {
 
 // -- @withUpdatableProperties decorator ----------------------
 
-export function $withUpdateableProperties(program: Program, target: Type) {
+export function $withUpdateableProperties({ program }: DecoratorContext, target: Type) {
   if (target.kind !== "Model") {
     program.reportDiagnostic(
       createDiagnostic({
@@ -474,7 +488,7 @@ export function $withUpdateableProperties(program: Program, target: Type) {
 
 // -- @withoutDefaultValues decorator ----------------------
 
-export function $withoutDefaultValues(program: Program, target: Type) {
+export function $withoutDefaultValues({ program }: DecoratorContext, target: Type) {
   if (target.kind !== "Model") {
     program.reportDiagnostic(
       createDiagnostic({
@@ -495,7 +509,7 @@ export function $withoutDefaultValues(program: Program, target: Type) {
 
 const listPropertiesKey = Symbol();
 
-export function $list(program: Program, target: Type, listedType?: Type) {
+export function $list({ program }: DecoratorContext, target: Type, listedType?: Type) {
   if (target.kind !== "Operation") {
     program.reportDiagnostic(
       createDiagnostic({
@@ -540,7 +554,7 @@ const tagPropertiesKey = Symbol();
 
 // Set a tag on an operation or namespace.  There can be multiple tags on either an
 // operation or namespace.
-export function $tag(program: Program, target: Type, tag: string) {
+export function $tag({ program }: DecoratorContext, target: Type, tag: string) {
   if (target.kind !== "Operation" && target.kind !== "Namespace" && target.kind !== "Interface") {
     program.reportDiagnostic(
       createDiagnostic({

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -656,7 +656,7 @@ export function validateDecoratorParamType(
 const friendlyNamesKey = Symbol();
 
 export function $friendlyName(
-  program: Program,
+  { program }: DecoratorContext,
   target: Type,
   friendlyName: string,
   sourceObject: Type | undefined

--- a/packages/compiler/lib/service.ts
+++ b/packages/compiler/lib/service.ts
@@ -1,6 +1,6 @@
 import { createDiagnostic } from "../core/messages.js";
 import { Program } from "../core/program.js";
-import { NamespaceType, Projector, Type } from "../core/types.js";
+import { DecoratorContext, NamespaceType, Projector, Type } from "../core/types.js";
 
 interface ServiceDetails {
   namespace?: NamespaceType;
@@ -36,7 +36,7 @@ export function checkIfServiceNamespace(program: Program, namespace: NamespaceTy
   return serviceDetails.namespace === namespace;
 }
 
-export function $serviceTitle(program: Program, target: Type, title: string) {
+export function $serviceTitle({ program }: DecoratorContext, target: Type, title: string) {
   const serviceDetails = getServiceDetails(program);
   if (serviceDetails.title) {
     program.reportDiagnostic(
@@ -68,7 +68,7 @@ export function getServiceTitle(program: Program): string {
   return serviceDetails.title || "(title)";
 }
 
-export function $serviceHost(program: Program, target: Type, host: string) {
+export function $serviceHost({ program }: DecoratorContext, target: Type, host: string) {
   const serviceDetails = getServiceDetails(program);
   if (serviceDetails.version) {
     program.reportDiagnostic(
@@ -105,7 +105,7 @@ export function setServiceHost(program: Program, host: string) {
   serviceDetails.host = host;
 }
 
-export function $serviceVersion(program: Program, target: Type, version: string) {
+export function $serviceVersion({ program }: DecoratorContext, target: Type, version: string) {
   const serviceDetails = getServiceDetails(program);
   if (serviceDetails.version) {
     program.reportDiagnostic(

--- a/packages/compiler/test/checker/duplicate-ids.ts
+++ b/packages/compiler/test/checker/duplicate-ids.ts
@@ -1,6 +1,5 @@
 import { match, strictEqual } from "assert";
-import { Program } from "../../core/program.js";
-import { Diagnostic } from "../../core/types.js";
+import { DecoratorContext, Diagnostic } from "../../core/types.js";
 import { createTestHost, TestHost } from "../../testing/index.js";
 
 describe("compiler: duplicate declarations", () => {
@@ -37,8 +36,8 @@ describe("compiler: duplicate declarations", () => {
 
   it("reports duplicate model declarations in global scope using eval", async () => {
     testHost.addJsFile("test.js", {
-      $eval(p: Program) {
-        p.evalCadlScript(`model A { }`);
+      $eval({ program }: DecoratorContext) {
+        program.evalCadlScript(`model A { }`);
       },
     });
     testHost.addCadlFile(
@@ -71,8 +70,8 @@ describe("compiler: duplicate declarations", () => {
 
   it("reports duplicate model declarations in a single namespace using eval", async () => {
     testHost.addJsFile("test.js", {
-      $eval(p: Program) {
-        p.evalCadlScript(`namespace Foo; model A { }; model A { };`);
+      $eval({ program }: DecoratorContext) {
+        program.evalCadlScript(`namespace Foo; model A { }; model A { };`);
       },
     });
     testHost.addCadlFile(
@@ -107,8 +106,8 @@ describe("compiler: duplicate declarations", () => {
 
   it("reports duplicate model declarations across multiple namespaces using eval", async () => {
     testHost.addJsFile("test.js", {
-      $eval(p: Program) {
-        p.evalCadlScript(`namespace Foo; model A { }`);
+      $eval({ program }: DecoratorContext) {
+        program.evalCadlScript(`namespace Foo; model A { }`);
       },
     });
     testHost.addCadlFile(

--- a/packages/compiler/test/checker/namespaces.ts
+++ b/packages/compiler/test/checker/namespaces.ts
@@ -1,6 +1,6 @@
 import { ok, strictEqual } from "assert";
 import { Program } from "../../core/program.js";
-import { ModelType, NamespaceType, Type } from "../../core/types.js";
+import { DecoratorContext, ModelType, NamespaceType, Type } from "../../core/types.js";
 import { createTestHost, TestHost } from "../../testing/index.js";
 
 describe("compiler: namespaces with blocks", () => {
@@ -365,8 +365,8 @@ describe("compiler: blockless namespaces", () => {
 
   it("merges properly with other namespaces using eval", async () => {
     testHost.addJsFile("test.js", {
-      $eval(p: Program) {
-        p.evalCadlScript(`namespace N; @test model Z { ... X, ... Y }`);
+      $eval({ program }: DecoratorContext) {
+        program.evalCadlScript(`namespace N; @test model Z { ... X, ... Y }`);
       },
     });
     testHost.addCadlFile(

--- a/packages/compiler/test/checker/projection.ts
+++ b/packages/compiler/test/checker/projection.ts
@@ -2,6 +2,7 @@ import { ok, strictEqual } from "assert";
 import { Program } from "../../core/program.js";
 import {
   DecoratorArgument,
+  DecoratorContext,
   EnumType,
   InterfaceType,
   ModelType,
@@ -128,15 +129,20 @@ describe("cadl: projections", () => {
       const removedOnKey = Symbol();
       const renamedFromKey = Symbol();
       testHost.addJsFile("versioning.js", {
-        $added(p: Program, t: Type, v: NumericLiteralType) {
-          p.stateMap(addedOnKey).set(t, v);
+        $added({ program }: DecoratorContext, t: Type, v: NumericLiteralType) {
+          program.stateMap(addedOnKey).set(t, v);
         },
-        $removed(p: Program, t: Type, v: NumericLiteralType) {
-          p.stateMap(removedOnKey).set(t, v);
+        $removed({ program }: DecoratorContext, t: Type, v: NumericLiteralType) {
+          program.stateMap(removedOnKey).set(t, v);
         },
-        $renamedFrom(p: Program, t: Type, v: NumericLiteralType, oldName: StringLiteralType) {
+        $renamedFrom(
+          { program }: DecoratorContext,
+          t: Type,
+          v: NumericLiteralType,
+          oldName: StringLiteralType
+        ) {
           const record = { v, oldName };
-          p.stateMap(renamedFromKey).set(t, record);
+          program.stateMap(renamedFromKey).set(t, record);
         },
         getAddedOn(p: Program, t: Type) {
           return p.stateMap(addedOnKey).get(t) || -1;

--- a/packages/compiler/test/checker/using.ts
+++ b/packages/compiler/test/checker/using.ts
@@ -1,6 +1,5 @@
 import { match, rejects, strictEqual } from "assert";
-import { getSourceLocation } from "../../core/index.js";
-import { Program } from "../../core/program";
+import { DecoratorContext, getSourceLocation } from "../../core/index.js";
 import { ModelType } from "../../core/types.js";
 import { createTestHost, expectDiagnosticEmpty, TestHost } from "../../testing/index.js";
 
@@ -364,8 +363,8 @@ describe("compiler: using statements", () => {
 
   it("Cadl namespace is automatically using'd in eval", async () => {
     testHost.addJsFile("test.js", {
-      $eval(p: Program) {
-        p.evalCadlScript(`namespace Bar; model A { a: int32 };`);
+      $eval({ program }: DecoratorContext) {
+        program.evalCadlScript(`namespace Bar; model A { a: int32 };`);
       },
     });
     testHost.addCadlFile(
@@ -383,8 +382,8 @@ describe("compiler: using statements", () => {
 
   it("works with eval", async () => {
     testHost.addJsFile("test.js", {
-      async $eval(p: Program) {
-        await p.evalCadlScript(`using Foo; model A { a: X };`);
+      async $eval({ program }: DecoratorContext) {
+        await program.evalCadlScript(`using Foo; model A { a: X };`);
       },
     });
     testHost.addCadlFile(

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -1,8 +1,8 @@
-import { Program, Type, validateDecoratorParamType } from "@cadl-lang/compiler";
+import { DecoratorContext, Program, Type, validateDecoratorParamType } from "@cadl-lang/compiler";
 import { reportDiagnostic } from "./lib.js";
 
 const operationIdsKey = Symbol();
-export function $operationId(program: Program, entity: Type, opId: string) {
+export function $operationId({ program }: DecoratorContext, entity: Type, opId: string) {
   if (entity.kind !== "Operation") {
     reportDiagnostic(program, {
       code: "decorator-wrong-type",
@@ -20,7 +20,12 @@ export function getOperationId(program: Program, entity: Type): string | undefin
 
 export type ExtensionKey = `x-${string}`;
 const openApiExtensionKey = Symbol();
-export function $extension(program: Program, entity: Type, extensionName: string, value: any) {
+export function $extension(
+  { program }: DecoratorContext,
+  entity: Type,
+  extensionName: string,
+  value: any
+) {
   if (!validateDecoratorParamType(program, entity, extensionName, "string")) {
     return;
   }

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1,6 +1,7 @@
 import {
   ArrayType,
   checkIfServiceNamespace,
+  DecoratorContext,
   EmitOptionsFor,
   EnumMemberType,
   EnumType,
@@ -63,7 +64,7 @@ export async function $onEmit(p: Program, emitterOptions?: EmitOptionsFor<OpenAP
 
 const refTargetsKey = Symbol();
 
-export function $useRef(program: Program, entity: Type, refUrl: string): void {
+export function $useRef({ program }: DecoratorContext, entity: Type, refUrl: string): void {
   if (entity.kind === "Model" || entity.kind === "ModelProperty") {
     program.stateMap(refTargetsKey).set(entity, refUrl);
   } else {
@@ -81,7 +82,7 @@ function getRef(program: Program, entity: Type): string | undefined {
 }
 
 const oneOfKey = Symbol();
-export function $oneOf(program: Program, entity: Type) {
+export function $oneOf({ program }: DecoratorContext, entity: Type) {
   if (entity.kind !== "Union") {
     reportDiagnostic(program, {
       code: "decorator-wrong-type",

--- a/packages/rest/src/http.ts
+++ b/packages/rest/src/http.ts
@@ -1,4 +1,5 @@
 import {
+  DecoratorContext,
   Program,
   setDecoratorNamespace,
   Type,
@@ -7,7 +8,7 @@ import {
 import { reportDiagnostic } from "./diagnostics.js";
 
 const headerFieldsKey = Symbol();
-export function $header(program: Program, entity: Type, headerName?: string) {
+export function $header({ program }: DecoratorContext, entity: Type, headerName?: string) {
   if (!headerName && entity.kind === "ModelProperty") {
     headerName = entity.name.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
   }
@@ -23,7 +24,7 @@ export function isHeader(program: Program, entity: Type) {
 }
 
 const queryFieldsKey = Symbol();
-export function $query(program: Program, entity: Type, queryKey: string) {
+export function $query({ program }: DecoratorContext, entity: Type, queryKey: string) {
   if (!queryKey && entity.kind === "ModelProperty") {
     queryKey = entity.name;
   }
@@ -39,7 +40,7 @@ export function isQueryParam(program: Program, entity: Type) {
 }
 
 const pathFieldsKey = Symbol();
-export function $path(program: Program, entity: Type, paramName: string) {
+export function $path({ program }: DecoratorContext, entity: Type, paramName: string) {
   if (!paramName && entity.kind === "ModelProperty") {
     paramName = entity.name;
   }
@@ -55,7 +56,7 @@ export function isPathParam(program: Program, entity: Type) {
 }
 
 const bodyFieldsKey = Symbol();
-export function $body(program: Program, entity: Type) {
+export function $body({ program }: DecoratorContext, entity: Type) {
   program.stateSet(bodyFieldsKey).add(entity);
 }
 
@@ -64,7 +65,7 @@ export function isBody(program: Program, entity: Type): boolean {
 }
 
 const statusCodeKey = Symbol();
-export function $statusCode(program: Program, entity: Type) {
+export function $statusCode({ program }: DecoratorContext, entity: Type) {
   if (entity.kind === "ModelProperty") {
     program.stateSet(statusCodeKey).add(entity);
   } else {
@@ -108,32 +109,32 @@ export function getOperationVerb(program: Program, entity: Type): HttpVerb | und
   return program.stateMap(operationVerbsKey).get(entity);
 }
 
-export function $get(program: Program, entity: Type, ...args: unknown[]) {
+export function $get({ program }: DecoratorContext, entity: Type, ...args: unknown[]) {
   validateVerbNoArgs(program, entity, args);
   setOperationVerb(program, entity, "get");
 }
 
-export function $put(program: Program, entity: Type, ...args: unknown[]) {
+export function $put({ program }: DecoratorContext, entity: Type, ...args: unknown[]) {
   validateVerbNoArgs(program, entity, args);
   setOperationVerb(program, entity, "put");
 }
 
-export function $post(program: Program, entity: Type, ...args: unknown[]) {
+export function $post({ program }: DecoratorContext, entity: Type, ...args: unknown[]) {
   validateVerbNoArgs(program, entity, args);
   setOperationVerb(program, entity, "post");
 }
 
-export function $patch(program: Program, entity: Type, ...args: unknown[]) {
+export function $patch({ program }: DecoratorContext, entity: Type, ...args: unknown[]) {
   validateVerbNoArgs(program, entity, args);
   setOperationVerb(program, entity, "patch");
 }
 
-export function $delete(program: Program, entity: Type, ...args: unknown[]) {
+export function $delete({ program }: DecoratorContext, entity: Type, ...args: unknown[]) {
   validateVerbNoArgs(program, entity, args);
   setOperationVerb(program, entity, "delete");
 }
 
-export function $head(program: Program, entity: Type, ...args: unknown[]) {
+export function $head({ program }: DecoratorContext, entity: Type, ...args: unknown[]) {
   validateVerbNoArgs(program, entity, args);
   setOperationVerb(program, entity, "head");
 }
@@ -157,7 +158,7 @@ setDecoratorNamespace(
   $statusCode
 );
 
-export function $plainData(program: Program, entity: Type) {
+export function $plainData({ program }: DecoratorContext, entity: Type) {
   if (entity.kind !== "Model") {
     reportDiagnostic(program, {
       code: "decorator-wrong-type",

--- a/packages/rest/src/resource.ts
+++ b/packages/rest/src/resource.ts
@@ -1,4 +1,5 @@
 import {
+  DecoratorContext,
   ModelType,
   ModelTypeProperty,
   Program,
@@ -15,7 +16,7 @@ export interface ResourceKey {
 
 const resourceKeyPropertiesKey = Symbol();
 
-export function $key(program: Program, entity: Type, altName?: string): void {
+export function $key({ program }: DecoratorContext, entity: Type, altName?: string): void {
   if (entity.kind !== "ModelProperty") {
     reportDiagnostic(program, {
       code: "decorator-wrong-type",
@@ -83,11 +84,12 @@ export function getResourceTypeKey(program: Program, resourceType: ModelType): R
   return resourceKey;
 }
 
-function cloneKeyProperties(program: Program, target: ModelType, resourceType: ModelType) {
+function cloneKeyProperties(context: DecoratorContext, target: ModelType, resourceType: ModelType) {
+  const { program } = context;
   // Add parent keys first
   const parentType = getParentResource(program, resourceType);
   if (parentType) {
-    cloneKeyProperties(program, target, parentType);
+    cloneKeyProperties(context, target, parentType);
   }
 
   const resourceKey = getResourceTypeKey(program, resourceType);
@@ -101,15 +103,19 @@ function cloneKeyProperties(program: Program, target: ModelType, resourceType: M
       decorator: $path,
       args: [],
     });
-    $path(program, newProp, undefined as any);
+    $path(context, newProp, undefined as any);
 
     target.properties.set(keyName, newProp);
   }
 }
 
-export function $copyResourceKeyParameters(program: Program, entity: Type, filter?: string) {
+export function $copyResourceKeyParameters(
+  context: DecoratorContext,
+  entity: Type,
+  filter?: string
+) {
   if (entity.kind !== "Model") {
-    reportDiagnostic(program, {
+    reportDiagnostic(context.program, {
       code: "decorator-wrong-type",
       format: { decorator: "copyResourceKeyParameters", entityKind: entity.kind },
       target: entity,
@@ -122,7 +128,7 @@ export function $copyResourceKeyParameters(program: Program, entity: Type, filte
     entity.templateArguments.length !== 1 ||
     entity.templateArguments[0].kind !== "Model"
   ) {
-    reportDiagnostic(program, {
+    reportDiagnostic(context.program, {
       code: "not-key-type",
       target: entity,
     });
@@ -133,13 +139,13 @@ export function $copyResourceKeyParameters(program: Program, entity: Type, filte
 
   if (filter === "parent") {
     // Only copy keys of the parent type if there is one
-    const parentType = getParentResource(program, resourceType);
+    const parentType = getParentResource(context.program, resourceType);
     if (parentType) {
-      cloneKeyProperties(program, entity, parentType);
+      cloneKeyProperties(context, entity, parentType);
     }
   } else {
     // Copy keys of the resource type and all parents
-    cloneKeyProperties(program, entity, resourceType);
+    cloneKeyProperties(context, entity, resourceType);
   }
 }
 
@@ -151,7 +157,7 @@ export function getParentResource(
   return program.stateMap(parentResourceTypesKey).get(resourceType);
 }
 
-export function $parentResource(program: Program, entity: Type, parentType: Type) {
+export function $parentResource({ program }: DecoratorContext, entity: Type, parentType: Type) {
   if (parentType.kind !== "Model") {
     reportDiagnostic(program, {
       code: "decorator-wrong-type",

--- a/packages/rest/src/route.ts
+++ b/packages/rest/src/route.ts
@@ -1,4 +1,5 @@
 import {
+  DecoratorContext,
   getServiceNamespace,
   InterfaceType,
   ModelTypeProperty,
@@ -47,14 +48,14 @@ export interface RoutePath {
   isReset: boolean;
 }
 
-export function $route(program: Program, entity: Type, path: string) {
+export function $route({ program }: DecoratorContext, entity: Type, path: string) {
   setRoute(program, entity, {
     path,
     isReset: false,
   });
 }
 
-export function $routeReset(program: Program, entity: Type, path: string) {
+export function $routeReset({ program }: DecoratorContext, entity: Type, path: string) {
   setRoute(program, entity, {
     path,
     isReset: true,
@@ -462,7 +463,7 @@ const resourceOperationToVerb: any = {
 };
 
 const autoRouteKey = Symbol();
-export function $autoRoute(program: Program, entity: Type) {
+export function $autoRoute({ program }: DecoratorContext, entity: Type) {
   if (entity.kind !== "Namespace" && entity.kind !== "Interface" && entity.kind !== "Operation") {
     reportDiagnostic(program, {
       code: "decorator-wrong-type",


### PR DESCRIPTION
Currently the context only contains the program but unlocks additional functionalities in the future without breaking changes.
```ts
export interface DecoratorContext {
  program: Program;
}
```

fix #231 