### PR TITLE
Filter out string constant path parameters when generating routes

### DIFF
--- a/common/changes/@cadl-lang/openapi3/route-fixes_2022-02-16-17-22.json
+++ b/common/changes/@cadl-lang/openapi3/route-fixes_2022-02-16-17-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Fix duplicate parameter type definitions in OpenAPI 3 output",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/route-fixes_2022-02-15-12-51.json
+++ b/common/changes/@cadl-lang/rest/route-fixes_2022-02-15-12-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Filter out string literal typed path parameters when generating routes automatically",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -794,8 +794,11 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
   function getParameterKey(property: ModelTypeProperty, param: any) {
     const parent = program.checker!.getTypeForNode(property.node.parent!) as ModelType;
     let key = program.checker!.getTypeName(parent);
+    let isQualifiedParamName = false;
+
     if (parent.properties.size > 1) {
       key += `.${property.name}`;
+      isQualifiedParamName = true;
     }
 
     // Try to shorten the type name to exclude the top-level service namespace
@@ -804,7 +807,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       baseKey = key.substring(serviceNamespace.length + 1);
 
       // If no parameter exists with the shortened name, use it, otherwise use the fully-qualified name
-      if (root.components.parameters[baseKey] === undefined) {
+      if (!root.components.parameters[baseKey] || isQualifiedParamName) {
         key = baseKey;
       }
     }

--- a/packages/rest/src/route.ts
+++ b/packages/rest/src/route.ts
@@ -211,7 +211,9 @@ function generatePathFromParameters(
   pathFragments: string[],
   parameters: HttpOperationParameters
 ) {
-  for (const { type, param } of parameters.parameters) {
+  const filteredParameters: HttpOperationParameter[] = [];
+  for (const httpParam of parameters.parameters) {
+    const { type, param } = httpParam;
     if (type === "path") {
       addSegmentFragment(program, param, pathFragments);
 
@@ -223,7 +225,13 @@ function generatePathFromParameters(
         pathFragments.push(`/{${param.name}}`);
       }
     }
+
+    // Push all usable parameters to the filtered list
+    filteredParameters.push(httpParam);
   }
+
+  // Replace the original parameters with filtered set
+  parameters.parameters = filteredParameters;
 
   // Add the operation's own segment if present
   addSegmentFragment(program, operation, pathFragments);

--- a/packages/rest/test/test-routes.ts
+++ b/packages/rest/test/test-routes.ts
@@ -172,6 +172,41 @@ describe("rest: routes", () => {
     ]);
   });
 
+  it("autoRoute operations filter out path parameters with a string literal type", async () => {
+    const routes = await getRoutesFor(
+      `
+      model ThingId {
+        @path
+        @segment("things")
+        thingId: string;
+      }
+
+      @autoRoute
+      namespace Things {
+        @get
+        op WithFilteredParam(
+          @path
+          @segment("subscriptions")
+          subscriptionId: string,
+
+          @path
+          @segment("providers")
+          provider: "Microsoft.Things",
+          ...ThingId
+        ): string;
+      }
+      `
+    );
+
+    deepStrictEqual(routes, [
+      {
+        verb: "get",
+        path: "/subscriptions/{subscriptionId}/providers/Microsoft.Things/things/{thingId}",
+        params: ["subscriptionId", "thingId"],
+      },
+    ]);
+  });
+
   it("emit diagnostics if operation has a body but didn't specify the verb", async () => {
     const [_, diagnostics] = await compileOperations(`
         @route("/test")

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -380,7 +380,7 @@
         "description": "Gets an instance of the resource.",
         "parameters": [
           {
-            "$ref": "#/components/parameters/PetStore.Pet.petId"
+            "$ref": "#/components/parameters/Pet.petId"
           },
           {
             "$ref": "#/components/parameters/Toy.toyId"
@@ -415,7 +415,7 @@
         "operationId": "Toys_list",
         "parameters": [
           {
-            "$ref": "#/components/parameters/PetStore.Pet.petId"
+            "$ref": "#/components/parameters/Pet.petId"
           },
           {
             "name": "nameFilter",
@@ -456,7 +456,7 @@
         "description": "Gets the singleton resource.",
         "parameters": [
           {
-            "$ref": "#/components/parameters/PetStore.Pet.petId"
+            "$ref": "#/components/parameters/Pet.petId"
           },
           {
             "$ref": "#/components/parameters/Toy.toyId"
@@ -490,7 +490,7 @@
         "description": "Updates the singleton resource.",
         "parameters": [
           {
-            "$ref": "#/components/parameters/PetStore.Pet.petId"
+            "$ref": "#/components/parameters/Pet.petId"
           },
           {
             "$ref": "#/components/parameters/Toy.toyId"
@@ -998,15 +998,6 @@
       },
       "Checkup.checkupId": {
         "name": "checkupId",
-        "in": "path",
-        "required": true,
-        "schema": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "PetStore.Pet.petId": {
-        "name": "petId",
         "in": "path",
         "required": true,
         "schema": {


### PR DESCRIPTION
This fixes an issue introduced by #167 which made improvements to how we handle HTTP parameters in the `rest` library.

The issue is that there was some logic removed which was used to filter out operation `path` parameters that have a string literal as the parameter type.  This pattern is being used by the new interface-based ARM service modelling library to get `providers/` path parts generating correctly on `autoRoute` operations.

The fix is to update the `HttpOperationParameter` array in `generatePathFromParameters` to remove these special path parameters once again.