### PR TITLE
Small parser fixes

### DIFF
--- a/common/changes/@cadl-lang/compiler/parser-fixes_2022-02-15-15-32.json
+++ b/common/changes/@cadl-lang/compiler/parser-fixes_2022-02-15-15-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix parser issue with missing error flag when using `interface extends` instead of `interface mixes`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/compiler/parser-fixes_2022-02-15-15-33.json
+++ b/common/changes/@cadl-lang/compiler/parser-fixes_2022-02-15-15-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix parser issue with incorrect `op` in various projection expressions, and wrong node type for `/` and `*`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/diagnostics.ts
+++ b/packages/compiler/core/diagnostics.ts
@@ -232,14 +232,14 @@ function getSourceLocationOfNode(node: Node): SourceLocation {
  * instead of producing the message then passing it here only to be dropped
  * when verbose output is disabled.
  */
-export function logVerboseTestOutput(messageOrCallback: string | ((log: LogSink) => void)) {
+export function logVerboseTestOutput(
+  messageOrCallback: string | ((log: (message: string) => void) => void)
+) {
   if (process.env.CADL_VERBOSE_TEST_OUTPUT) {
     if (typeof messageOrCallback === "string") {
       console.log(messageOrCallback);
     } else {
-      messageOrCallback({
-        log: ({ message }) => console.log(message),
-      });
+      messageOrCallback(console.log);
     }
   }
 }


### PR DESCRIPTION
* Fix issue with missing error flag when using `interface extends` instead of `interface mixes`.
* Fix issue with incorrect `op` in various projection expressions, and wrong node type for `/` and `*`.
* Format diagnostics with location in verbose test output