### PR TITLE
Improve list parsing error recovery

### DIFF
--- a/common/changes/@cadl-lang/compiler/better-list-recovery_2022-02-18-16-28.json
+++ b/common/changes/@cadl-lang/compiler/better-list-recovery_2022-02-18-16-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Improve list parsing error recovery",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/test/checker/check-parse-errors.ts
+++ b/packages/compiler/test/checker/check-parse-errors.ts
@@ -19,7 +19,7 @@ describe("compiler: semantic checks on source with parse errors", () => {
 
     const diagnostics = await testHost.diagnose("./");
     strictEqual(diagnostics.length, 5);
-    match(diagnostics[0].message, /Property expected/);
+    match(diagnostics[0].message, /'}' expected/);
     match(diagnostics[1].message, /Unknown identifier Q/);
     match(diagnostics[2].message, /Unknown identifier B/);
     match(diagnostics[3].message, /Unknown identifier C/);

--- a/packages/compiler/test/test-parser.ts
+++ b/packages/compiler/test/test-parser.ts
@@ -141,8 +141,16 @@ describe("compiler: syntax", () => {
       "interface Foo { op foo(): int32; op bar(): int32; baz(): int32; }",
     ]);
 
-    parseErrorEach([["interface Foo<T> extends Bar<T> {}", [/mixes/]]]);
+    parseErrorEach([
+      ["interface Foo<T> extends Bar<T> {}", [/mixes/]],
+      ["interface X {", [/'}' expected/]],
+      ["interface X { foo(): string; interface Y", [/'}' expected/]],
+      ["interface X { foo(a: string", [/'\)' expected/]],
+      ["interface X { foo(@dec", [/Property expected/]],
+      ["interface X { foo(#suppress x", [/Property expected/]],
+    ]);
   });
+
   describe("model expressions", () => {
     parseEach(['model Car { engine: { type: "v8" } }']);
   });
@@ -557,7 +565,7 @@ describe("compiler: syntax", () => {
         [`projection x#f`, [/'{' expected/]],
         [`projection x#f {`, [/'}' expected/]],
         [`projection x#f { asdf`, [/from or to expected/]],
-        [`projection x#f { to (`, [/Identifier expected/]],
+        [`projection x#f { to (`, [/'\)' expected/]],
         [`projection x#f { to @`, [/'{' expected/]],
         [`projection x#f { to {`, [/} expected/]],
         [`projection x#f { to {}`, [/'}' expected/]],


### PR DESCRIPTION
* End all lists when statement keyword or EOF is encountered.
* Do not put items that were parsed entirely out of synthesized tokens at the end of lists.

Fix #255 