### PR TITLE
Improve decorator param validation

### DIFF
--- a/common/changes/@cadl-lang/compiler/dec-param-validation-improvements_2022-02-16-21-14.json
+++ b/common/changes/@cadl-lang/compiler/dec-param-validation-improvements_2022-02-16-21-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi/dec-param-validation-improvements_2022-02-16-21-14.json
+++ b/common/changes/@cadl-lang/openapi/dec-param-validation-improvements_2022-02-16-21-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/rest/dec-param-validation-improvements_2022-02-16-21-14.json
+++ b/common/changes/@cadl-lang/rest/dec-param-validation-improvements_2022-02-16-21-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/compiler/core/decorator-utils.ts
+++ b/packages/compiler/core/decorator-utils.ts
@@ -2,6 +2,15 @@ import { reportDiagnostic } from "./messages.js";
 import { Program } from "./program.js";
 import { Type } from "./types.js";
 
+export type CadlValue = Type | string | number | boolean;
+
+// prettier-ignore
+export type InferredCadlValue<K extends Type["kind"]> = 
+  K extends "String" ? string 
+  : K extends "Number" ? number 
+  : K extends "Boolean" ? boolean 
+  : Type & { kind: K };
+
 /**
  * Validate the decorator target is matching the expected value.
  * @param program
@@ -16,11 +25,7 @@ export function validateDecoratorTarget<K extends Type["kind"]>(
   decoratorName: string,
   expectedType: K | K[]
 ): target is Type & { kind: K } {
-  const isCorrectType =
-    typeof expectedType === "string"
-      ? target.kind === expectedType
-      : expectedType.includes(target.kind as any);
-
+  const isCorrectType = isCadlValueTypeOf(target, expectedType);
   if (!isCorrectType) {
     reportDiagnostic(program, {
       code: "decorator-wrong-target",
@@ -34,6 +39,41 @@ export function validateDecoratorTarget<K extends Type["kind"]>(
   }
 
   return true;
+}
+
+/**
+ * Check if the given target is of any of the cadl types.
+ * @param target Target to validate.
+ * @param expectedType One or multiple allowed cadl types.
+ * @returns boolean if the target is of one of the allowed types.
+ */
+export function isCadlValueTypeOf<K extends Type["kind"]>(
+  target: CadlValue,
+  expectedType: K | K[]
+): target is InferredCadlValue<K> {
+  const kind = getTypeKind(target);
+  if (kind === undefined) {
+    return false;
+  }
+
+  return typeof expectedType === "string"
+    ? kind === expectedType
+    : expectedType.includes(kind as any);
+}
+
+function getTypeKind(target: CadlValue): Type["kind"] | undefined {
+  switch (typeof target) {
+    case "object":
+      return target.kind;
+    case "string":
+      return "String";
+    case "number":
+      return "Number";
+    case "boolean":
+      return "Boolean";
+    default:
+      return undefined;
+  }
 }
 
 /**
@@ -59,21 +99,26 @@ export function validateDecoratorParamCount(
 }
 
 /**
- * Validate the given
+ * Validate a decorator parameter has the correct type.
+ * @param program Program
+ * @param target Decorator target
+ * @param value Value of the parameter.
+ * @param expectedType Expected type or list of expected type
+ * @returns true if the value is of one of the type in the list of expected types. If not emit a diagnostic.
  */
-export function validateDecoratorParamType(
+export function validateDecoratorParamType<K extends Type["kind"]>(
   program: Program,
   target: Type,
-  value: unknown,
-  expected: "string" | "number"
-): boolean {
-  if (typeof value !== expected) {
+  value: CadlValue,
+  expectedType: K | K[]
+): value is InferredCadlValue<K> {
+  if (!isCadlValueTypeOf(value, expectedType)) {
     reportDiagnostic(program, {
       code: "invalid-argument",
       format: {
         value: prettyValue(program, value),
-        actual: typeof value,
-        expected: expected,
+        actual: getTypeKind(value)!,
+        expected: typeof expectedType === "string" ? expectedType : expectedType.join(", "),
       },
       target,
     });

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -33,7 +33,7 @@ function setTemplatedStringProperty(
 ) {
   // TODO: replace with built-in decorator validation https://github.com/Azure/cadl-azure/issues/1022
 
-  if (!validateDecoratorParamType(program, target, text, "string")) {
+  if (!validateDecoratorParamType(program, target, text, "String")) {
     return;
   }
 
@@ -527,7 +527,7 @@ export function $friendlyName(
   sourceObject: Type | undefined
 ) {
   // TODO: replace with built-in decorator validation https://github.com/Azure/cadl-azure/issues/1022
-  if (!validateDecoratorParamType(program, target, friendlyName, "string")) {
+  if (!validateDecoratorParamType(program, target, friendlyName, "String")) {
     return;
   }
 

--- a/packages/compiler/test/decorators/decorators.ts
+++ b/packages/compiler/test/decorators/decorators.ts
@@ -1,6 +1,6 @@
 import { ok, strictEqual } from "assert";
 import { getDoc, getFriendlyName, isErrorModel } from "../../lib/decorators.js";
-import { createTestHost, TestHost } from "../../testing/index.js";
+import { createTestHost, expectDiagnostics, TestHost } from "../../testing/index.js";
 
 describe("compiler: built-in decorators", () => {
   let testHost: TestHost;
@@ -56,14 +56,12 @@ describe("compiler: built-in decorators", () => {
       `
       );
 
-      const [_, diagnostics] = await testHost.compileAndDiagnose("./");
+      const diagnostics = await testHost.diagnose("./");
 
-      strictEqual(diagnostics.length, 1);
-      strictEqual(diagnostics[0].code, "invalid-argument");
-      strictEqual(
-        diagnostics[0].message,
-        `Argument 'foo | bar' of type 'object' is not assignable to parameter of type 'string'`
-      );
+      expectDiagnostics(diagnostics, {
+        code: "invalid-argument",
+        message: `Argument 'foo | bar' of type 'Union' is not assignable to parameter of type 'String'`,
+      });
     });
   });
 

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -11,7 +11,7 @@ const operationIdsKey = Symbol();
 export function $operationId({ program }: DecoratorContext, entity: Type, opId: string) {
   if (
     !validateDecoratorTarget(program, entity, "@operationId", "Operation") ||
-    !validateDecoratorParamType(program, entity, opId, "string")
+    !validateDecoratorParamType(program, entity, opId, "String")
   ) {
     return;
   }
@@ -30,7 +30,7 @@ export function $extension(
   extensionName: string,
   value: any
 ) {
-  if (!validateDecoratorParamType(program, entity, extensionName, "string")) {
+  if (!validateDecoratorParamType(program, entity, extensionName, "String")) {
     return;
   }
 

--- a/packages/openapi/test/test-decorators.ts
+++ b/packages/openapi/test/test-decorators.ts
@@ -31,7 +31,7 @@ describe("openapi: decorators", () => {
 
       expectDiagnostics(diagnostics, {
         code: "invalid-argument",
-        message: "Argument '123' of type 'number' is not assignable to parameter of type 'string'",
+        message: "Argument '123' of type 'Number' is not assignable to parameter of type 'String'",
       });
     });
   });
@@ -62,7 +62,7 @@ describe("openapi: decorators", () => {
 
       expectDiagnostics(diagnostics, {
         code: "invalid-argument",
-        message: "Argument '123' of type 'number' is not assignable to parameter of type 'string'",
+        message: "Argument '123' of type 'Number' is not assignable to parameter of type 'String'",
       });
     });
 

--- a/packages/rest/src/http.ts
+++ b/packages/rest/src/http.ts
@@ -15,7 +15,7 @@ export function $header({ program }: DecoratorContext, entity: Type, headerName?
     return;
   }
 
-  if (headerName && !validateDecoratorParamType(program, entity, headerName, "string")) {
+  if (headerName && !validateDecoratorParamType(program, entity, headerName, "String")) {
     return;
   }
 
@@ -39,7 +39,7 @@ export function $query({ program }: DecoratorContext, entity: Type, queryKey?: s
     return;
   }
 
-  if (queryKey && !validateDecoratorParamType(program, entity, queryKey, "string")) {
+  if (queryKey && !validateDecoratorParamType(program, entity, queryKey, "String")) {
     return;
   }
 
@@ -63,7 +63,7 @@ export function $path({ program }: DecoratorContext, entity: Type, paramName?: s
     return;
   }
 
-  if (paramName && !validateDecoratorParamType(program, entity, paramName, "string")) {
+  if (paramName && !validateDecoratorParamType(program, entity, paramName, "String")) {
     return;
   }
 

--- a/packages/rest/test/test-http-decorators.ts
+++ b/packages/rest/test/test-http-decorators.ts
@@ -61,7 +61,7 @@ describe("rest: http decorators", () => {
 
       expectDiagnostics(diagnostics, {
         code: "invalid-argument",
-        message: "Argument '123' of type 'number' is not assignable to parameter of type 'string'",
+        message: "Argument '123' of type 'Number' is not assignable to parameter of type 'String'",
       });
     });
 
@@ -110,7 +110,7 @@ describe("rest: http decorators", () => {
 
       expectDiagnostics(diagnostics, {
         code: "invalid-argument",
-        message: "Argument '123' of type 'number' is not assignable to parameter of type 'string'",
+        message: "Argument '123' of type 'Number' is not assignable to parameter of type 'String'",
       });
     });
 
@@ -159,7 +159,7 @@ describe("rest: http decorators", () => {
 
       expectDiagnostics(diagnostics, {
         code: "invalid-argument",
-        message: "Argument '123' of type 'number' is not assignable to parameter of type 'string'",
+        message: "Argument '123' of type 'Number' is not assignable to parameter of type 'String'",
       });
     });
 


### PR DESCRIPTION
A few improvements to the `validateDecoratorParam` util to provide validation for non primitive types. Brings in a mix between the `validateDecoratorTarget` which could only validate for non primitive cadl types and its previous implementation 

Needed for improvements in @daviwil PR for the cadl arm interfaces.