### PR TITLE
Service description in openapi3 spec

### DIFF
--- a/common/changes/@cadl-lang/openapi3/feature-service-description_2022-02-18-00-54.json
+++ b/common/changes/@cadl-lang/openapi3/feature-service-description_2022-02-18-00-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "@doc on service namespace set openapi description",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -562,6 +562,7 @@ Here's an example that uses these to define a Pet Store service:
 ```cadl
 @serviceTitle("Pet Store Service")
 @serviceVersion("2021-03-25")
+@doc("This is a sample server Petstore server.")
 @Cadl.Rest.produces("application/json", "image/png")
 @Cadl.Rest.consumes("application/json")
 namespace PetStore;

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -198,6 +198,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       info: {
         title: getServiceTitle(program),
         version: version ?? getServiceVersion(program),
+        description: getDoc(program, getServiceNamespace(program)!),
       },
       tags: [],
       paths: {},
@@ -227,6 +228,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     params = new Map();
     tags = new Set();
   }
+
   async function emitOpenAPI() {
     const serviceNs = getServiceNamespace(program);
     if (!serviceNs) {

--- a/packages/openapi3/test/test-info.ts
+++ b/packages/openapi3/test/test-info.ts
@@ -1,0 +1,35 @@
+import { strictEqual } from "assert";
+import { openApiFor } from "./test-host.js";
+
+describe("openapi3: info", () => {
+  it("set the service title with @serviceTitle", async () => {
+    const res = await openApiFor(
+      `
+      @serviceTitle("My Service")
+      namespace Foo {}
+      `
+    );
+    strictEqual(res.info.title, "My Service");
+  });
+
+  it("set the service version with @serviceVersion", async () => {
+    const res = await openApiFor(
+      `
+      @serviceVersion("1.2.3-test")
+      namespace Foo {}
+      `
+    );
+    strictEqual(res.info.version, "1.2.3-test");
+  });
+
+  it("set the service description with @doc", async () => {
+    const res = await openApiFor(
+      `
+      @doc("My service description")
+      @serviceTitle("My Service")
+      namespace Foo {}
+      `
+    );
+    strictEqual(res.info.description, "My service description");
+  });
+});

--- a/packages/samples/petstore/petstore.cadl
+++ b/packages/samples/petstore/petstore.cadl
@@ -4,6 +4,7 @@ import "./decorators.js";
 
 @serviceTitle("Pet Store Service")
 @serviceVersion("2021-03-25")
+@doc("This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.")
 namespace PetStore;
 
 using Cadl.Http;

--- a/packages/samples/test/output/petstore/openapi.json
+++ b/packages/samples/test/output/petstore/openapi.json
@@ -2,7 +2,8 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Pet Store Service",
-    "version": "2021-03-25"
+    "version": "2021-03-25",
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters."
   },
   "tags": [],
   "paths": {


### PR DESCRIPTION
fix https://github.com/Azure/cadl-azure/issues/1032

Respect @doc on service namespace to set the `info.description` property of openapi spec