### PR TITLE
Use the proper symbols to use cadl exports in eval

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-eval-bug_2022-02-23-17-51.json
+++ b/common/changes/@cadl-lang/compiler/fix-eval-bug_2022-02-23-17-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Use the proper symbol to use cadl exports in eval",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -253,7 +253,7 @@ export function createChecker(program: Program): Checker {
   if (cadlNamespaceBinding) {
     // the cadl namespace binding will be absent if we've passed
     // the no-std-lib option.
-    // the first declaration here is the cadl script.
+    // the first declaration here is the JS file for the cadl script.
     cadlNamespaceNode = cadlNamespaceBinding.declarations[1] as NamespaceStatementNode;
     initializeCadlIntrinsics();
     for (const file of program.sourceFiles.values()) {
@@ -357,7 +357,7 @@ export function createChecker(program: Program): Checker {
     }
 
     if (cadlNamespaceNode) {
-      for (const [name, binding] of cadlNamespaceNode.symbol.exports!) {
+      for (const [name, binding] of cadlNamespaceBinding!.exports!) {
         file.locals!.set(name, createUsingSymbol(binding));
       }
     }

--- a/packages/compiler/test/checker/namespaces.ts
+++ b/packages/compiler/test/checker/namespaces.ts
@@ -404,7 +404,7 @@ describe("compiler: blockless namespaces", () => {
     strictEqual(Z.properties.size, 2, "has two properties");
   });
 
-  it.only("can access the cadl namespace using eval", async () => {
+  it("can access the cadl namespace using eval", async () => {
     testHost.addJsFile("test.js", {
       $eval({ program }: DecoratorContext) {
         program.evalCadlScript(`namespace Z; @test model Z { @doc("x") x: int32 }`);

--- a/packages/compiler/test/checker/namespaces.ts
+++ b/packages/compiler/test/checker/namespaces.ts
@@ -404,6 +404,28 @@ describe("compiler: blockless namespaces", () => {
     strictEqual(Z.properties.size, 2, "has two properties");
   });
 
+  it.only("can access the cadl namespace using eval", async () => {
+    testHost.addJsFile("test.js", {
+      $eval({ program }: DecoratorContext) {
+        program.evalCadlScript(`namespace Z; @test model Z { @doc("x") x: int32 }`);
+      },
+    });
+
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+      import "./test.js";
+
+      @test @eval model X { x: int32 }
+      `
+    );
+
+    const { X } = (await testHost.compile("./")) as {
+      X: ModelType;
+    };
+    strictEqual((X.properties.get("x")!.type as ModelType).name, "int32");
+  });
+
   it("does lookup correctly", async () => {
     testHost.addCadlFile(
       "main.cadl",


### PR DESCRIPTION
Previously we were using the symbol from the cadl namespace declaration only, resulting in only cadl types but no decorators getting used.