### PR TITLE
Stop publishing .tsbuildinfo files

### DIFF
--- a/common/changes/@cadl-lang/compiler/clean-tsbuildinfo_2022-02-24-21-13.json
+++ b/common/changes/@cadl-lang/compiler/clean-tsbuildinfo_2022-02-24-21-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi/clean-tsbuildinfo_2022-02-24-21-13.json
+++ b/common/changes/@cadl-lang/openapi/clean-tsbuildinfo_2022-02-24-21-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/openapi3/clean-tsbuildinfo_2022-02-24-21-13.json
+++ b/common/changes/@cadl-lang/openapi3/clean-tsbuildinfo_2022-02-24-21-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/clean-tsbuildinfo_2022-02-24-21-13.json
+++ b/common/changes/@cadl-lang/rest/clean-tsbuildinfo_2022-02-24-21-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/versioning/clean-tsbuildinfo_2022-02-24-21-13.json
+++ b/common/changes/@cadl-lang/versioning/clean-tsbuildinfo_2022-02-24-21-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/common/changes/cadl-vscode/clean-tsbuildinfo_2022-02-24-21-13.json
+++ b/common/changes/cadl-vscode/clean-tsbuildinfo_2022-02-24-21-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vscode",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "cadl-vscode"
+}

--- a/common/changes/tmlanguage-generator/clean-tsbuildinfo_2022-02-24-21-13.json
+++ b/common/changes/tmlanguage-generator/clean-tsbuildinfo_2022-02-24-21-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "tmlanguage-generator",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "tmlanguage-generator"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4021,11 +4021,12 @@ packages:
       eslint: 8.9.0
       onigasm: 2.2.5
       plist: 3.0.4
+      rimraf: 3.0.2
       typescript: 4.5.5
     dev: false
     name: '@rush-temp/tmlanguage-generator'
     resolution:
-      integrity: sha512-2je3B5fn3fEHMvKgJSbMMCOJPuKA7z1Hib9zlrHB0pUnU5WzpM+w3FS/RZ7RRtPQ5mHef0Uavmd2xq6k+Zo/xA==
+      integrity: sha512-nKdhYEUuUjOleZFdVjXKiIjOuWZ2DqlgoyCDcc6m+4LeDUNhf4M/2KnjaS61OCPkRjrnY5fNgVY2GxnnkV5YvQ==
       tarball: file:projects/tmlanguage-generator.tgz
     version: 0.0.0
   file:projects/versioning.tgz:

--- a/packages/cadl-vscode/package.json
+++ b/packages/cadl-vscode/package.json
@@ -83,7 +83,7 @@
     ]
   },
   "scripts": {
-    "clean": "rimraf ./dist ./dist-dev",
+    "clean": "rimraf ./dist ./dist-dev ./temp",
     "build": "npm run compile && npm run rollup && npm run generate-tmlanguage && npm run generate-third-party-notices && npm run package-vsix",
     "compile": "tsc -p .",
     "watch": "tsc -p . --watch",

--- a/packages/cadl-vscode/tsconfig.json
+++ b/packages/cadl-vscode/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "outDir": "dist-dev",
     "rootDir": ".",
+    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo",
     "module": "CommonJS",
     "skipLibCheck": true,
     "types": ["node", "mocha"]

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -37,7 +37,7 @@
     "!dist/test/**"
   ],
   "scripts": {
-    "clean": "rimraf ./dist",
+    "clean": "rimraf ./dist ./temp",
     "build": "npm run compile",
     "compile": "tsc -p .",
     "watch": "tsc -p . --watch",

--- a/packages/compiler/tsconfig.json
+++ b/packages/compiler/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
+    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo",
     "types": ["node", "mocha"]
   },
   "include": ["./**/*.ts"],

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -37,7 +37,7 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "clean": "rimraf ./dist",
+    "clean": "rimraf ./dist ./temp",
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",
     "test": "mocha",

--- a/packages/openapi/tsconfig.json
+++ b/packages/openapi/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
+    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo",
     "types": ["node", "mocha"]
   },
   "include": ["src/**/*.ts", "test/**/*.ts"]

--- a/packages/openapi3/package.json
+++ b/packages/openapi3/package.json
@@ -23,7 +23,7 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "clean": "rimraf ./dist",
+    "clean": "rimraf ./dist ./temp",
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",
     "test": "mocha",

--- a/packages/openapi3/tsconfig.json
+++ b/packages/openapi3/tsconfig.json
@@ -8,6 +8,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
+    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo",
     "types": ["node", "mocha"]
   },
   "include": ["src/**/*.ts", "test/**/*.ts"]

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -37,7 +37,7 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "clean": "rimraf ./dist",
+    "clean": "rimraf ./dist ./temp",
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",
     "test": "mocha",

--- a/packages/rest/tsconfig.json
+++ b/packages/rest/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
+    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo",
     "types": ["node", "mocha"]
   },
   "include": ["src/**/*.ts", "test/**/*.ts"]

--- a/packages/tmlanguage-generator/package.json
+++ b/packages/tmlanguage-generator/package.json
@@ -22,6 +22,7 @@
     "node": ">=14.0.0"
   },
   "scripts": {
+    "clean": "rimraf ./dist ./temp",
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",
     "lint": "eslint . --ext .ts --max-warnings=0",
@@ -40,6 +41,7 @@
     "@types/plist": "~3.0.2",
     "@cadl-lang/eslint-config-cadl": "~0.1.0",
     "eslint": "^8.7.0",
+    "rimraf": "~3.0.2",
     "typescript": "~4.5.5"
   }
 }

--- a/packages/tmlanguage-generator/tsconfig.json
+++ b/packages/tmlanguage-generator/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
+    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo",
     "module": "CommonJS"
   },
   "include": ["src/**/*.ts"]

--- a/packages/versioning/package.json
+++ b/packages/versioning/package.json
@@ -37,7 +37,7 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "clean": "rimraf ./dist",
+    "clean": "rimraf ./dist ./temp",
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",
     "test": "mocha",

--- a/packages/versioning/tsconfig.json
+++ b/packages/versioning/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
+    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo",
     "types": ["node", "mocha"]
   },
   "include": ["src/**/*.ts", "test/**/*.ts"]


### PR DESCRIPTION
Also add clean script for tmlanguage-generator

It turns out the issue with cadl-vscode not building after `rush clean` was fixed as other changes to its config moved the tsbuildinfo to the dist-dev/ folder that is cleaned. But it's weird how this file can move around, so I've opted to explicitly put it in temp/ for all our projects and have temp/ get cleaned. This also removes the .tsbuildinfo from being shipped in our packages.