### PR TITLE
Add `no-console` eslint rule

### DIFF
--- a/common/changes/@cadl-lang/compiler/no-console_2022-03-07-17-35.json
+++ b/common/changes/@cadl-lang/compiler/no-console_2022-03-07-17-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/eslint-config-cadl/no-console_2022-03-07-17-35.json
+++ b/common/changes/@cadl-lang/eslint-config-cadl/no-console_2022-03-07-17-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/eslint-config-cadl",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/eslint-config-cadl"
+}

--- a/common/changes/tmlanguage-generator/no-console_2022-03-07-17-35.json
+++ b/common/changes/tmlanguage-generator/no-console_2022-03-07-17-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "tmlanguage-generator",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "tmlanguage-generator"
+}

--- a/packages/compiler/core/cli.ts
+++ b/packages/compiler/core/cli.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { spawnSync, SpawnSyncOptionsWithStringEncoding } from "child_process";
 import { mkdtemp, readdir, rmdir } from "fs/promises";
 import mkdirp from "mkdirp";

--- a/packages/compiler/core/diagnostics.ts
+++ b/packages/compiler/core/diagnostics.ts
@@ -238,8 +238,10 @@ export function logVerboseTestOutput(
 ) {
   if (process.env.CADL_VERBOSE_TEST_OUTPUT) {
     if (typeof messageOrCallback === "string") {
+      // eslint-disable-next-line no-console
       console.log(messageOrCallback);
     } else {
+      // eslint-disable-next-line no-console
       messageOrCallback(console.log);
     }
   }

--- a/packages/compiler/core/formatter.ts
+++ b/packages/compiler/core/formatter.ts
@@ -41,6 +41,7 @@ export async function formatCadlFiles(patterns: string[], { debug }: { debug?: b
     } catch (e) {
       if (e instanceof PrettierParserError) {
         const details = debug ? e.message : "";
+        // eslint-disable-next-line no-console
         console.error(`File '${file}' failed to fromat. ${details}`);
       } else {
         throw e;
@@ -67,6 +68,7 @@ export async function findUnformattedCadlFiles(
     } catch (e) {
       if (e instanceof PrettierParserError) {
         const details = debug ? e.message : "";
+        // eslint-disable-next-line no-console
         console.error(`File '${file}' failed to fromat. ${details}`);
         unformatted.push(file);
       } else {

--- a/packages/compiler/core/install.ts
+++ b/packages/compiler/core/install.ts
@@ -19,10 +19,12 @@ export async function installCadlDependencies(directory: string): Promise<void> 
   return new Promise(() => {
     child.on("error", (error: SpawnError) => {
       if (error.code === "ENOENT") {
+        // eslint-disable-next-line no-console
         console.error(
           "Cannot find `npm` executable. Make sure to have npm installed in your path."
         );
       } else {
+        // eslint-disable-next-line no-console
         console.error("Error", error);
       }
       process.exit(error.errno);

--- a/packages/compiler/core/logger.ts
+++ b/packages/compiler/core/logger.ts
@@ -48,6 +48,7 @@ function processLog(log: LogInfo): ProcessedLog {
 
 export function createConsoleSink(): LogSink {
   function log(data: ProcessedLog) {
+    // eslint-disable-next-line no-console
     console.log(formatLog(data));
   }
 

--- a/packages/compiler/init/init.ts
+++ b/packages/compiler/init/init.ts
@@ -203,6 +203,7 @@ export async function scaffoldNewProject(host: CompilerHost, config: Scaffolding
   await writeMain(host, config);
   await writeFiles(host, config);
 
+  // eslint-disable-next-line no-console
   console.log("Cadl init completed. You can run `cadl install` now to install dependencies.");
 }
 

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -81,12 +81,16 @@ export function getDoc(program: Program, target: Type): string | undefined {
 }
 
 export function inspectType(program: Program, target: Type, text: string) {
+  // eslint-disable-next-line no-console
   if (text) console.log(text);
+  // eslint-disable-next-line no-console
   console.dir(target, { depth: 3 });
 }
 
 export function inspectTypeName(program: Program, target: Type, text: string) {
+  // eslint-disable-next-line no-console
   if (text) console.log(text);
+  // eslint-disable-next-line no-console
   console.log(program.checker!.getTypeName(target));
 }
 

--- a/packages/compiler/server/server.ts
+++ b/packages/compiler/server/server.ts
@@ -70,8 +70,10 @@ function fatalError(e: any) {
   // If we failed to send any log messages over LSP pipe, send them to
   // stderr before exiting.
   for (const pending of server?.pendingMessages ?? []) {
+    // eslint-disable-next-line no-console
     console.error(pending);
   }
+  // eslint-disable-next-line no-console
   console.error(e);
   process.exit(1);
 }

--- a/packages/compiler/test/manual/fuzz.ts
+++ b/packages/compiler/test/manual/fuzz.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { logVerboseTestOutput } from "../../core/diagnostics.js";
 import { parse } from "../../core/parser.js";
 

--- a/packages/eslint-config-cadl/index.js
+++ b/packages/eslint-config-cadl/index.js
@@ -34,6 +34,9 @@ module.exports = {
         destructuring: "all",
       },
     ],
+
+    // Do not want console.log left from debugging or using console.log for logging. Use the program logger.
+    "no-console": "warn",
   },
   ignorePatterns: ["dist/**/*", "dist-dev/**/*"],
   overrides: [

--- a/packages/tmlanguage-generator/src/tmlanguage-generator.ts
+++ b/packages/tmlanguage-generator/src/tmlanguage-generator.ts
@@ -184,7 +184,9 @@ async function processGrammar(grammar: Grammar, options: EmitOptions): Promise<a
       }
       const sourceFile = options.errorSourceFilePath ?? "unknown_file";
       //prettier-ignore
+      // eslint-disable-next-line no-console
       console.error(`${sourceFile}(1,1): error TM0001: Bad regex: ${JSON.stringify({[prop]: regexp})}: ${err.message}`);
+      // eslint-disable-next-line no-console
       console.error(node);
       throw err;
     }


### PR DESCRIPTION
Add the `no-console` eslint rule as warning that will create a lint warning if using any of the `console.` functions. This will prevent leaving debug `console.log` in the code as well as trying to use console.log for logging information instead of the program logger