### PR TITLE
Redirect console.* output in language server to stderr

### DIFF
--- a/common/changes/@cadl-lang/compiler/redirect-stdout_2022-03-08-18-57.json
+++ b/common/changes/@cadl-lang/compiler/redirect-stdout_2022-03-08-18-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add back `@inspectType` and `@inspectTypeName` decorators",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/compiler/redirect-stdout_2022-03-08-18-58.json
+++ b/common/changes/@cadl-lang/compiler/redirect-stdout_2022-03-08-18-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Redirect console.log to stderr in language server",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/cadl-vs/redirect-stdout_2022-03-08-18-57.json
+++ b/common/changes/cadl-vs/redirect-stdout_2022-03-08-18-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vs",
+      "comment": "Remove debug assert for stderr output from language server",
+      "type": "patch"
+    }
+  ],
+  "packageName": "cadl-vs"
+}

--- a/packages/cadl-vs/src/VSExtension.cs
+++ b/packages/cadl-vs/src/VSExtension.cs
@@ -122,14 +122,7 @@ namespace Microsoft.Cadl.VisualStudio {
         return;
       }
 
-      // Normally logging from language server should come through LSP. If something
-      // gets here via stderr (besides the messages from node about the debugger),
-      // there's probably a bug.
       Debugger.Log(0, null, "cadl-server (stderr): " + message);
-      Debug.Assert(
-        message.IndexOf("debugger", StringComparison.OrdinalIgnoreCase) >= 0 ||
-        message.IndexOf("https://nodejs.org/en/docs/inspector", StringComparison.Ordinal) >= 0,
-        "Unexpected output on stderr from cadl-server: " + message);
     }
 
 #if DEBUG

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -1,4 +1,3 @@
-import { inspect } from "util";
 import {
   validateDecoratorParamType,
   validateDecoratorTarget,
@@ -81,18 +80,18 @@ export function getDoc(program: Program, target: Type): string | undefined {
   return program.stateMap(docsKey).get(target);
 }
 
-export function inspectType(program: Program, target: Type, text: string) {
+export function $inspectType(program: Program, target: Type, text: string) {
   // eslint-disable-next-line no-console
-  if (text) console.error(text);
+  if (text) console.log(text);
   // eslint-disable-next-line no-console
-  console.error(inspect(target, { depth: 3 }));
+  console.dir(target, { depth: 3 });
 }
 
-export function inspectTypeName(program: Program, target: Type, text: string) {
+export function $inspectTypeName(program: Program, target: Type, text: string) {
   // eslint-disable-next-line no-console
-  if (text) console.error(text);
+  if (text) console.log(text);
   // eslint-disable-next-line no-console
-  console.error(program.checker!.getTypeName(target));
+  console.log(program.checker!.getTypeName(target));
 }
 
 const intrinsicsKey = Symbol();

--- a/packages/compiler/server/server.ts
+++ b/packages/compiler/server/server.ts
@@ -24,7 +24,7 @@ function main() {
   // Redirect all console stdout output to stderr since LSP pipe uses stdout
   // and writing to stdout for anything other than LSP protocol will break
   // things badly.
-  console = new Console(process.stderr, process.stderr);
+  global.console = new Console(process.stderr, process.stderr);
 
   let clientHasWorkspaceFolderCapability = false;
   const connection = createConnection(ProposedFeatures.all);

--- a/packages/compiler/server/server.ts
+++ b/packages/compiler/server/server.ts
@@ -1,3 +1,4 @@
+import { Console } from "console";
 import { fileURLToPath } from "url";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import {
@@ -20,6 +21,11 @@ try {
 }
 
 function main() {
+  // Redirect all console stdout output to stderr since LSP pipe uses stdout
+  // and writing to stdout for anything other than LSP protocol will break
+  // things badly.
+  console = new Console(process.stderr, process.stderr);
+
   let clientHasWorkspaceFolderCapability = false;
   const connection = createConnection(ProposedFeatures.all);
   const documents = new TextDocuments(TextDocument);


### PR DESCRIPTION
Logging to stdout breaks LSP when the stdio pipe is used. The failure mode when console.log is used unexpectedly is really bad and can take a very long time to diagnose.

This change makes the language server use stderr for all console methods, so now when decorators or emitters reach for console.log, they will just see their output.

This change also restores inpsectType and inspectTypeName as decorators. I think they never got the $ prefix, and I think this was unintentional. They happen to serve as a good ad-hoc manual test that console.log now works as we expect, which is why they are reinstated here.

In VS Code, the output to stderr from language server will show up in the Cadl output pane.

However, in VS Classic, it currently goes to debugger log only. You have to be attached to see it. It's possible to fix this, but we deleted a whole bunch of code from the VS extension to stop making output pane messages ourselves and I'd prefer not to reinstate it unless we decide we really need it.

Fix #291 

cc @xirzec