### PR TITLE
Fix: Issue with generated `.d.ts` file being invalid with diagnostic types

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-definition-files_2022-03-09-00-48.json
+++ b/common/changes/@cadl-lang/compiler/fix-definition-files_2022-03-09-00-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -1235,7 +1235,7 @@ export interface CadlLibrary<
     names?: readonly E[];
   };
 
-  reportDiagnostic<C extends keyof T, M extends keyof T[C] = "default">(
+  reportDiagnostic<C extends keyof T, M extends keyof T[C]>(
     program: Program,
     diag: DiagnosticReport<T, C, M>
   ): void;


### PR DESCRIPTION
fix #304

Removing `= "default"` doesn't seem to affect the typing of `reportDiagnostic`. Typescript is smart enough to infer "default" from the `DiagnosticReport` interface.

Issue really was that typescript would extract the typing for the reportDiagnostic function as we are reexporting it and that exported type is not valid.