### PR TITLE
Allow template params to be intersected

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-intersection-templates_2022-03-15-18-57.json
+++ b/common/changes/@cadl-lang/compiler/fix-intersection-templates_2022-03-15-18-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix using `&` with tempalte parameters",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/test/checker/intersections.ts
+++ b/packages/compiler/test/checker/intersections.ts
@@ -7,7 +7,7 @@ import {
   expectDiagnostics,
 } from "../../testing/index.js";
 
-describe.only("compiler: intersections", () => {
+describe("compiler: intersections", () => {
   let runner: BasicTestRunner;
 
   beforeEach(async () => {

--- a/packages/compiler/test/checker/intersections.ts
+++ b/packages/compiler/test/checker/intersections.ts
@@ -1,0 +1,62 @@
+import { ok, strictEqual } from "assert";
+import { ModelType } from "../../core/index.js";
+import {
+  BasicTestRunner,
+  createTestHost,
+  createTestWrapper,
+  expectDiagnostics,
+} from "../../testing/index.js";
+
+describe.only("compiler: intersections", () => {
+  let runner: BasicTestRunner;
+
+  beforeEach(async () => {
+    const host = await createTestHost();
+    runner = createTestWrapper(host, (code) => code);
+  });
+
+  it("intersect 2 models", async () => {
+    const { Foo } = (await runner.compile(`
+      @test model Foo {
+        prop: {a: string} & {b: string};
+      }
+    `)) as { Foo: ModelType };
+
+    const prop = Foo.properties.get("prop")!.type as ModelType;
+    strictEqual(prop.kind, "Model");
+    strictEqual(prop.properties.size, 2);
+    ok(prop.properties.has("a"));
+    ok(prop.properties.has("b"));
+  });
+
+  it("allow intersections of template params", async () => {
+    const { Foo } = (await runner.compile(`
+      model Bar<A, B> {
+        prop: A & B;
+      }
+      @test model Foo {
+        prop: Bar<{a: string}, {b: string}>;
+      }
+    `)) as { Foo: ModelType };
+
+    const Bar = Foo.properties.get("prop")!.type as ModelType;
+    const prop = Bar.properties.get("prop")!.type as ModelType;
+    strictEqual(prop.kind, "Model");
+    strictEqual(prop.properties.size, 2);
+    ok(prop.properties.has("a"));
+    ok(prop.properties.has("b"));
+  });
+
+  it("emit diagnostic if one of the intersected type is not a model", async () => {
+    const diagnostics = await runner.diagnose(`
+      @test model Foo {
+        prop: {a: string} & "string literal";
+      }
+    `);
+
+    expectDiagnostics(diagnostics, {
+      code: "intersect-non-model",
+      message: "Cannot intersect non-model types (including union types).",
+    });
+  });
+});


### PR DESCRIPTION
fix #301

Enable the following scenario
```cadl
model Bar<A, B> {
  prop: A & B;
}
```

Do the same logic as with spread: ignore the template parameter