### PR TITLE
Add base discriminator property with doc

### DIFF
--- a/common/changes/@cadl-lang/openapi3/base-discriminator-doc_2022-03-15-20-06.json
+++ b/common/changes/@cadl-lang/openapi3/base-discriminator-doc_2022-03-15-20-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Include discriminator property in base schema with a boilerplace description",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/base-discriminator-doc_2022-03-15-20-06.json
+++ b/common/changes/@cadl-lang/rest/base-discriminator-doc_2022-03-15-20-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -60,7 +60,7 @@ import {
 } from "@cadl-lang/rest";
 import { getVersionRecords } from "@cadl-lang/versioning";
 import { OpenAPILibrary, reportDiagnostic } from "./lib.js";
-import {  OpenAPI3Discriminator, OpenAPI3Schema } from "./types.js";
+import { OpenAPI3Discriminator, OpenAPI3Schema } from "./types.js";
 
 const {
   getHeaderFieldName,
@@ -1014,17 +1014,17 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
         return {};
       }
 
-      const openApiDiscriminator: OpenAPI3Discriminator = {...discriminator};
+      const openApiDiscriminator: OpenAPI3Discriminator = { ...discriminator };
       const mapping = getDiscriminatorMapping(discriminator, childModels);
-      if(mapping) {
+      if (mapping) {
         openApiDiscriminator.mapping = mapping;
       }
 
       modelSchema.discriminator = openApiDiscriminator;
       modelSchema.properties[discriminator.propertyName] = {
         type: "string",
-        description: `Discriminator property for ${model.name}.`
-      }
+        description: `Discriminator property for ${model.name}.`,
+      };
     }
 
     applyExternalDocs(model, modelSchema);
@@ -1099,7 +1099,10 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     }
   }
 
-  function validateDiscriminator(discriminator: Discriminator, childModels: readonly ModelType[]): boolean {
+  function validateDiscriminator(
+    discriminator: Discriminator,
+    childModels: readonly ModelType[]
+  ): boolean {
     const { propertyName } = discriminator;
     const retVals = childModels.map((t) => {
       const prop = getProperty(t, propertyName);
@@ -1151,7 +1154,10 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     return retVals.every((v) => v);
   }
 
-  function getDiscriminatorMapping(discriminator: any, childModels: readonly ModelType[]): Record<string, string> | undefined {
+  function getDiscriminatorMapping(
+    discriminator: any,
+    childModels: readonly ModelType[]
+  ): Record<string, string> | undefined {
     const { propertyName } = discriminator;
     const getMapping = (t: ModelType): any => {
       const prop = t.properties?.get(propertyName);

--- a/packages/openapi3/src/types.ts
+++ b/packages/openapi3/src/types.ts
@@ -1,0 +1,24 @@
+export type ExtensionKey = `x-${string}`;
+
+export type Extensions = {
+  [key in ExtensionKey]?: any;
+};
+
+export interface OpenAPI3Discriminator extends Extensions {
+  propertyName: string;
+  mapping?: Record<string, string>;
+}
+
+export type JsonType = "array" | "boolean" | "integer" | "number" |  "object" | "string";
+
+export type OpenAPI3Schema = Extensions & {
+  type: JsonType;
+  description?: string;
+  properties?: Record<string, any>;
+  required?: string[];
+  discriminator?: OpenAPI3Discriminator;
+
+  allOf?: any[];
+  anyOf?: any[];
+  oneOf?: any[];
+}

--- a/packages/openapi3/src/types.ts
+++ b/packages/openapi3/src/types.ts
@@ -9,7 +9,7 @@ export interface OpenAPI3Discriminator extends Extensions {
   mapping?: Record<string, string>;
 }
 
-export type JsonType = "array" | "boolean" | "integer" | "number" |  "object" | "string";
+export type JsonType = "array" | "boolean" | "integer" | "number" | "object" | "string";
 
 export type OpenAPI3Schema = Extensions & {
   type: JsonType;
@@ -21,4 +21,4 @@ export type OpenAPI3Schema = Extensions & {
   allOf?: any[];
   anyOf?: any[];
   oneOf?: any[];
-}
+};

--- a/packages/openapi3/test/test-discriminator.ts
+++ b/packages/openapi3/test/test-discriminator.ts
@@ -42,7 +42,12 @@ describe("openapi3: discriminated unions", () => {
     });
     deepStrictEqual(openApi.components.schemas.Pet, {
       type: "object",
-      properties: {},
+      properties: {
+        kind: {
+          type: "string",
+          description: "Discriminator property for Pet.",
+        },
+      },
       discriminator: {
         propertyName: "kind",
         mapping: {
@@ -84,7 +89,14 @@ describe("openapi3: discriminated unions", () => {
     });
     deepStrictEqual(openApi.components.schemas.Pet, {
       type: "object",
-      properties: { name: { type: "string" }, weight: { type: "number", format: "float" } },
+      properties: {
+        kind: {
+          type: "string",
+          description: "Discriminator property for Pet.",
+        },
+        name: { type: "string" },
+        weight: { type: "number", format: "float" },
+      },
       required: ["name"],
       discriminator: {
         propertyName: "kind",
@@ -171,7 +183,14 @@ describe("openapi3: discriminated unions", () => {
     });
     deepStrictEqual(openApi.components.schemas.Pet, {
       type: "object",
-      properties: { name: { type: "string" }, weight: { type: "number", format: "float" } },
+      properties: {
+        name: { type: "string" },
+        kind: {
+          type: "string",
+          description: "Discriminator property for Pet.",
+        },
+        weight: { type: "number", format: "float" },
+      },
       required: ["name"],
       discriminator: {
         propertyName: "kind",
@@ -228,7 +247,14 @@ describe("openapi3: discriminated unions", () => {
     });
     deepStrictEqual(openApi.components.schemas.Pet, {
       type: "object",
-      properties: { name: { type: "string" }, weight: { type: "number", format: "float" } },
+      properties: {
+        kind: {
+          type: "string",
+          description: "Discriminator property for Pet.",
+        },
+        name: { type: "string" },
+        weight: { type: "number", format: "float" },
+      },
       required: ["name"],
       discriminator: {
         propertyName: "kind",
@@ -240,7 +266,14 @@ describe("openapi3: discriminated unions", () => {
     });
     deepStrictEqual(openApi.components.schemas.Dog, {
       type: "object",
-      properties: { kind: { type: "string", enum: ["dog"] }, bark: { type: "string" } },
+      properties: {
+        kind: { type: "string", enum: ["dog"] },
+        breed: {
+          type: "string",
+          description: "Discriminator property for Dog.",
+        },
+        bark: { type: "string" },
+      },
       required: ["kind", "bark"],
       allOf: [{ $ref: "#/components/schemas/Pet" }],
       discriminator: {
@@ -293,8 +326,8 @@ describe("openapi3: discriminated unions", () => {
       properties: {
         kind: {
           type: "string",
-          description: "Discriminator property for Pet."
-        }
+          description: "Discriminator property for Pet.",
+        },
       },
       discriminator: {
         propertyName: "kind",

--- a/packages/openapi3/test/test-discriminator.ts
+++ b/packages/openapi3/test/test-discriminator.ts
@@ -290,7 +290,12 @@ describe("openapi3: discriminated unions", () => {
     });
     deepStrictEqual(openApi.components.schemas.Pet, {
       type: "object",
-      properties: {},
+      properties: {
+        kind: {
+          type: "string",
+          description: "Discriminator property for Pet."
+        }
+      },
       discriminator: {
         propertyName: "kind",
         mapping: {

--- a/packages/rest/src/rest.ts
+++ b/packages/rest/src/rest.ts
@@ -41,6 +41,10 @@ export function getConsumes(program: Program, entity: Type): string[] {
   return program.stateMap(consumesTypesKey).get(entity) || [];
 }
 
+export interface Discriminator {
+  propertyName: string;
+}
+
 const discriminatorKey = Symbol();
 export function $discriminator({ program }: DecoratorContext, entity: Type, propertyName: string) {
   if (!validateDecoratorTarget(program, entity, "@discriminator", "Model")) {
@@ -49,7 +53,7 @@ export function $discriminator({ program }: DecoratorContext, entity: Type, prop
   program.stateMap(discriminatorKey).set(entity, propertyName);
 }
 
-export function getDiscriminator(program: Program, entity: Type): any | undefined {
+export function getDiscriminator(program: Program, entity: Type): Discriminator | undefined {
   const propertyName = program.stateMap(discriminatorKey).get(entity);
   if (propertyName) {
     return { propertyName };

--- a/packages/samples/test/output/polymorphism/openapi.json
+++ b/packages/samples/test/output/polymorphism/openapi.json
@@ -30,6 +30,10 @@
       "Pet": {
         "type": "object",
         "properties": {
+          "kind": {
+            "type": "string",
+            "description": "Discriminator property for Pet."
+          },
           "name": {
             "type": "string"
           },


### PR DESCRIPTION
fix #280

When emitting a base class add the discriminator as a `type:string` property and add a description.

Also adds some basic types of the OpenAPI document: to be expanded