### PR TITLE
Fix various issues with template types with errors

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-circular-template-ref_2022-03-18-16-23.json
+++ b/common/changes/@cadl-lang/compiler/fix-circular-template-ref_2022-03-18-16-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix: stack overflow when defining template argument where default reference argument itself. `Foo<T = T>`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -1223,9 +1223,11 @@ export function createChecker(program: Program): Checker {
       if (binding) return binding.flags & SymbolFlags.DuplicateUsing ? undefined : binding;
     }
 
-    program.reportDiagnostic(
-      createDiagnostic({ code: "unknown-identifier", format: { id: node.sv }, target: node })
-    );
+    if (!isInstantiatingTemplateType()) {
+      program.reportDiagnostic(
+        createDiagnostic({ code: "unknown-identifier", format: { id: node.sv }, target: node })
+      );
+    }
     return undefined;
   }
 

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -1496,11 +1496,13 @@ export function createChecker(program: Program): Checker {
     }
 
     if (pendingResolutions.has(getNodeSymId(target.declarations[0] as any))) {
-      reportDiagnostic(program, {
-        code: "circular-base-type",
-        format: { typeName: (target.declarations[0] as any).id.sv },
-        target: target,
-      });
+      if (!instantiatingTemplate) {
+        reportDiagnostic(program, {
+          code: "circular-base-type",
+          format: { typeName: (target.declarations[0] as any).id.sv },
+          target: target,
+        });
+      }
       return undefined;
     }
     const heritageType = checkTypeReferenceSymbol(target, heritageRef);
@@ -1543,11 +1545,13 @@ export function createChecker(program: Program): Checker {
       return undefined;
     }
     if (pendingResolutions.has(getNodeSymId(target.declarations[0] as any))) {
-      reportDiagnostic(program, {
-        code: "circular-base-type",
-        format: { typeName: (target.declarations[0] as any).id.sv },
-        target: target,
-      });
+      if (!instantiatingTemplate) {
+        reportDiagnostic(program, {
+          code: "circular-base-type",
+          format: { typeName: (target.declarations[0] as any).id.sv },
+          target: target,
+        });
+      }
       return undefined;
     }
     const isType = checkTypeReferenceSymbol(target, isExpr);

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -720,7 +720,8 @@ export function createChecker(program: Program): Checker {
       if (isErrorType(type)) {
         return errorType;
       } else {
-        throw new Error(
+        compilerAssert(
+          false,
           `Unexpected checker error. symbolLinks.instantiations was not defined for ${
             SyntaxKind[templateNode.kind]
           }`

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -261,6 +261,7 @@ export interface UnionTypeVariant extends BaseType, DecoratedType {
 export interface TemplateParameterType extends BaseType {
   kind: "TemplateParameter";
   node: TemplateParameterDeclarationNode;
+  default?: Type;
 }
 
 export interface Sym {

--- a/packages/compiler/test/checker/alias.ts
+++ b/packages/compiler/test/checker/alias.ts
@@ -177,6 +177,22 @@ describe("compiler: aliases", () => {
     });
   });
 
+  it("emit single diagnostics if assign itself as generic and is referenced", async () => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+      alias A<T> = A<T>;
+
+      model Foo {a: A<string>}
+      `
+    );
+    const diagnostics = await testHost.diagnose("main.cadl");
+    expectDiagnostics(diagnostics, {
+      code: "circular-alias-type",
+      message: "Alias type 'A' recursively references itself.",
+    });
+  });
+
   it("emit diagnostics if reference itself", async () => {
     testHost.addCadlFile(
       "main.cadl",

--- a/packages/compiler/test/checker/model.ts
+++ b/packages/compiler/test/checker/model.ts
@@ -78,6 +78,27 @@ describe("compiler: models", () => {
     strictEqual(calls, 0);
   });
 
+  it("emit single error when there is an invalid ref in a templated type", async () => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+        model A<T> {t: T, invalid: notValidType }
+
+        model Bar {
+          instance1: A<string>;
+          instance2: A<int32>;
+        }
+        `
+    );
+    const diagnostics = await testHost.diagnose("main.cadl");
+    expectDiagnostics(diagnostics, [
+      {
+        code: "unknown-identifier",
+        message: "Unknown identifier notValidType",
+      },
+    ]);
+  });
+
   describe("doesn't allow a default of different type than the property type", () => {
     const testCases: [string, string, RegExp][] = [
       ["string", "123", /Default must be a string/],

--- a/packages/compiler/test/checker/templates.ts
+++ b/packages/compiler/test/checker/templates.ts
@@ -215,6 +215,25 @@ describe("compiler: templates", () => {
     });
   });
 
+  it("emit diagnostics if args reference each other", async () => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+        @test model A<T = K, K = T> { a: T }
+        model B { 
+          foo: A
+        };
+      `
+    );
+
+    const diagnostics = await testHost.diagnose("main.cadl");
+    expectDiagnostics(diagnostics, {
+      code: "invalid-template-default",
+      message:
+        "Template parameter defaults can only reference previously declared type parameters.",
+    });
+  });
+
   it("emit diagnostics if referencing itself nested", async () => {
     testHost.addCadlFile(
       "main.cadl",

--- a/packages/compiler/test/checker/templates.ts
+++ b/packages/compiler/test/checker/templates.ts
@@ -179,14 +179,15 @@ describe("compiler: templates", () => {
     testHost.addCadlFile(
       "main.cadl",
       `
-        @test model A<T, X = T> { a: T, b: X }
-        model B { 
+        model A<T, X = T> { a: T, b: X }
+        @test model B { 
           foo: A<"bye">
         };
       `
     );
 
-    const { A } = (await testHost.compile("main.cadl")) as { A: ModelType };
+    const { B } = (await testHost.compile("main.cadl")) as { B: ModelType };
+    const A = B.properties.get("foo")?.type as any as ModelType;
     const a = A.properties.get("a")!;
     const b = A.properties.get("b")!;
     strictEqual(a.type.kind, "String");
@@ -195,7 +196,7 @@ describe("compiler: templates", () => {
     strictEqual((b.type as StringLiteralType).value, "bye");
   });
 
-  it.only("emit diagnostics if referencing itself", async () => {
+  it("emit diagnostics if referencing itself", async () => {
     testHost.addCadlFile(
       "main.cadl",
       `
@@ -214,7 +215,7 @@ describe("compiler: templates", () => {
     });
   });
 
-  it.only("emit diagnostics if referencing itself nested", async () => {
+  it("emit diagnostics if referencing itself nested", async () => {
     testHost.addCadlFile(
       "main.cadl",
       `

--- a/packages/compiler/test/checker/templates.ts
+++ b/packages/compiler/test/checker/templates.ts
@@ -179,15 +179,14 @@ describe("compiler: templates", () => {
     testHost.addCadlFile(
       "main.cadl",
       `
-        model A<T, X = T> { a: T, b: X }
-        @test model B { 
+        @test model A<T, X = T> { a: T, b: X }
+        model B { 
           foo: A<"bye">
         };
       `
     );
 
-    const { B } = (await testHost.compile("main.cadl")) as { B: ModelType };
-    const A = B.properties.get("foo")?.type as any as ModelType;
+    const { A } = (await testHost.compile("main.cadl")) as { A: ModelType };
     const a = A.properties.get("a")!;
     const b = A.properties.get("b")!;
     strictEqual(a.type.kind, "String");

--- a/packages/compiler/test/checker/templates.ts
+++ b/packages/compiler/test/checker/templates.ts
@@ -195,23 +195,41 @@ describe("compiler: templates", () => {
     strictEqual((b.type as StringLiteralType).value, "bye");
   });
 
-  it.skip("can only reference parameters prior to itself", async () => {
+  it.only("emit diagnostics if referencing itself", async () => {
     testHost.addCadlFile(
       "main.cadl",
       `
-        @test model A<T = U, U = "hi"> { a: T, b: U }
+        @test model A<T = T> { a: T }
         model B { 
           foo: A
         };
       `
     );
 
-    const { A } = (await testHost.compile("main.cadl")) as { A: ModelType };
-    const a = A.properties.get("a")!;
-    const b = A.properties.get("b")!;
-    strictEqual(a.type.kind, "String");
-    strictEqual((a.type as StringLiteralType).value, "bye");
-    strictEqual(b.type.kind, "String");
-    strictEqual((b.type as StringLiteralType).value, "bye");
+    const diagnostics = await testHost.diagnose("main.cadl");
+    expectDiagnostics(diagnostics, {
+      code: "invalid-template-default",
+      message:
+        "Template parameter defaults can only reference previously declared type parameters.",
+    });
+  });
+
+  it.only("emit diagnostics if referencing itself nested", async () => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+        @test model A<T = {foo: T}> { a: T }
+        model B { 
+          foo: A
+        };
+      `
+    );
+
+    const diagnostics = await testHost.diagnose("main.cadl");
+    expectDiagnostics(diagnostics, {
+      code: "invalid-template-default",
+      message:
+        "Template parameter defaults can only reference previously declared type parameters.",
+    });
   });
 });


### PR DESCRIPTION
fix #294 

Issues fixed: 
- [x] Stackoverflow when template default self reference itself `Foo<A = A>`
- [x] Duplicate diagnostics in circular reference of a templated type. `model Foo<T> is Foo<T>` Would create 1 diagnostic + 1 per different instantiation
- [x] Crash when templated alias self references = `alias Foo<T> = Foo<T>`. 
- [ ] Duplicate diagnostics when error in a templated type
   - [x]  unknown identifier `model Foo<A> { a: A;  b: stringw}`
