### PR TITLE
Fix VSCode extension

### DIFF
--- a/common/changes/@cadl-lang/prettier-plugin-cadl/fix-cadl-vscode_2022-03-18-22-08.json
+++ b/common/changes/@cadl-lang/prettier-plugin-cadl/fix-cadl-vscode_2022-03-18-22-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/prettier-plugin-cadl",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/prettier-plugin-cadl"
+}

--- a/common/changes/cadl-vscode/fix-cadl-vscode_2022-03-18-22-08.json
+++ b/common/changes/cadl-vscode/fix-cadl-vscode_2022-03-18-22-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vscode",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "cadl-vscode"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 dependencies:
-  '@rollup/plugin-commonjs': 17.1.0_rollup@2.70.1
+  '@rollup/plugin-commonjs': 22.0.0-13_rollup@2.70.1
   '@rollup/plugin-json': 4.1.0_rollup@2.70.1
-  '@rollup/plugin-node-resolve': 11.2.1_rollup@2.70.1
+  '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
   '@rollup/plugin-replace': 2.4.2_rollup@2.70.1
   '@rush-temp/cadl-playground': file:projects/cadl-playground.tgz
   '@rush-temp/cadl-vs': file:projects/cadl-vs.tgz
@@ -244,23 +244,23 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
-  /@rollup/plugin-commonjs/17.1.0_rollup@2.70.1:
+  /@rollup/plugin-commonjs/22.0.0-13_rollup@2.70.1:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.70.1
       commondir: 1.0.1
       estree-walker: 2.0.2
-      glob: 7.1.7
+      glob: 7.2.0
       is-reference: 1.2.1
       magic-string: 0.25.7
       resolve: 1.22.0
       rollup: 2.70.1
     dev: false
     engines:
-      node: '>= 8.0.0'
+      node: '>= 12.0.0'
     peerDependencies:
-      rollup: ^2.30.0
+      rollup: ^2.68.0
     resolution:
-      integrity: sha512-PoMdXCw0ZyvjpCMT5aV4nkL0QywxP29sODQsSGeDpr/oI49Qq9tRtAsb/LbYbDzFlOydVEqHmmZWFtXJEAX9ew==
+      integrity: sha512-KkDaDbqUD4kIhlIQ5z1cqiBu+MA8ebXAESoVxid/UXz47aghQvtajCzlRxXEB97aD9QJju8Hc6tkaCPaNqpt7g==
   /@rollup/plugin-json/4.1.0_rollup@2.70.1:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.70.1
@@ -270,7 +270,7 @@ packages:
       rollup: ^1.20.0 || ^2.0.0
     resolution:
       integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
-  /@rollup/plugin-node-resolve/11.2.1_rollup@2.70.1:
+  /@rollup/plugin-node-resolve/13.1.3_rollup@2.70.1:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.70.1
       '@types/resolve': 1.17.1
@@ -283,9 +283,9 @@ packages:
     engines:
       node: '>= 10.0.0'
     peerDependencies:
-      rollup: ^1.20.0||^2.0.0
+      rollup: ^2.42.0
     resolution:
-      integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==
+      integrity: sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==
   /@rollup/plugin-replace/2.4.2_rollup@2.70.1:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.70.1
@@ -2101,7 +2101,7 @@ packages:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.0.4
+      minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: false
@@ -4212,8 +4212,8 @@ packages:
     version: 0.0.0
   file:projects/cadl-vscode.tgz:
     dependencies:
-      '@rollup/plugin-commonjs': 17.1.0_rollup@2.70.1
-      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.70.1
+      '@rollup/plugin-commonjs': 22.0.0-13_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       '@types/mkdirp': 1.0.2
       '@types/mocha': 9.1.0
       '@types/node': 14.0.27
@@ -4233,7 +4233,7 @@ packages:
     dev: false
     name: '@rush-temp/cadl-vscode'
     resolution:
-      integrity: sha512-o1SRBv2SMAA9HASyOuDo+cKYgUfl/tyK8t/2RYWAaEHDtOSNes+qxwV7MxAOXqOprLONlqpKO6iPNau1m17hmQ==
+      integrity: sha512-cEcVxeDGOZf2+nX7nqSYf156uw5GHbB5MohMjYWtH+YK7jyLMW4vMcVPnzXyNg17TVqBVYRJJMI9mUW67sJiDg==
       tarball: file:projects/cadl-vscode.tgz
     version: 0.0.0
   file:projects/compiler.tgz:
@@ -4324,9 +4324,9 @@ packages:
     version: 0.0.0
   file:projects/prettier-plugin-cadl.tgz:
     dependencies:
-      '@rollup/plugin-commonjs': 17.1.0_rollup@2.70.1
+      '@rollup/plugin-commonjs': 22.0.0-13_rollup@2.70.1
       '@rollup/plugin-json': 4.1.0_rollup@2.70.1
-      '@rollup/plugin-node-resolve': 11.2.1_rollup@2.70.1
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.70.1
       '@rollup/plugin-replace': 2.4.2_rollup@2.70.1
       mocha: 9.2.1
       prettier: 2.5.1
@@ -4334,7 +4334,7 @@ packages:
     dev: false
     name: '@rush-temp/prettier-plugin-cadl'
     resolution:
-      integrity: sha512-XeeKHGD8IjjxV/ONsM08j8GXt9SgLJZy1ZHdVuaOR1ucX3JviM1m+WY3oqhC6V09HCOdYep1CsvsewFltfzF7Q==
+      integrity: sha512-qXCdRK/gg8iAvtiRXneY/6CqhZ1IJSBzqpsx2qLvpH+J+5NKRWVvWvDC1BnQGKpkrZWUqaBXF4k8uuBWafcLRA==
       tarball: file:projects/prettier-plugin-cadl.tgz
     version: 0.0.0
   file:projects/rest.tgz:
@@ -4406,9 +4406,9 @@ packages:
       tarball: file:projects/versioning.tgz
     version: 0.0.0
 specifiers:
-  '@rollup/plugin-commonjs': ~17.1.0
+  '@rollup/plugin-commonjs': ~22.0.0-13
   '@rollup/plugin-json': ~4.1.0
-  '@rollup/plugin-node-resolve': ~11.2.0
+  '@rollup/plugin-node-resolve': ~13.1.3
   '@rollup/plugin-replace': ~2.4.2
   '@rush-temp/cadl-playground': file:./projects/cadl-playground.tgz
   '@rush-temp/cadl-vs': file:./projects/cadl-vs.tgz

--- a/packages/cadl-vscode/package.json
+++ b/packages/cadl-vscode/package.json
@@ -98,8 +98,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@rollup/plugin-commonjs": "~17.1.0",
-    "@rollup/plugin-node-resolve": "~11.2.0",
+    "@rollup/plugin-commonjs": "~22.0.0-13",
+    "@rollup/plugin-node-resolve": "~13.1.3",
     "@types/mkdirp": "~1.0.1",
     "@types/mocha": "~9.1.0",
     "@types/node": "~14.0.27",

--- a/packages/cadl-vscode/rollup.config.js
+++ b/packages/cadl-vscode/rollup.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
     file: "dist/src/extension.js",
     format: "commonjs",
     sourcemap: true,
-    exports: "default",
+    exports: "named",
   },
   external: ["fs/promises", "vscode"],
   plugins: [resolve({ preferBuiltins: true }), commonjs()],

--- a/packages/prettier-plugin-cadl/package.json
+++ b/packages/prettier-plugin-cadl/package.json
@@ -16,9 +16,9 @@
   },
   "devDependencies": {
     "@cadl-lang/compiler": "~0.29.0",
-    "@rollup/plugin-commonjs": "~17.1.0",
+    "@rollup/plugin-commonjs": "~22.0.0-13",
     "@rollup/plugin-json": "~4.1.0",
-    "@rollup/plugin-node-resolve": "~11.2.0",
+    "@rollup/plugin-node-resolve": "~13.1.3",
     "@rollup/plugin-replace": "~2.4.2",
     "mocha": "~9.2.0",
     "rollup": "~2.70.1"


### PR DESCRIPTION
PR that fixed the prettier plugin by upgrading rollup version #330 seems to have broken the bundling of the vscode extension. This also required updating the commonjs and nodejs resolve plugins.