### PR TITLE
Implement multiple response content types

### DIFF
--- a/common/changes/@cadl-lang/openapi3/multiple-response-contenttypes_2022-03-21-19-12.json
+++ b/common/changes/@cadl-lang/openapi3/multiple-response-contenttypes_2022-03-21-19-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "implement multiple response content types",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -30,7 +30,13 @@ export const libDef = {
     "duplicate-response": {
       severity: "error",
       messages: {
-        default: paramMessage`Multiple return types for status code ${"statusCode"}`,
+        default: paramMessage`Multiple return types for content type ${"contentType"} and status code ${"statusCode"}`,
+      },
+    },
+    "duplicate-header": {
+      severity: "error",
+      messages: {
+        default: paramMessage`The header ${"header"} is defined across multiple content types`,
       },
     },
     "content-type-ignored": {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -449,7 +449,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
         // OpenAPI can't represent different headers per content type.
         // So we merge headers here, and report any duplicates.
         // It may be possible in principle to not error for identically declared
-        // yeaders.
+        // headers.
         for (const [key, value] of Object.entries(headers)) {
           if (response.headers[key]) {
             reportDiagnostic(program, {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -424,20 +424,46 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     // Put them into currentEndpoint.responses
 
     for (const statusCode of statusCodes) {
-      if (currentEndpoint.responses[statusCode]) {
-        reportDiagnostic(program, {
-          code: "duplicate-response",
-          format: { statusCode },
-          target: responseModel,
-        });
-        continue;
-      }
-      const response: any = {
+      // the first model for this statusCode/content type pair carries the
+      // description for the endpoint. This could probably be improved.
+      const response = currentEndpoint.responses[statusCode] ?? {
         description: getResponseDescription(responseModel, statusCode),
-      };
-      if (Object.keys(headers).length > 0) {
-        response.headers = headers;
       }
+
+      // check for duplicates
+      if (response.content) {
+        for (const contentType of contentTypes) {
+          if (response.content[contentType]) {
+            reportDiagnostic(program, {
+              code: "duplicate-response",
+              format: { statusCode, contentType },
+              target: responseModel,
+            });
+          }
+        }
+      }
+
+      if (Object.keys(headers).length > 0) {
+        response.headers ??= {};
+        
+        // OpenAPI can't represent different headers per content type.
+        // So we merge headers here, and report any duplicates.
+        // It may be possible in principle to not error for identically declared
+        // yeaders.
+        for (const [key, value] of Object.entries(headers)) {
+          if (response.headers[key]) {
+            reportDiagnostic(program, {
+              code: "duplicate-header",
+              format: { header: key },
+              target: responseModel
+            });
+            continue;
+          }
+
+          response.headers[key] = value;
+        }
+      }
+
       for (const contentType of contentTypes) {
         response.content ??= {};
         const isBinary = isBinaryPayload(bodyModel!, contentType);

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -428,7 +428,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       // description for the endpoint. This could probably be improved.
       const response = currentEndpoint.responses[statusCode] ?? {
         description: getResponseDescription(responseModel, statusCode),
-      }
+      };
 
       // check for duplicates
       if (response.content) {
@@ -445,7 +445,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
 
       if (Object.keys(headers).length > 0) {
         response.headers ??= {};
-        
+
         // OpenAPI can't represent different headers per content type.
         // So we merge headers here, and report any duplicates.
         // It may be possible in principle to not error for identically declared
@@ -455,7 +455,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
             reportDiagnostic(program, {
               code: "duplicate-header",
               format: { header: key },
-              target: responseModel
+              target: responseModel,
             });
             continue;
           }

--- a/packages/openapi3/test/test-return-types.ts
+++ b/packages/openapi3/test/test-return-types.ts
@@ -298,7 +298,7 @@ describe("openapi3: return types", () => {
     `
     );
     expectDiagnostics(diagnostics, [{ code: "@cadl-lang/openapi3/duplicate-response" }]);
-    strictEqual(diagnostics[0].message, "Multiple return types for status code 200");
+    strictEqual(diagnostics[0].message, "Multiple return types for content type application/json and status code 200");
   });
 
   it("issues diagnostics for invalid status codes", async () => {
@@ -595,6 +595,38 @@ describe("openapi3: return types", () => {
     const res = await openApiFor(`@get op read(): {@body body: void};`);
     ok(res.paths["/"].get.responses["204"]);
   });
+
+  describe("multiple content types", () => {
+    it("handles multiple content types for the same status code", async () => {
+      const res = await openApiFor(
+        `@get op read():
+          | { @body body: {} }
+          | {@header contentType: "text/plain", @body body: string };
+        `);
+      ok(res.paths["/"].get.responses[200].content["application/json"]);
+      ok(res.paths["/"].get.responses[200].content["text/plain"]);
+    });
+
+    it("merges headers from multiple responses", async () => {
+      const res = await openApiFor(
+        `@get op read():
+          | { @body body: {}, @header foo: string }
+          | {@header contentType: "text/plain", @body body: string, @header bar: string };
+        `);
+      ok(res.paths["/"].get.responses[200].headers["foo"]);
+      ok(res.paths["/"].get.responses[200].headers["bar"]);
+    })
+
+    it("issues a diagnostic for duplicate headers across responses", async () => {
+      const diagnostics = await checkFor(
+        `@get op read():
+          | { @body body: {}, @header foo: string }
+          | {@header contentType: "text/plain", @body body: string, @header foo: string };
+        `);
+      expectDiagnostics(diagnostics, [{ code: "@cadl-lang/openapi3/duplicate-header" }]);
+    });
+  });
+
 
   describe("binary responses", () => {
     it("bytes responses should default to application/json with byte format", async () => {

--- a/packages/openapi3/test/test-return-types.ts
+++ b/packages/openapi3/test/test-return-types.ts
@@ -298,7 +298,10 @@ describe("openapi3: return types", () => {
     `
     );
     expectDiagnostics(diagnostics, [{ code: "@cadl-lang/openapi3/duplicate-response" }]);
-    strictEqual(diagnostics[0].message, "Multiple return types for content type application/json and status code 200");
+    strictEqual(
+      diagnostics[0].message,
+      "Multiple return types for content type application/json and status code 200"
+    );
   });
 
   it("issues diagnostics for invalid status codes", async () => {
@@ -602,7 +605,8 @@ describe("openapi3: return types", () => {
         `@get op read():
           | { @body body: {} }
           | {@header contentType: "text/plain", @body body: string };
-        `);
+        `
+      );
       ok(res.paths["/"].get.responses[200].content["application/json"]);
       ok(res.paths["/"].get.responses[200].content["text/plain"]);
     });
@@ -612,21 +616,22 @@ describe("openapi3: return types", () => {
         `@get op read():
           | { @body body: {}, @header foo: string }
           | {@header contentType: "text/plain", @body body: string, @header bar: string };
-        `);
+        `
+      );
       ok(res.paths["/"].get.responses[200].headers["foo"]);
       ok(res.paths["/"].get.responses[200].headers["bar"]);
-    })
+    });
 
     it("issues a diagnostic for duplicate headers across responses", async () => {
       const diagnostics = await checkFor(
         `@get op read():
           | { @body body: {}, @header foo: string }
           | {@header contentType: "text/plain", @body body: string, @header foo: string };
-        `);
+        `
+      );
       expectDiagnostics(diagnostics, [{ code: "@cadl-lang/openapi3/duplicate-header" }]);
     });
   });
-
 
   describe("binary responses", () => {
     it("bytes responses should default to application/json with byte format", async () => {


### PR DESCRIPTION
I was hoping to implement multiple REQUEST bodies to unblock Will but that side is much harder and seems wrapped up in the metadata proposal. Multiple response bodies though was fairly easy.