### PR TITLE
Add formatting button and shortcuts to playground

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4187,12 +4187,14 @@ packages:
       '@types/lz-string': 1.3.34
       '@types/mocha': 9.1.0
       '@types/node': 14.0.27
+      '@types/prettier': 2.4.4
       c8: 7.11.0
       debounce: 1.2.1
       eslint: 8.9.0
       lzutf8: 0.6.1
       mocha: 9.2.1
       monaco-editor: 0.32.1
+      prettier: 2.5.1
       rimraf: 3.0.2
       typescript: 4.5.5
       vite: 2.8.6
@@ -4200,7 +4202,7 @@ packages:
     dev: false
     name: '@rush-temp/cadl-playground'
     resolution:
-      integrity: sha512-UGZAFHtV4a5YVmt94avBe8sw+b3zfT7vPu41Q0FiGVuVRTAZSef4z/5lmYzWqYH4nYOwJn4QGx+1tDAK5w7zig==
+      integrity: sha512-pOK8nv/h53rStnLA9fnIjovtqJNkVNc9t9o2Uu15JkQVr6oisG4FvVhz4bn1jrxygsm3OFAKMyVuRjfKCN8FUw==
       tarball: file:projects/cadl-playground.tgz
     version: 0.0.0
   file:projects/cadl-vs.tgz:

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -20,9 +20,6 @@
         <label>
           <button id="newIssue">Open Issue</button>
         </label>
-        <label>
-          <button id="format">Format</button>
-        </label>
       </div>
       <div id="outputTabs"></div>
       <div id="editorContainer">

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -12,7 +12,7 @@
           <button id="share">Share</button>
         </label>
         <label>
-          Load a sample: 
+          Load a sample:
           <select id="samples">
             <option value="" disabled selected>Select sample...</option>
           </select>
@@ -20,15 +20,16 @@
         <label>
           <button id="newIssue">Open Issue</button>
         </label>
+        <label>
+          <button id="format">Format</button>
+        </label>
       </div>
-      <div id="outputTabs">
-      </div>
+      <div id="outputTabs"></div>
       <div id="editorContainer">
         <div id="editor"></div>
       </div>
       <div id="outputContainer">
-        <div id="output">
-        </div>
+        <div id="output"></div>
       </div>
     </div>
     <script type="module" src="/src/main.ts"></script>

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -42,6 +42,7 @@
     "@cadl-lang/openapi3": "~0.9.0",
     "@cadl-lang/openapi": "~0.7.0",
     "monaco-editor": "~0.32.1",
+    "prettier": "~2.5.1",
     "vite": "^2.8.0",
     "vscode-languageserver-textdocument": "~1.0.1",
     "lzutf8": "~0.6.1",
@@ -50,6 +51,7 @@
   "devDependencies": {
     "@types/mocha": "~9.1.0",
     "@types/node": "~14.0.27",
+    "@types/prettier": "^2.0.2",
     "@cadl-lang/eslint-config-cadl": "~0.2.0",
     "eslint": "^8.7.0",
     "mocha": "~9.2.0",

--- a/packages/playground/src/ui.ts
+++ b/packages/playground/src/ui.ts
@@ -66,7 +66,7 @@ export function createUI(host: BrowserHost) {
 
   document.getElementById("share")?.addEventListener("click", saveCode);
   document.getElementById("newIssue")?.addEventListener("click", newIssue);
-  document.getElementById("format")?.addEventListener("click", format);
+
   initSamples();
   doCompile();
 

--- a/packages/playground/src/ui.ts
+++ b/packages/playground/src/ui.ts
@@ -1,7 +1,8 @@
-import { compile, getSourceLocation } from "@cadl-lang/compiler";
+import { CadlPrettierPlugin, compile, getSourceLocation } from "@cadl-lang/compiler";
 import debounce from "debounce";
 import lzutf8 from "lzutf8";
 import * as monaco from "monaco-editor";
+import prettier from "prettier";
 import { BrowserHost } from "./browserHost";
 import { samples } from "./samples";
 import "./style.css";
@@ -31,6 +32,12 @@ export function createUI(host: BrowserHost) {
     },
   });
 
+  // Add shortcuts
+  // ctrl/cmd+shift+F => format
+  editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.KeyF, format);
+  // alt+shift+F => format
+  editor.addCommand(monaco.KeyMod.Alt | monaco.KeyMod.Shift | monaco.KeyCode.KeyF, format);
+
   const output = monaco.editor.create(document.getElementById("output")!, {
     readOnly: true,
     language: "json",
@@ -59,6 +66,7 @@ export function createUI(host: BrowserHost) {
 
   document.getElementById("share")?.addEventListener("click", saveCode);
   document.getElementById("newIssue")?.addEventListener("click", newIssue);
+  document.getElementById("format")?.addEventListener("click", format);
   initSamples();
   doCompile();
 
@@ -163,5 +171,14 @@ export function createUI(host: BrowserHost) {
     const bodyPayload = encodeURIComponent(`\n\n\n[Playground Link](${document.location.href})`);
     const url = `https://github.com/microsoft/cadl/issues/new?body=${bodyPayload}`;
     window.open(url, "_blank");
+  }
+
+  function format() {
+    const code = mainModel.getValue();
+    const output = prettier.format(code, {
+      parser: "cadl",
+      plugins: [CadlPrettierPlugin],
+    });
+    mainModel.setValue(output);
   }
 }


### PR DESCRIPTION
Add a format button running the formatter in the code
![image](https://user-images.githubusercontent.com/1031227/159386405-129e50c4-799b-4645-8d3f-78cdc4c67a6b.png)

Also added keyboard shortcuts
- `ctrl+shift+F`: windows/linux
- `cmd+shift+F`: osx
- `alt+shift+F`: all