### PR TITLE
[openapi3] Fix issue with enum values of `0`

### DIFF
--- a/common/changes/@cadl-lang/openapi3/fixOpenApiEnum_2022-03-22-01-04.json
+++ b/common/changes/@cadl-lang/openapi3/fixOpenApiEnum_2022-03-22-01-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Fix bug with number enums that reference `0`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -884,7 +884,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
         continue;
       }
 
-      values.push(option.value ? option.value : option.name);
+      values.push(option.value ?? option.name);
     }
 
     const schema: any = { type, description: getDoc(program, e) };
@@ -894,8 +894,10 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
 
     return schema;
     function enumMemberType(member: EnumMemberType) {
-      if (!member.value || typeof member.value === "string") return "string";
-      return "number";
+      if (typeof member.value === "number") {
+        return "number";
+      }
+      return "string";
     }
 
     function reportUnsupportedUnion(messageId: "default" | "empty" = "default") {

--- a/packages/openapi3/test/test-openapi-output.ts
+++ b/packages/openapi3/test/test-openapi-output.ts
@@ -316,6 +316,21 @@ describe("openapi3: definitions", () => {
     deepStrictEqual(res.schemas.PetType.enum, ["Dog", "Cat"]);
   });
 
+  it("defines enum types with custom values", async () => {
+    const res = await oapiForModel(
+      "Pet",
+      `
+      enum PetType {
+        Dog: 0, Cat: 1
+      }
+      model Pet { type: PetType };
+      `
+    );
+    ok(res.isRef);
+    strictEqual(res.schemas.Pet.properties.type.$ref, "#/components/schemas/PetType");
+    deepStrictEqual(res.schemas.PetType.enum, [0, 1]);
+  });
+
   it("defines known values", async () => {
     const res = await oapiForModel(
       "Pet",


### PR DESCRIPTION
Since `0` is falsy in JS, some checks we were doing for `undefined` were causing us to treat "Foo: 0" as if it were "Foo", resulting in errors when enums explicitly listed several enum values, including zero, as the enum would no longer have members all of the same type.

Small repro file:

```
import "@cadl-lang/rest";

@serviceTitle("Hello world")
@serviceVersion("0.1.0")
namespace Demo.HelloWorld;

using Cadl.Http;

@doc("The type of step to execute")
enum CampaignStepType {
    Invalid: 0,
    Ransomware: 1
}

@doc("Step Definition")
model Step {
    @doc("The type of the step to execute")
    type: CampaignStepType;
    @doc("List of valid targets for the step to execute against")
    targets: string[];
}


@doc("Hello world service")
@route("/hello")
namespace Hello {
  @doc("Returns 'hi'")
  @get
  op sayHi(): OkResponse<Step>;
}
```