### PR TITLE
rest: Raise error when child resource duplicates a parent key name

### DIFF
--- a/common/changes/@cadl-lang/rest/resource-duplicate-keys_2022-03-22-13-20.json
+++ b/common/changes/@cadl-lang/rest/resource-duplicate-keys_2022-03-22-13-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Raise a diagnostic when a resource type specifies a parent type which holds the same key name.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/src/diagnostics.ts
+++ b/packages/rest/src/diagnostics.ts
@@ -51,6 +51,12 @@ const libDefinition = {
         default: paramMessage`More than one key found on model type ${"resourceName"}`,
       },
     },
+    "duplicate-parent-key": {
+      severity: "error",
+      messages: {
+        default: paramMessage`Resource type '${"resourceName"}' has a key property named '${"keyName"}' which is already used by parent type '${"parentName"}'.`,
+      },
+    },
     "missing-path-param": {
       severity: "error",
       messages: {


### PR DESCRIPTION
This PR addresses an issue in `@cadl-lang/rest` that @johanste found and filed in #352 where a child resource type can define a key property with a name that duplicates a parent type's key name resulting in erroneous route paths.

The fix is to add a check to the `@parentResource` decorator to ensure that the parent type(s) of the target type do not use the same key name.