### PR TITLE
Add `@rename` decorator for general renaming of types in Cadl

### DIFF
--- a/common/changes/@cadl-lang/compiler/rename-types_2022-03-22-14-09.json
+++ b/common/changes/@cadl-lang/compiler/rename-types_2022-03-22-14-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add @rename decorator for general renaming of types in Cadl",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -621,3 +621,25 @@ export function isKey(program: Program, property: ModelTypeProperty) {
 export function getKeyName(program: Program, property: ModelTypeProperty): string {
   return program.stateMap(keyKey).get(property);
 }
+
+export function $rename({ program }: DecoratorContext, entity: Type, newName: Type) {
+  if (newName.kind === "TemplateParameter") {
+    // Don't execute when this decorator is being applied within a templated type
+    return;
+  }
+
+  if (
+    !validateDecoratorTarget(program, entity, "@rename", ["Model", "ModelProperty", "Operation"])
+  ) {
+    // TODO: Diagnostic
+    return;
+  }
+
+  if (!validateDecoratorParamType(program, entity, newName, "String")) {
+    // TODO: Diagnostic
+    return;
+  }
+
+  // Set the name on any of the supported types
+  (entity as any).name = newName;
+}


### PR DESCRIPTION
This change adds a new decorator `@rename` which makes it possible to rename a limited subset of types in Cadl documents: `Model`, `ModelProperty`, and `Operation`.  The purpose of this is to enable renaming of certain language elements via template parameters, such as interface operations in the Azure Resource Manager library.

Feel free to suggest other types to add, or let me know if you think I should make this less general and use type-specific decorators instead.