### PR TITLE
Fix null ref in VS extension activation

### DIFF
--- a/common/changes/cadl-vs/fix-nullref_2022-03-24-23-20.json
+++ b/common/changes/cadl-vs/fix-nullref_2022-03-24-23-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vs",
+      "comment": "Fix null ref in VS extension activation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "cadl-vs"
+}

--- a/packages/cadl-vs/src/VSExtension.cs
+++ b/packages/cadl-vs/src/VSExtension.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Cadl.VisualStudio {
       }
 #endif
 
-      var serverPath = settings.Property<string>("cadl.cadl-server.path");
+      var serverPath = settings?.Property<string>("cadl.cadl-server.path");
       if (serverPath == null) {
         return ("cadl-server.cmd", args);
       }


### PR DESCRIPTION
Fix #358 (hopefully)