### PR TITLE
Turn on promise linting and fix issues

### DIFF
--- a/common/changes/@cadl-lang/compiler/promise-linting_2022-03-25-20-02.json
+++ b/common/changes/@cadl-lang/compiler/promise-linting_2022-03-25-20-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix issues with mishandled promises",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/eslint-config-cadl/promise-linting_2022-03-25-20-02.json
+++ b/common/changes/@cadl-lang/eslint-config-cadl/promise-linting_2022-03-25-20-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/eslint-config-cadl",
+      "comment": "Turn on promise linting",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/eslint-config-cadl"
+}

--- a/common/changes/@cadl-lang/openapi/promise-linting_2022-03-25-20-02.json
+++ b/common/changes/@cadl-lang/openapi/promise-linting_2022-03-25-20-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/openapi3/promise-linting_2022-03-25-20-02.json
+++ b/common/changes/@cadl-lang/openapi3/promise-linting_2022-03-25-20-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/promise-linting_2022-03-25-20-02.json
+++ b/common/changes/@cadl-lang/rest/promise-linting_2022-03-25-20-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/versioning/promise-linting_2022-03-25-20-02.json
+++ b/common/changes/@cadl-lang/versioning/promise-linting_2022-03-25-20-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/common/changes/cadl-vscode/promise-linting_2022-03-28-13-04.json
+++ b/common/changes/cadl-vscode/promise-linting_2022-03-28-13-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vscode",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "cadl-vscode"
+}

--- a/common/changes/tmlanguage-generator/promise-linting_2022-03-25-20-02.json
+++ b/common/changes/tmlanguage-generator/promise-linting_2022-03-25-20-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "tmlanguage-generator",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "tmlanguage-generator"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -30,17 +30,17 @@ dependencies:
   '@types/prompts': 2.0.14
   '@types/vscode': 1.53.0
   '@types/yargs': 17.0.8
-  '@typescript-eslint/eslint-plugin': 5.12.1_aa3af6382115a42a71cc388b7b2c30b3
-  '@typescript-eslint/parser': 5.12.1_eslint@8.9.0+typescript@4.5.5
+  '@typescript-eslint/eslint-plugin': 5.16.0_ed767fc79466c0e7303335c5b5d352be
+  '@typescript-eslint/parser': 5.16.0_eslint@8.12.0+typescript@4.5.5
   ajv: 8.9.0
   autorest: 3.3.2
   c8: 7.11.0
   change-case: 4.1.2
   debounce: 1.2.1
   ecmarkup: 9.8.1
-  eslint: 8.9.0
-  eslint-config-prettier: 8.4.0_eslint@8.9.0
-  eslint-plugin-prettier: 4.0.0_9f62b85ce3ce02949dbd2ccffcebe95f
+  eslint: 8.12.0
+  eslint-config-prettier: 8.5.0_eslint@8.12.0
+  eslint-plugin-prettier: 4.0.0_a3db0e8b63bb0d3e2028c4b7c69a389a
   glob: 7.1.7
   grammarkdown: 3.1.2
   js-yaml: 4.1.0
@@ -174,13 +174,13 @@ packages:
       node: ^10.12.0 || >=12.0.0
     resolution:
       integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==
-  /@eslint/eslintrc/1.1.0:
+  /@eslint/eslintrc/1.2.1:
     dependencies:
       ajv: 6.12.6
       debug: 4.3.3
       espree: 9.3.1
       globals: 13.12.1
-      ignore: 4.0.6
+      ignore: 5.2.0
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       minimatch: 3.1.2
@@ -189,7 +189,7 @@ packages:
     engines:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
     resolution:
-      integrity: sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==
+      integrity: sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==
   /@humanwhocodes/config-array/0.5.0:
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -407,14 +407,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-wDeUwiUmem9FzsyysEwRukaEdDNcwbROvQ9QGRKaLI6t+IltNzbn4/i4asmB10auvZGQCzSQ6t0GSczEThlUXw==
-  /@typescript-eslint/eslint-plugin/5.12.1_aa3af6382115a42a71cc388b7b2c30b3:
+  /@typescript-eslint/eslint-plugin/5.16.0_ed767fc79466c0e7303335c5b5d352be:
     dependencies:
-      '@typescript-eslint/parser': 5.12.1_eslint@8.9.0+typescript@4.5.5
-      '@typescript-eslint/scope-manager': 5.12.1
-      '@typescript-eslint/type-utils': 5.12.1_eslint@8.9.0+typescript@4.5.5
-      '@typescript-eslint/utils': 5.12.1_eslint@8.9.0+typescript@4.5.5
+      '@typescript-eslint/parser': 5.16.0_eslint@8.12.0+typescript@4.5.5
+      '@typescript-eslint/scope-manager': 5.16.0
+      '@typescript-eslint/type-utils': 5.16.0_eslint@8.12.0+typescript@4.5.5
+      '@typescript-eslint/utils': 5.16.0_eslint@8.12.0+typescript@4.5.5
       debug: 4.3.3
-      eslint: 8.9.0
+      eslint: 8.12.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
@@ -432,14 +432,14 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-M499lqa8rnNK7mUv74lSFFttuUsubIRdAbHcVaP93oFcKkEmHmLqy2n7jM9C8DVmFMYK61ExrZU6dLYhQZmUpw==
-  /@typescript-eslint/parser/5.12.1_eslint@8.9.0+typescript@4.5.5:
+      integrity: sha512-SJoba1edXvQRMmNI505Uo4XmGbxCK9ARQpkvOd00anxzri9RNQk0DDCxD+LIl+jYhkzOJiOMMKYEHnHEODjdCw==
+  /@typescript-eslint/parser/5.16.0_eslint@8.12.0+typescript@4.5.5:
     dependencies:
-      '@typescript-eslint/scope-manager': 5.12.1
-      '@typescript-eslint/types': 5.12.1
-      '@typescript-eslint/typescript-estree': 5.12.1_typescript@4.5.5
+      '@typescript-eslint/scope-manager': 5.16.0
+      '@typescript-eslint/types': 5.16.0
+      '@typescript-eslint/typescript-estree': 5.16.0_typescript@4.5.5
       debug: 4.3.3
-      eslint: 8.9.0
+      eslint: 8.12.0
       typescript: 4.5.5
     dev: false
     engines:
@@ -451,21 +451,21 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-6LuVUbe7oSdHxUWoX/m40Ni8gsZMKCi31rlawBHt7VtW15iHzjbpj2WLiToG2758KjtCCiLRKZqfrOdl3cNKuw==
-  /@typescript-eslint/scope-manager/5.12.1:
+      integrity: sha512-fkDq86F0zl8FicnJtdXakFs4lnuebH6ZADDw6CYQv0UZeIjHvmEw87m9/29nk2Dv5Lmdp0zQ3zDQhiMWQf/GbA==
+  /@typescript-eslint/scope-manager/5.16.0:
     dependencies:
-      '@typescript-eslint/types': 5.12.1
-      '@typescript-eslint/visitor-keys': 5.12.1
+      '@typescript-eslint/types': 5.16.0
+      '@typescript-eslint/visitor-keys': 5.16.0
     dev: false
     engines:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
     resolution:
-      integrity: sha512-J0Wrh5xS6XNkd4TkOosxdpObzlYfXjAFIm9QxYLCPOcHVv1FyyFCPom66uIh8uBr0sZCrtS+n19tzufhwab8ZQ==
-  /@typescript-eslint/type-utils/5.12.1_eslint@8.9.0+typescript@4.5.5:
+      integrity: sha512-P+Yab2Hovg8NekLIR/mOElCDPyGgFZKhGoZA901Yax6WR6HVeGLbsqJkZ+Cvk5nts/dAlFKm8PfL43UZnWdpIQ==
+  /@typescript-eslint/type-utils/5.16.0_eslint@8.12.0+typescript@4.5.5:
     dependencies:
-      '@typescript-eslint/utils': 5.12.1_eslint@8.9.0+typescript@4.5.5
+      '@typescript-eslint/utils': 5.16.0_eslint@8.12.0+typescript@4.5.5
       debug: 4.3.3
-      eslint: 8.9.0
+      eslint: 8.12.0
       tsutils: 3.21.0_typescript@4.5.5
       typescript: 4.5.5
     dev: false
@@ -478,17 +478,17 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-Gh8feEhsNLeCz6aYqynh61Vsdy+tiNNkQtc+bN3IvQvRqHkXGUhYkUi+ePKzP0Mb42se7FDb+y2SypTbpbR/Sg==
-  /@typescript-eslint/types/5.12.1:
+      integrity: sha512-SKygICv54CCRl1Vq5ewwQUJV/8padIWvPgCxlWPGO/OgQLCijY9G7lDu6H+mqfQtbzDNlVjzVWQmeqbLMBLEwQ==
+  /@typescript-eslint/types/5.16.0:
     dev: false
     engines:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
     resolution:
-      integrity: sha512-hfcbq4qVOHV1YRdhkDldhV9NpmmAu2vp6wuFODL71Y0Ixak+FLeEU4rnPxgmZMnGreGEghlEucs9UZn5KOfHJA==
-  /@typescript-eslint/typescript-estree/5.12.1_typescript@4.5.5:
+      integrity: sha512-oUorOwLj/3/3p/HFwrp6m/J2VfbLC8gjW5X3awpQJ/bSG+YRGFS4dpsvtQ8T2VNveV+LflQHjlLvB6v0R87z4g==
+  /@typescript-eslint/typescript-estree/5.16.0_typescript@4.5.5:
     dependencies:
-      '@typescript-eslint/types': 5.12.1
-      '@typescript-eslint/visitor-keys': 5.12.1
+      '@typescript-eslint/types': 5.16.0
+      '@typescript-eslint/visitor-keys': 5.16.0
       debug: 4.3.3
       globby: 11.1.0
       is-glob: 4.0.3
@@ -504,16 +504,16 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-ahOdkIY9Mgbza7L9sIi205Pe1inCkZWAHE1TV1bpxlU4RZNPtXaDZfiiFWcL9jdxvW1hDYZJXrFm+vlMkXRbBw==
-  /@typescript-eslint/utils/5.12.1_eslint@8.9.0+typescript@4.5.5:
+      integrity: sha512-SE4VfbLWUZl9MR+ngLSARptUv2E8brY0luCdgmUevU6arZRY/KxYoLI/3V/yxaURR8tLRN7bmZtJdgmzLHI6pQ==
+  /@typescript-eslint/utils/5.16.0_eslint@8.12.0+typescript@4.5.5:
     dependencies:
       '@types/json-schema': 7.0.9
-      '@typescript-eslint/scope-manager': 5.12.1
-      '@typescript-eslint/types': 5.12.1
-      '@typescript-eslint/typescript-estree': 5.12.1_typescript@4.5.5
-      eslint: 8.9.0
+      '@typescript-eslint/scope-manager': 5.16.0
+      '@typescript-eslint/types': 5.16.0
+      '@typescript-eslint/typescript-estree': 5.16.0_typescript@4.5.5
+      eslint: 8.12.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0_eslint@8.9.0
+      eslint-utils: 3.0.0_eslint@8.12.0
     dev: false
     engines:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
@@ -521,16 +521,16 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     resolution:
-      integrity: sha512-Qq9FIuU0EVEsi8fS6pG+uurbhNTtoYr4fq8tKjBupsK5Bgbk2I32UGm0Sh+WOyjOPgo/5URbxxSNV6HYsxV4MQ==
-  /@typescript-eslint/visitor-keys/5.12.1:
+      integrity: sha512-iYej2ER6AwmejLWMWzJIHy3nPJeGDuCqf8Jnb+jAQVoPpmWzwQOfa9hWVB8GIQE5gsCv/rfN4T+AYb/V06WseQ==
+  /@typescript-eslint/visitor-keys/5.16.0:
     dependencies:
-      '@typescript-eslint/types': 5.12.1
+      '@typescript-eslint/types': 5.16.0
       eslint-visitor-keys: 3.3.0
     dev: false
     engines:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
     resolution:
-      integrity: sha512-l1KSLfupuwrXx6wc0AuOmC7Ko5g14ZOQ86wJJqRbdLbXLK02pK/DPiDDqCc7BqqiiA04/eAA6ayL0bgOrAkH7A==
+      integrity: sha512-jqxO8msp5vZDhikTwq9ubyMHqZ67UIvawohr4qF3KhlpL7gzSjOd+8471H3nh5LyABkaI85laEKKU8SnGUK5/g==
   /@ungap/promise-all-settled/1.1.2:
     dev: false
     resolution:
@@ -1620,19 +1620,19 @@ packages:
       source-map: 0.6.1
     resolution:
       integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
-  /eslint-config-prettier/8.4.0_eslint@8.9.0:
+  /eslint-config-prettier/8.5.0_eslint@8.12.0:
     dependencies:
-      eslint: 8.9.0
+      eslint: 8.12.0
     dev: false
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     resolution:
-      integrity: sha512-CFotdUcMY18nGRo5KGsnNxpznzhkopOcOo0InID+sgQssPrzjvsyKZPvOgymTFeHrFuC3Tzdf2YndhXtULK9Iw==
-  /eslint-plugin-prettier/4.0.0_9f62b85ce3ce02949dbd2ccffcebe95f:
+      integrity: sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
+  /eslint-plugin-prettier/4.0.0_a3db0e8b63bb0d3e2028c4b7c69a389a:
     dependencies:
-      eslint: 8.9.0
-      eslint-config-prettier: 8.4.0_eslint@8.9.0
+      eslint: 8.12.0
+      eslint-config-prettier: 8.5.0_eslint@8.12.0
       prettier: 2.5.1
       prettier-linter-helpers: 1.0.0
     dev: false
@@ -1673,9 +1673,9 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
-  /eslint-utils/3.0.0_eslint@8.9.0:
+  /eslint-utils/3.0.0_eslint@8.12.0:
     dependencies:
-      eslint: 8.9.0
+      eslint: 8.12.0
       eslint-visitor-keys: 2.1.0
     dev: false
     engines:
@@ -1750,9 +1750,9 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==
-  /eslint/8.9.0:
+  /eslint/8.12.0:
     dependencies:
-      '@eslint/eslintrc': 1.1.0
+      '@eslint/eslintrc': 1.2.1
       '@humanwhocodes/config-array': 0.9.3
       ajv: 6.12.6
       chalk: 4.1.2
@@ -1761,7 +1761,7 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
-      eslint-utils: 3.0.0_eslint@8.9.0
+      eslint-utils: 3.0.0_eslint@8.12.0
       eslint-visitor-keys: 3.3.0
       espree: 9.3.1
       esquery: 1.4.0
@@ -1792,7 +1792,7 @@ packages:
       node: ^12.22.0 || ^14.17.0 || >=16.0.0
     hasBin: true
     resolution:
-      integrity: sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==
+      integrity: sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==
   /espree/7.3.1:
     dependencies:
       acorn: 7.4.1
@@ -4197,7 +4197,7 @@ packages:
       '@types/node': 14.0.27
       '@types/vscode': 1.53.0
       c8: 7.11.0
-      eslint: 8.9.0
+      eslint: 8.12.0
       mkdirp: 1.0.4
       mocha: 9.2.1
       rimraf: 3.0.2
@@ -4211,7 +4211,7 @@ packages:
     dev: false
     name: '@rush-temp/cadl-vscode'
     resolution:
-      integrity: sha512-cEcVxeDGOZf2+nX7nqSYf156uw5GHbB5MohMjYWtH+YK7jyLMW4vMcVPnzXyNg17TVqBVYRJJMI9mUW67sJiDg==
+      integrity: sha512-lOQ6N0f2mn5pgTmvmY0AMq8wEVAM7dO88UJfwEBXDUYAiwqwp0ld9dxBmT/GJFJjAAnDx9pigqYtfwPxhh4msw==
       tarball: file:projects/cadl-vscode.tgz
     version: 0.0.0
   file:projects/compiler.tgz:
@@ -4228,7 +4228,7 @@ packages:
       ajv: 8.9.0
       c8: 7.11.0
       change-case: 4.1.2
-      eslint: 8.9.0
+      eslint: 8.12.0
       glob: 7.1.7
       grammarkdown: 3.1.2
       js-yaml: 4.1.0
@@ -4249,17 +4249,17 @@ packages:
     dev: false
     name: '@rush-temp/compiler'
     resolution:
-      integrity: sha512-W3Ig+HY/eZS2EH5jleYRzp/X6KwK/QgqSQIhlMFIh8kxpQtCvsszre6FZXGsx/QLIOmFVkrixPnl5VIvBoizrg==
+      integrity: sha512-C+9nahppgYtfjgCnWvSnIqtGD2GmtkgAV4L5x6Divgo5XU/Fy6vEq4KKGqpMcAZeA6yWEQrhKYHbINPge0Wyew==
       tarball: file:projects/compiler.tgz
     version: 0.0.0
   file:projects/eslint-config-cadl.tgz_prettier@2.5.1:
     dependencies:
       '@rushstack/eslint-patch': 1.1.0
-      '@typescript-eslint/eslint-plugin': 5.12.1_aa3af6382115a42a71cc388b7b2c30b3
-      '@typescript-eslint/parser': 5.12.1_eslint@8.9.0+typescript@4.5.5
-      eslint: 8.9.0
-      eslint-config-prettier: 8.4.0_eslint@8.9.0
-      eslint-plugin-prettier: 4.0.0_9f62b85ce3ce02949dbd2ccffcebe95f
+      '@typescript-eslint/eslint-plugin': 5.16.0_ed767fc79466c0e7303335c5b5d352be
+      '@typescript-eslint/parser': 5.16.0_eslint@8.12.0+typescript@4.5.5
+      eslint: 8.12.0
+      eslint-config-prettier: 8.5.0_eslint@8.12.0
+      eslint-plugin-prettier: 4.0.0_a3db0e8b63bb0d3e2028c4b7c69a389a
       typescript: 4.5.5
     dev: false
     id: file:projects/eslint-config-cadl.tgz
@@ -4267,7 +4267,7 @@ packages:
     peerDependencies:
       prettier: '*'
     resolution:
-      integrity: sha512-djZZqlrkfB2H3h/gGEqfGgqZ8YUJ43e5yUDKW+9RnDGLLYXYV2KFr5rnyuEsdnrGfo70lg/NZ36G8pVt7xB1Dg==
+      integrity: sha512-A0DmwUe9t4sr4lYUQvVss2lf0C6KvOubB1UAcp/bYH7bt7wy5/09mrvWl0V3rNRHedOIM8hKmcHlvLE+qkrx6g==
       tarball: file:projects/eslint-config-cadl.tgz
     version: 0.0.0
   file:projects/openapi.tgz:
@@ -4275,14 +4275,14 @@ packages:
       '@types/mocha': 9.1.0
       '@types/node': 14.0.27
       c8: 7.11.0
-      eslint: 8.9.0
+      eslint: 8.12.0
       mocha: 9.2.1
       rimraf: 3.0.2
       typescript: 4.5.5
     dev: false
     name: '@rush-temp/openapi'
     resolution:
-      integrity: sha512-OWhISfziSsx7yzvaKvgMyE2erNXJ1P6VTUcCMD99Ls8Gn37PSdTLb2EWD2P8Cv16o7L9DAuTQi+DZypfqlucfQ==
+      integrity: sha512-zWZ4iMS4Mj/RKmxCM3S4AMZHAJ7taUMNIOb8yutKz1kHVYcVDcuIdKVfUKHtV1UB48Z4JrkUmi682rTWaLj7CQ==
       tarball: file:projects/openapi.tgz
     version: 0.0.0
   file:projects/openapi3.tgz:
@@ -4290,14 +4290,14 @@ packages:
       '@types/mocha': 9.1.0
       '@types/node': 14.0.27
       c8: 7.11.0
-      eslint: 8.9.0
+      eslint: 8.12.0
       mocha: 9.2.1
       rimraf: 3.0.2
       typescript: 4.5.5
     dev: false
     name: '@rush-temp/openapi3'
     resolution:
-      integrity: sha512-lZhmQx6xq1WVjXiNQidyMF4ufCfNyI0sTXwOk4OHPG4rIB7/l/MsTA04nH4nAAu8FRimvURi9whTZ5WfZQgz7Q==
+      integrity: sha512-P1HkfrEoPTLXqPgMKAnKtKHgUy6WpKblsozs+09aXT1OYEC0HyKGcLhcqtPL9MZO7gBLKQ+L5+Fzwq0dqGNchw==
       tarball: file:projects/openapi3.tgz
     version: 0.0.0
   file:projects/playground.tgz:
@@ -4309,7 +4309,7 @@ packages:
       '@types/prettier': 2.4.4
       c8: 7.11.0
       debounce: 1.2.1
-      eslint: 8.9.0
+      eslint: 8.12.0
       lzutf8: 0.6.1
       mocha: 9.2.1
       monaco-editor: 0.32.1
@@ -4321,7 +4321,7 @@ packages:
     dev: false
     name: '@rush-temp/playground'
     resolution:
-      integrity: sha512-WgKeXW0Jjjntze4sO576ult23mEiPcyjtwpdaK0MOYR1vmBjvPcrbEEsI6b0xliMl8xjEvMeTZJp9gBbd8rJ9w==
+      integrity: sha512-H+U0Du/9WQBuhogIBvDNajDYcFUoKQMG7LFdtXI+fIKOamFi5XqCynjYlP4O5e37ofClrrlgy8dDUV7SK+XUYg==
       tarball: file:projects/playground.tgz
     version: 0.0.0
   file:projects/prettier-plugin-cadl.tgz:
@@ -4344,14 +4344,14 @@ packages:
       '@types/mocha': 9.1.0
       '@types/node': 14.0.27
       c8: 7.11.0
-      eslint: 8.9.0
+      eslint: 8.12.0
       mocha: 9.2.1
       rimraf: 3.0.2
       typescript: 4.5.5
     dev: false
     name: '@rush-temp/rest'
     resolution:
-      integrity: sha512-zDy60s5k/XEvzDK0/KghCvEZBLBQHIF7bnR1haVsZtarYm5Zn+PMABUY3CcRUHhcAVGYAP63eut/cLJ0ZnI6lg==
+      integrity: sha512-7Ncemp9zHkQNQdgLrva+ndfFSUHrY0IBtDo/LLQLwO4Ccdirf2gT/5J3eQKSNaLSlzuZXTo/XrSzGNWK9/Kgqw==
       tarball: file:projects/rest.tgz
     version: 0.0.0
   file:projects/samples.tgz:
@@ -4381,7 +4381,7 @@ packages:
     dependencies:
       '@types/node': 14.0.27
       '@types/plist': 3.0.2
-      eslint: 8.9.0
+      eslint: 8.12.0
       onigasm: 2.2.5
       plist: 3.0.4
       rimraf: 3.0.2
@@ -4389,7 +4389,7 @@ packages:
     dev: false
     name: '@rush-temp/tmlanguage-generator'
     resolution:
-      integrity: sha512-n/Y5imJfQS5BKE8o1Sf+awMHZojdEMsKYlKoaink3TDsOvqB+8GDI2X0EGjY5M6vDE8+PO0nDjdp9GM0UTObXA==
+      integrity: sha512-f/KWEM1sXCQumxBAyiH6xDTIk+3ECzzPUQtdfAOpqczvv0XPLctMDRVmgiD2RY0frlTDWmWofXVbJZCFViUhMA==
       tarball: file:projects/tmlanguage-generator.tgz
     version: 0.0.0
   file:projects/versioning.tgz:
@@ -4397,14 +4397,14 @@ packages:
       '@types/mocha': 9.1.0
       '@types/node': 14.0.27
       c8: 7.11.0
-      eslint: 8.9.0
+      eslint: 8.12.0
       mocha: 9.2.1
       rimraf: 3.0.2
       typescript: 4.5.5
     dev: false
     name: '@rush-temp/versioning'
     resolution:
-      integrity: sha512-L15Tt9ZsoSMHjBjeWUqru6C53gNkrEkknFR7SwjlyLwHmkvS76alf24xgGrTw/rz428IPmZjnxp+fs/yq0Zw6w==
+      integrity: sha512-C0GSBG1/gedVR3A1zaAZwqKN61j2sgPzC9ie6Hm4DitXrvwNP18Toc3SBy6y24aHit1aEQcAufBE38xO0JilPQ==
       tarball: file:projects/versioning.tgz
     version: 0.0.0
 specifiers:
@@ -4439,16 +4439,16 @@ specifiers:
   '@types/prompts': ~2.0.14
   '@types/vscode': ~1.53.0
   '@types/yargs': ~17.0.2
-  '@typescript-eslint/eslint-plugin': ^5.10.0
-  '@typescript-eslint/parser': ^5.10.0
+  '@typescript-eslint/eslint-plugin': ^5.16.0
+  '@typescript-eslint/parser': ^5.16.0
   ajv: ~8.9.0
   autorest: ~3.3.2
   c8: ~7.11.0
   change-case: ~4.1.2
   debounce: ~1.2.1
   ecmarkup: ~9.8.1
-  eslint: ^8.7.0
-  eslint-config-prettier: ^8.3.0
+  eslint: ^8.12.0
+  eslint-config-prettier: ^8.5.0
   eslint-plugin-prettier: ^4.0.0
   glob: ~7.1.6
   grammarkdown: ~3.1.2

--- a/packages/cadl-vscode/package.json
+++ b/packages/cadl-vscode/package.json
@@ -105,7 +105,7 @@
     "@types/node": "~14.0.27",
     "@types/vscode": "~1.53.0",
     "@cadl-lang/eslint-config-cadl": "~0.2.0",
-    "eslint": "^8.7.0",
+    "eslint": "^8.12.0",
     "c8": "~7.11.0",
     "mkdirp": "~1.0.4",
     "mocha": "~9.2.0",

--- a/packages/compiler/.eslintrc.cjs
+++ b/packages/compiler/.eslintrc.cjs
@@ -2,4 +2,5 @@ require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
+  parserOptions: { project: "./tsconfig.json" },
 };

--- a/packages/compiler/core/module-resolver.ts
+++ b/packages/compiler/core/module-resolver.ts
@@ -86,7 +86,7 @@ export async function resolveModule(
     const dirs = getPackageCandidates(name, baseDir);
     for (const dir of dirs) {
       if (await isDirectory(host, dir)) {
-        const n = loadAsDirectory(dir);
+        const n = await loadAsDirectory(dir);
         if (n) return n;
       }
     }

--- a/packages/compiler/core/program.ts
+++ b/packages/compiler/core/program.ts
@@ -54,7 +54,7 @@ export interface Program {
   readonly diagnostics: readonly Diagnostic[];
   loadCadlScript(cadlScript: SourceFile): Promise<CadlScriptNode>;
   evalCadlScript(cadlScript: string): void;
-  onValidate(cb: (program: Program) => void): Promise<void> | void;
+  onValidate(cb: (program: Program) => void | Promise<void>): void;
   getOption(key: string): string | undefined;
   stateSet(key: symbol): Set<Type>;
   stateSets: Map<symbol, Set<Type>>;

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -78,7 +78,7 @@
     "@types/prompts": "~2.0.14",
     "@types/yargs": "~17.0.2",
     "@cadl-lang/eslint-config-cadl": "~0.2.0",
-    "eslint": "^8.7.0",
+    "eslint": "^8.12.0",
     "grammarkdown": "~3.1.2",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",

--- a/packages/compiler/server/server.ts
+++ b/packages/compiler/server/server.ts
@@ -73,7 +73,7 @@ function main() {
   connection.listen();
 }
 
-function fatalError(e: any) {
+function fatalError(e: unknown) {
   // If we failed to send any log messages over LSP pipe, send them to
   // stderr before exiting.
   for (const pending of server?.pendingMessages ?? []) {

--- a/packages/compiler/test/config/config.ts
+++ b/packages/compiler/test/config/config.ts
@@ -10,7 +10,7 @@ import { SchemaValidator } from "../../core/schema-validator.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe("compiler: config file loading", () => {
-  describe("file discovery", async () => {
+  describe("file discovery", () => {
     const scenarioRoot = resolve(__dirname, "../../../test/config/scenarios");
     const loadTestConfig = async (folderName: string) => {
       const folderPath = join(scenarioRoot, folderName);

--- a/packages/compiler/test/decorators/decorators.ts
+++ b/packages/compiler/test/decorators/decorators.ts
@@ -198,7 +198,7 @@ describe("compiler: built-in decorators", () => {
     });
   });
 
-  describe("@key", async () => {
+  describe("@key", () => {
     it("emits diagnostic when argument is not a string", async () => {
       const diagnostics = await runner.diagnose(
         `model M {

--- a/packages/compiler/test/formatter/scenarios/scenarios.ts
+++ b/packages/compiler/test/formatter/scenarios/scenarios.ts
@@ -53,7 +53,7 @@ async function testScenario(name: string) {
   }
 }
 
-describe("compiler: prettier formatter scenarios", async () => {
+describe("compiler: prettier formatter scenarios", () => {
   // describe has to be sync, so using sync readdir here.
   const scenarioFiles = readdirSync(join(__dirname, "../../../../test/formatter/scenarios/inputs"));
 

--- a/packages/eslint-config-cadl/index.js
+++ b/packages/eslint-config-cadl/index.js
@@ -19,6 +19,8 @@ module.exports = {
       "warn",
       { varsIgnorePattern: "^_", argsIgnorePattern: ".*", ignoreRestSiblings: true },
     ],
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-misused-promises": "error",
 
     /**
      * Core

--- a/packages/eslint-config-cadl/package.json
+++ b/packages/eslint-config-cadl/package.json
@@ -14,11 +14,11 @@
     "build": "echo 'No build.'"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.10.0",
-    "@typescript-eslint/parser": "^5.10.0",
+    "@typescript-eslint/eslint-plugin": "^5.16.0",
+    "@typescript-eslint/parser": "^5.16.0",
     "@rushstack/eslint-patch": "1.1.0 ",
-    "eslint": "^8.7.0",
-    "eslint-config-prettier": "^8.3.0",
+    "eslint": "^8.12.0",
+    "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
     "typescript": "~4.5.5"
   },

--- a/packages/openapi/.eslintrc.cjs
+++ b/packages/openapi/.eslintrc.cjs
@@ -2,4 +2,5 @@ require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
+  parserOptions: { project: "./tsconfig.json" },
 };

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -60,7 +60,7 @@
     "@cadl-lang/compiler": "~0.29.0",
     "@cadl-lang/rest": "~0.12.0",
     "@cadl-lang/eslint-config-cadl": "~0.2.0",
-    "eslint": "^8.7.0",
+    "eslint": "^8.12.0",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",
     "rimraf": "~3.0.2",

--- a/packages/openapi3/.eslintrc.cjs
+++ b/packages/openapi3/.eslintrc.cjs
@@ -2,4 +2,5 @@ require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
+  parserOptions: { project: "./tsconfig.json" },
 };

--- a/packages/openapi3/package.json
+++ b/packages/openapi3/package.json
@@ -64,7 +64,7 @@
     "@cadl-lang/openapi": "~0.7.0",
     "@cadl-lang/versioning": "~0.3.2",
     "@cadl-lang/eslint-config-cadl": "~0.2.0",
-    "eslint": "^8.7.0",
+    "eslint": "^8.12.0",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",
     "rimraf": "~3.0.2",

--- a/packages/playground/.eslintignore
+++ b/packages/playground/.eslintignore
@@ -1,0 +1,1 @@
+vite.config.ts

--- a/packages/playground/.eslintrc.cjs
+++ b/packages/playground/.eslintrc.cjs
@@ -4,7 +4,13 @@ module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
   parserOptions: { project: "./tsconfig.json" },
   rules: {
-    "@typescript-eslint/no-floating-promises": "off",
-    "@typescript-eslint/no-misused-promises": "off",
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      {
+        checksVoidReturn: {
+          //arguments: false, // too much noise when adding async event listeners
+        },
+      },
+    ],
   },
 };

--- a/packages/playground/.eslintrc.cjs
+++ b/packages/playground/.eslintrc.cjs
@@ -8,7 +8,7 @@ module.exports = {
       "error",
       {
         checksVoidReturn: {
-          //arguments: false, // too much noise when adding async event listeners
+          arguments: false, // too much noise when adding async event listeners
         },
       },
     ],

--- a/packages/playground/.eslintrc.cjs
+++ b/packages/playground/.eslintrc.cjs
@@ -2,4 +2,9 @@ require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
+  parserOptions: { project: "./tsconfig.json" },
+  rules: {
+    "@typescript-eslint/no-floating-promises": "off",
+    "@typescript-eslint/no-misused-promises": "off",
+  },
 };

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -54,7 +54,7 @@
     "@types/node": "~14.0.27",
     "@types/prettier": "^2.0.2",
     "@cadl-lang/eslint-config-cadl": "~0.2.0",
-    "eslint": "^8.7.0",
+    "eslint": "^8.12.0",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",
     "rimraf": "~3.0.2",

--- a/packages/playground/scripts/preload.ts
+++ b/packages/playground/scripts/preload.ts
@@ -44,4 +44,4 @@ async function load() {
   await writeFile("./dist-dev/cadlContents.json", JSON.stringify(staticContents));
 }
 
-load();
+await load();

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -16,4 +16,4 @@ import { createUI } from "./ui";
 
 const host = await createBrowserHost();
 attachServices(host);
-createUI(host);
+await createUI(host);

--- a/packages/rest/.eslintrc.cjs
+++ b/packages/rest/.eslintrc.cjs
@@ -2,4 +2,5 @@ require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
+  parserOptions: { project: "./tsconfig.json" },
 };

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -58,7 +58,7 @@
     "@types/node": "~14.0.27",
     "@cadl-lang/compiler": "~0.29.0",
     "@cadl-lang/eslint-config-cadl": "~0.2.0",
-    "eslint": "^8.7.0",
+    "eslint": "^8.12.0",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",
     "rimraf": "~3.0.2",

--- a/packages/tmlanguage-generator/.eslintrc.cjs
+++ b/packages/tmlanguage-generator/.eslintrc.cjs
@@ -2,4 +2,5 @@ require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
+  parserOptions: { project: "./tsconfig.json" },
 };

--- a/packages/tmlanguage-generator/package.json
+++ b/packages/tmlanguage-generator/package.json
@@ -40,7 +40,7 @@
     "@types/node": "~14.0.27",
     "@types/plist": "~3.0.2",
     "@cadl-lang/eslint-config-cadl": "~0.2.0",
-    "eslint": "^8.7.0",
+    "eslint": "^8.12.0",
     "rimraf": "~3.0.2",
     "typescript": "~4.5.5"
   }

--- a/packages/versioning/.eslintrc.cjs
+++ b/packages/versioning/.eslintrc.cjs
@@ -2,4 +2,5 @@ require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
+  parserOptions: { project: "./tsconfig.json" },
 };

--- a/packages/versioning/package.json
+++ b/packages/versioning/package.json
@@ -57,7 +57,7 @@
     "@types/mocha": "~9.1.0",
     "@types/node": "~14.0.27",
     "@cadl-lang/eslint-config-cadl": "~0.2.0",
-    "eslint": "^8.7.0",
+    "eslint": "^8.12.0",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",
     "rimraf": "~3.0.2",


### PR DESCRIPTION
This would have caught https://github.com/Azure/cadl-azure/issues/1297 via static analysis. So I propose turning on the relevant eslint rules to prevent another long debugging session like that. 😁

Everything but playground was pretty clean and some real issues were found and fixed everywhere else without any suppressions. Where issues weren't "real", it still helped to make the code clearer. So I think the value is reasonably high and the noise is reasonably low. 

~~I just opted playground out (for now?). I wasn't familiar enough with the code to be confident changing it and maybe it's too noisy for browser code patterns?~~

*EDIT*: I fixed most of playground now, and only turned off one part of one rule for it since it fires whenever you add an async function as an event listener.


