### PR TITLE
Customize VS output when language server activation fails

### DIFF
--- a/common/changes/cadl-vs/vs-activation-failure-stack_2022-03-28-17-45.json
+++ b/common/changes/cadl-vs/vs-activation-failure-stack_2022-03-28-17-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vs",
+      "comment": "Customize VS output when language server activation fails",
+      "type": "patch"
+    }
+  ],
+  "packageName": "cadl-vs"
+}

--- a/packages/cadl-vs/src/VSExtension.cs
+++ b/packages/cadl-vs/src/VSExtension.cs
@@ -108,8 +108,14 @@ namespace Microsoft.Cadl.VisualStudio {
 
 #if VS2022
     public Task<InitializationFailureContext?> OnServerInitializeFailedAsync(ILanguageClientInitializationInfo initializationState) {
-      Debug.Fail("Failed to initialize cadl-server:\r\n\r\n" + initializationState.InitializationException);
-      return Task.FromResult<InitializationFailureContext?>(null);
+      var exception = initializationState.InitializationException;
+      Debug.Fail("Failed to initialize cadl-server:\r\n\r\n" + exception);
+      return Task.FromResult<InitializationFailureContext?>(
+        new InitializationFailureContext {
+          FailureMessage = "Failed to activate Cadl language server!\r\n" +
+                           "File issue at https://github.com/microsoft/cadl\r\n\r\n" +
+                           exception
+      });
     }
 #endif
 


### PR DESCRIPTION
Fix #361 