### PR TITLE
Fix eslint in vscode

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-eslint-vscode_2022-03-28-20-05.json
+++ b/common/changes/@cadl-lang/compiler/fix-eslint-vscode_2022-03-28-20-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/eslint-config-cadl/fix-eslint-vscode_2022-03-28-20-05.json
+++ b/common/changes/@cadl-lang/eslint-config-cadl/fix-eslint-vscode_2022-03-28-20-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/eslint-config-cadl",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/eslint-config-cadl"
+}

--- a/common/changes/@cadl-lang/openapi/fix-eslint-vscode_2022-03-28-20-05.json
+++ b/common/changes/@cadl-lang/openapi/fix-eslint-vscode_2022-03-28-20-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/openapi3/fix-eslint-vscode_2022-03-28-20-05.json
+++ b/common/changes/@cadl-lang/openapi3/fix-eslint-vscode_2022-03-28-20-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/fix-eslint-vscode_2022-03-28-20-05.json
+++ b/common/changes/@cadl-lang/rest/fix-eslint-vscode_2022-03-28-20-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/versioning/fix-eslint-vscode_2022-03-28-20-05.json
+++ b/common/changes/@cadl-lang/versioning/fix-eslint-vscode_2022-03-28-20-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/common/changes/tmlanguage-generator/fix-eslint-vscode_2022-03-28-20-05.json
+++ b/common/changes/tmlanguage-generator/fix-eslint-vscode_2022-03-28-20-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "tmlanguage-generator",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "tmlanguage-generator"
+}

--- a/packages/compiler/.eslintrc.cjs
+++ b/packages/compiler/.eslintrc.cjs
@@ -2,5 +2,5 @@ require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
-  parserOptions: { project: "./tsconfig.json" },
+  parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/eslint-config-cadl/index.js
+++ b/packages/eslint-config-cadl/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   parser: "@typescript-eslint/parser",
+  parserOptions: { project: "./tsconfig.json" },
   plugins: ["@typescript-eslint/eslint-plugin", "prettier"],
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
   env: {

--- a/packages/openapi/.eslintrc.cjs
+++ b/packages/openapi/.eslintrc.cjs
@@ -2,5 +2,5 @@ require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
-  parserOptions: { project: "./tsconfig.json" },
+  parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/openapi3/.eslintrc.cjs
+++ b/packages/openapi3/.eslintrc.cjs
@@ -2,5 +2,5 @@ require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
-  parserOptions: { project: "./tsconfig.json" },
+  parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/playground/.eslintrc.cjs
+++ b/packages/playground/.eslintrc.cjs
@@ -2,7 +2,7 @@ require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
-  parserOptions: { project: "./tsconfig.json" },
+  parserOptions: { tsconfigRootDir: __dirname },
   rules: {
     "@typescript-eslint/no-misused-promises": [
       "error",

--- a/packages/rest/.eslintrc.cjs
+++ b/packages/rest/.eslintrc.cjs
@@ -2,5 +2,5 @@ require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
-  parserOptions: { project: "./tsconfig.json" },
+  parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/tmlanguage-generator/.eslintrc.cjs
+++ b/packages/tmlanguage-generator/.eslintrc.cjs
@@ -2,5 +2,5 @@ require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
-  parserOptions: { project: "./tsconfig.json" },
+  parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/versioning/.eslintrc.cjs
+++ b/packages/versioning/.eslintrc.cjs
@@ -2,5 +2,5 @@ require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
   extends: "@cadl-lang/eslint-config-cadl",
-  parserOptions: { project: "./tsconfig.json" },
+  parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/versioning/src/versioning.ts
+++ b/packages/versioning/src/versioning.ts
@@ -17,7 +17,6 @@ const renamedFromKey = Symbol();
 const madeOptionalKey = Symbol();
 
 export function $added({ program }: DecoratorContext, t: Type, v: string) {
-  console.log("Abc");
   if (typeof v !== "string") {
     reportDiagnostic(program, { code: "version-must-be-string", target: t });
     return;

--- a/packages/versioning/src/versioning.ts
+++ b/packages/versioning/src/versioning.ts
@@ -17,6 +17,7 @@ const renamedFromKey = Symbol();
 const madeOptionalKey = Symbol();
 
 export function $added({ program }: DecoratorContext, t: Type, v: string) {
+  console.log("Abc");
   if (typeof v !== "string") {
     reportDiagnostic(program, { code: "version-must-be-string", target: t });
     return;


### PR DESCRIPTION
Recent change caused issue with the eslint extension in vscode. 
![image](https://user-images.githubusercontent.com/1031227/160477767-09e945ee-e1ec-43f5-8f76-660d4d7d01bb.png)
It seems to have problem resolving where the tsconfig file is. For each tsconfig set the tsconfig dir to be __dirname. Same logic done in the rush repo. https://github.com/microsoft/rushstack/blob/master/apps/rush/.eslintrc.js