### PR TITLE
Add parent .model to ModelTypeProperty

### DIFF
--- a/common/changes/@cadl-lang/compiler/parent-model_2022-03-28-20-18.json
+++ b/common/changes/@cadl-lang/compiler/parent-model_2022-03-28-20-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add parent .model to ModelTypeProperty",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi3/parent-model_2022-03-28-20-18.json
+++ b/common/changes/@cadl-lang/openapi3/parent-model_2022-03-28-20-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Use parent .model of ModelTypeProperty",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -98,8 +98,6 @@ export interface Checker {
   setUsingsForFile(file: CadlScriptNode): void;
   checkProgram(): void;
   checkSourceFile(file: CadlScriptNode): void;
-  checkModelProperty(prop: ModelPropertyNode): ModelTypeProperty;
-  checkUnionExpression(node: UnionExpressionNode): UnionType;
   getGlobalNamespaceType(): NamespaceType;
   getGlobalNamespaceNode(): NamespaceStatementNode;
   getMergedSymbol(sym: Sym | undefined): Sym | undefined;
@@ -273,8 +271,6 @@ export function createChecker(program: Program): Checker {
     getTypeForNode,
     checkProgram,
     checkSourceFile,
-    checkModelProperty,
-    checkUnionExpression,
     getLiteralType,
     getTypeName,
     getNamespaceString,
@@ -796,8 +792,16 @@ export function createChecker(program: Program): Checker {
    */
   function checkIntersectionExpression(node: IntersectionExpressionNode) {
     const optionTypes = node.options.map(getTypeForNode);
-
     const properties = new Map<string, ModelTypeProperty>();
+
+    const intersection: ModelType = createType({
+      kind: "Model",
+      node,
+      name: "",
+      properties: properties,
+      decorators: [], // could probably include both sets of decorators here...
+    });
+
     for (const option of optionTypes) {
       if (option.kind === "TemplateParameter") {
         continue;
@@ -819,24 +823,12 @@ export function createChecker(program: Program): Checker {
           continue;
         }
 
-        const newPropType = finishType({
-          ...prop,
-          sourceProperty: prop,
-        });
-
+        const newPropType = cloneType(prop, { sourceProperty: prop, model: intersection });
         properties.set(prop.name, newPropType);
       }
     }
 
-    const intersection = createAndFinishType({
-      kind: "Model",
-      node,
-      name: "",
-      properties: properties,
-      decorators: [], // could probably include both sets of decorators here...
-    });
-
-    return intersection;
+    return finishType(intersection);
   }
 
   function checkArrayExpression(node: ArrayExpressionNode): ArrayType {
@@ -1416,7 +1408,7 @@ export function createChecker(program: Program): Checker {
     );
 
     // Evaluate the properties after
-    checkModelProperties(node, type.properties, inheritedPropNames);
+    checkModelProperties(node, type.properties, type, inheritedPropNames);
 
     if (shouldCreateTypeForTemplate(node)) {
       finishType(type);
@@ -1436,30 +1428,30 @@ export function createChecker(program: Program): Checker {
 
   function checkModelExpression(node: ModelExpressionNode) {
     const properties = new Map();
-    checkModelProperties(node, properties);
-    const type: ModelType = createAndFinishType({
+    const type: ModelType = createType({
       kind: "Model",
       name: "",
       node: node,
       properties,
       decorators: [],
     });
-
-    return type;
+    checkModelProperties(node, properties, type);
+    return finishType(type);
   }
 
   function checkModelProperties(
     node: ModelExpressionNode | ModelStatementNode,
     properties: Map<string, ModelTypeProperty>,
+    parentModel: ModelType,
     inheritedPropertyNames?: Set<string>
   ) {
     for (const prop of node.properties!) {
       if ("id" in prop) {
-        const newProp = getTypeForNode(prop) as ModelTypeProperty;
+        const newProp = checkModelProperty(prop, parentModel);
         defineProperty(properties, newProp, inheritedPropertyNames);
       } else {
         // spread property
-        const newProperties = checkSpreadProperty(prop.target);
+        const newProperties = checkSpreadProperty(prop.target, parentModel);
 
         for (const newProp of newProperties) {
           defineProperty(properties, newProp, inheritedPropertyNames);
@@ -1581,7 +1573,10 @@ export function createChecker(program: Program): Checker {
     return isType;
   }
 
-  function checkSpreadProperty(targetNode: TypeReferenceNode): ModelTypeProperty[] {
+  function checkSpreadProperty(
+    targetNode: TypeReferenceNode,
+    parentModel: ModelType
+  ): ModelTypeProperty[] {
     const props: ModelTypeProperty[] = [];
     const targetType = getTypeForNode(targetNode);
 
@@ -1593,7 +1588,7 @@ export function createChecker(program: Program): Checker {
 
       // copy each property
       for (const prop of walkPropertiesInherited(targetType)) {
-        const newProp = cloneType(prop, { sourceProperty: prop });
+        const newProp = cloneType(prop, { sourceProperty: prop, model: parentModel });
         props.push(newProp);
       }
     }
@@ -1610,7 +1605,7 @@ export function createChecker(program: Program): Checker {
     }
   }
 
-  function checkModelProperty(prop: ModelPropertyNode): ModelTypeProperty {
+  function checkModelProperty(prop: ModelPropertyNode, parentModel?: ModelType): ModelTypeProperty {
     const decorators = checkDecorators(prop);
     const valueType = getTypeForNode(prop.value);
     const defaultValue = prop.default && checkDefault(getTypeForNode(prop.default), valueType);
@@ -1624,15 +1619,16 @@ export function createChecker(program: Program): Checker {
       type: valueType,
       decorators,
       default: defaultValue,
+      model: parentModel,
     });
 
-    const parentModel = prop.parent! as
+    const parentModelNode = prop.parent! as
       | ModelStatementNode
       | ModelExpressionNode
       | OperationStatementNode;
     if (
-      parentModel.kind !== SyntaxKind.ModelStatement ||
-      shouldCreateTypeForTemplate(parentModel)
+      parentModelNode.kind !== SyntaxKind.ModelStatement ||
+      shouldCreateTypeForTemplate(parentModelNode)
     ) {
       finishType(type);
     }
@@ -2445,7 +2441,7 @@ export function createChecker(program: Program): Checker {
 
     for (const propNode of node.properties) {
       if (propNode.kind === SyntaxKind.ProjectionModelProperty) {
-        const prop = evalProjectionModelProperty(propNode);
+        const prop = evalProjectionModelProperty(propNode, modelType);
         if (prop.kind === "Return") {
           return prop;
         }
@@ -2467,7 +2463,8 @@ export function createChecker(program: Program): Checker {
   }
 
   function evalProjectionModelProperty(
-    node: ProjectionModelPropertyNode
+    node: ProjectionModelPropertyNode,
+    model: ModelType
   ): ModelTypeProperty | ReturnRecord {
     const type = evalProjectionNode(node.value);
     if (type.kind === "Return") {
@@ -2481,6 +2478,7 @@ export function createChecker(program: Program): Checker {
       decorators: [],
       optional: node.optional,
       type,
+      model,
     });
   }
 

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -799,7 +799,7 @@ export function createChecker(program: Program): Checker {
       node,
       name: "",
       properties: properties,
-      decorators: [], // could probably include both sets of decorators here...
+      decorators: [],
     });
 
     for (const option of optionTypes) {

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -168,6 +168,7 @@ export interface ModelTypeProperty extends BaseType, DecoratedType {
   sourceProperty?: ModelTypeProperty;
   optional: boolean;
   default?: Type;
+  model?: ModelType;
 }
 
 export interface InterfaceType extends BaseType, DecoratedType, TemplatedType {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -626,7 +626,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
   }
 
   function getParameterKey(property: ModelTypeProperty, param: any) {
-    const parent = program.checker!.getTypeForNode(property.node.parent!) as ModelType;
+    const parent = property.model!;
     let key = program.checker!.getTypeName(parent);
     let isQualifiedParamName = false;
 


### PR DESCRIPTION
This add a .model to model properties just as there is a .interface on operations.

The property is optional because it is currently possible to get a model property from getTypeForNode without checking the parent model and we don't memoize getTypeForNode(propertyNode). I started down a road of addressing this, but it got complicated and I thought I'd put this out with parity between operation interface and model properties first, and we can see if that is even a problem worth solving. Even if so, I'd prefer to move on to other parts of metadata work in the short term before going any deeper on that.

