### PR TITLE
Add validation when using versioned library without @versionedDependency

### DIFF
--- a/common/changes/@cadl-lang/versioning/feature-validate-using-versioned-lib_2022-03-28-20-55.json
+++ b/common/changes/@cadl-lang/versioning/feature-validate-using-versioned-lib_2022-03-28-20-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "Add validation when using versioned library without @versionedDependency",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/packages/versioning/src/lib.ts
+++ b/packages/versioning/src/lib.ts
@@ -33,6 +33,12 @@ const libDef = {
         default: paramMessage`The versionedDependency decorator must provide a version of the dependency '${"dependency"}'.`,
       },
     },
+    "using-versioned-library": {
+      severity: "error",
+      messages: {
+        default: paramMessage`Namespace '${"sourceNs"}' is referencing types from versioned namespace '${"targetNs"}' but didn't specified which versions with @versionedDependency.`,
+      },
+    },
   },
 } as const;
 export const { reportDiagnostic } = createCadlLibrary(libDef);

--- a/packages/versioning/src/versioning.ts
+++ b/packages/versioning/src/versioning.ts
@@ -2,6 +2,7 @@ import {
   DecoratorContext,
   NamespaceType,
   navigateProgram,
+  NoTarget,
   Program,
   ProjectionApplication,
   Type,
@@ -178,7 +179,37 @@ export function getVersionDependencies(
 }
 
 export function $onValidate(program: Program) {
+  const namespaceDependencies = new Map();
+  function addDependency(source: NamespaceType | undefined, target: Type | undefined) {
+    if (target === undefined || !("namespace" in target) || target.namespace === undefined) {
+      return;
+    }
+    let set = namespaceDependencies.get(source);
+    if (set === undefined) {
+      set = new Set();
+      namespaceDependencies.set(source, set);
+    }
+    if (target.namespace !== source) {
+      set.add(target.namespace);
+    }
+  }
+
   navigateProgram(program, {
+    model: (model) => {
+      addDependency(model.namespace, model.baseModel);
+      for (const prop of model.properties.values()) {
+        addDependency(model.namespace, prop.type);
+      }
+    },
+    union: (model) => {
+      for (const option of model.options.values()) {
+        addDependency(model.namespace, option);
+      }
+    },
+    operation: (op) => {
+      addDependency(op.namespace, op.parameters);
+      addDependency(op.namespace, op.returnType);
+    },
     namespace: (namespace) => {
       const version = getVersion(program, namespace);
       const dependencies = getVersionDependencies(program, namespace);
@@ -207,6 +238,30 @@ export function $onValidate(program: Program) {
       }
     },
   });
+  validateVersionedNamespaceUsage(program, namespaceDependencies);
+}
+
+function validateVersionedNamespaceUsage(
+  program: Program,
+  namespaceDependencies: Map<NamespaceType | undefined, Set<NamespaceType>>
+) {
+  for (const [source, targets] of namespaceDependencies.entries()) {
+    const dependencies = source && getVersionDependencies(program, source);
+    for (const target of targets) {
+      const targetVersions = getVersion(program, target);
+
+      if (targetVersions !== undefined && dependencies?.get(target) === undefined) {
+        reportDiagnostic(program, {
+          code: "using-versioned-library",
+          format: {
+            sourceNs: program.checker!.getNamespaceString(source),
+            targetNs: program.checker!.getNamespaceString(target),
+          },
+          target: source ?? NoTarget,
+        });
+      }
+    }
+  }
 }
 
 interface VersionRecord {

--- a/packages/versioning/src/versioning.ts
+++ b/packages/versioning/src/versioning.ts
@@ -196,6 +196,10 @@ export function $onValidate(program: Program) {
 
   navigateProgram(program, {
     model: (model) => {
+      // If this is an instantiated type we don't want to keep the mapping.
+      if (model.templateArguments && model.templateArguments.length > 0) {
+        return;
+      }
       addDependency(model.namespace, model.baseModel);
       for (const prop of model.properties.values()) {
         addDependency(model.namespace, prop.type);

--- a/packages/versioning/test/test-versioned-dependencies.ts
+++ b/packages/versioning/test/test-versioned-dependencies.ts
@@ -108,4 +108,45 @@ describe("cadl: versioning: depdendencies", () => {
       });
     });
   });
+
+  describe("when using versioned library without @versionedDependency", () => {
+    it("emit diagnostic when used in extends", async () => {
+      const diagnostics = await runner.diagnose(`
+        namespace MyService {
+          model Test extends VersionedLib.Foo {}
+        } 
+    `);
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/versioning/using-versioned-library",
+        message:
+          "Namespace 'MyService' is referencing types from versioned namespace 'VersionedLib' but didn't specified which versions with @versionedDependency.",
+      });
+    });
+
+    it("emit diagnostic when used in properties", async () => {
+      const diagnostics = await runner.diagnose(`
+        namespace MyService {
+          model Test {
+            foo: VersionedLib.Foo
+          }
+        } 
+    `);
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/versioning/using-versioned-library",
+        message:
+          "Namespace 'MyService' is referencing types from versioned namespace 'VersionedLib' but didn't specified which versions with @versionedDependency.",
+      });
+    });
+
+    it("emit diagnostic when project has no namespace", async () => {
+      const diagnostics = await runner.diagnose(`
+        model Test extends VersionedLib.Foo {}
+    `);
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/versioning/using-versioned-library",
+        message:
+          "Namespace '' is referencing types from versioned namespace 'VersionedLib' but didn't specified which versions with @versionedDependency.",
+      });
+    });
+  });
 });


### PR DESCRIPTION
fix #322

- [x] Seems to be some issue with templated types creating false positives(e.g. using OkResponse from a versioned library)