### PR TITLE
Fix formatting of comment between decorator and statement

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-comment-between-decorator-statement_2022-03-29-01-03.json
+++ b/common/changes/@cadl-lang/compiler/fix-comment-between-decorator-statement_2022-03-29-01-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix formatting of comment between decorator and statement",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -64,7 +64,6 @@ export function printNode(
 ): prettier.Doc {
   const node: Node = path.getValue();
   printDirectives(path, options, print);
-
   switch (node.kind) {
     // Root
     case SyntaxKind.CadlScript:

--- a/packages/compiler/test/formatter/formatter.ts
+++ b/packages/compiler/test/formatter/formatter.ts
@@ -390,6 +390,36 @@ interface Foo {
 `,
       });
     });
+
+    it("format comment between decorator and namespace statement", () => {
+      assertFormat({
+        code: `
+@foo
+// comment
+namespace Bar;
+`,
+        expected: `
+// comment
+@foo
+namespace Bar;
+`,
+      });
+    });
+
+    it("format comment between decorator and model statement", () => {
+      assertFormat({
+        code: `
+@foo
+// comment
+model Bar {}
+`,
+        expected: `
+// comment
+@foo
+model Bar {}
+`,
+      });
+    });
   });
 
   describe("alias union", () => {

--- a/packages/samples/nullable/nullable.cadl
+++ b/packages/samples/nullable/nullable.cadl
@@ -1,3 +1,25 @@
-// comment
-@foo
-model VersionedApi {}
+import "@cadl-lang/rest";
+import "@cadl-lang/openapi";
+
+using Cadl.Http;
+
+model HasNullables {
+  str: string;
+  when: plainTime;
+  strOrNull: string | null;
+  modelOrNull: AnotherModel | null;
+  literalsOrNull: "one" | "two" | null;
+  manyNullsOneString: null | null | string | null;
+  manyNullsSomeValues: null | 42 | null | 100 | null;
+  arr: string[] | null;
+  // thisWillFail: AnotherModel | string | null;
+}
+
+@route("/test")
+namespace NullableMethods {
+  @get op read(@query someParam: string | null, modelOrNull: AnotherModel | null): HasNullables;
+}
+
+model AnotherModel {
+  num: int32;
+}

--- a/packages/samples/nullable/nullable.cadl
+++ b/packages/samples/nullable/nullable.cadl
@@ -1,25 +1,3 @@
-import "@cadl-lang/rest";
-import "@cadl-lang/openapi";
-
-using Cadl.Http;
-
-model HasNullables {
-  str: string;
-  when: plainTime;
-  strOrNull: string | null;
-  modelOrNull: AnotherModel | null;
-  literalsOrNull: "one" | "two" | null;
-  manyNullsOneString: null | null | string | null;
-  manyNullsSomeValues: null | 42 | null | 100 | null;
-  arr: string[] | null;
-  // thisWillFail: AnotherModel | string | null;
-}
-
-@route("/test")
-namespace NullableMethods {
-  @get op read(@query someParam: string | null, modelOrNull: AnotherModel | null): HasNullables;
-}
-
-model AnotherModel {
-  num: int32;
-}
+// comment
+@foo
+model VersionedApi {}


### PR DESCRIPTION
fix #370

This applied to any decorable statement declaration. `model`, `namespace`, etc.