### PR TITLE
Fix: Missing @key  on resource create error instead of duplicate route

### DIFF
--- a/common/changes/@cadl-lang/rest/fix-missing-key-error_2022-03-29-15-28.json
+++ b/common/changes/@cadl-lang/rest/fix-missing-key-error_2022-03-29-15-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add validation when using Resource interfaces when missing @key on resource",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -1,5 +1,6 @@
 import "./http.cadl";
 import "../dist/src/resource.js";
+import "../dist/src/internal-decorators.js";
 
 namespace Cadl.Rest.Resource;
 
@@ -32,6 +33,7 @@ model ResourceCollectionParameters<TResource> {
   ...ParentKeysOf<TResource>;
 }
 
+@validateHasKey(TResource)
 interface ResourceRead<TResource, TError> {
   @autoRoute
   @doc("Gets an instance of the resource.")
@@ -65,6 +67,7 @@ interface ResourceCreate<TResource, TError> {
   ): TResource | ResourceCreatedResponse<TResource> | TError;
 }
 
+@validateHasKey(TResource)
 interface ResourceUpdate<TResource, TError> {
   @autoRoute
   @doc("Updates an existing instance of the resource.")
@@ -82,6 +85,7 @@ model ResourceDeletedResponse {
   _: 200;
 }
 
+@validateHasKey(TResource)
 interface ResourceDelete<TResource, TError> {
   @autoRoute
   @doc("Deletes an existing instance of the resource.")
@@ -105,19 +109,23 @@ interface ResourceList<TResource, TError> {
   list(...ResourceCollectionParameters<TResource>): Page<TResource> | TError;
 }
 
+@validateHasKey(TResource)
 interface ResourceInstanceOperations<TResource, TError>
   mixes ResourceRead<TResource, TError>,
     ResourceUpdate<TResource, TError>,
     ResourceDelete<TResource, TError> {}
 
+@validateHasKey(TResource)
 interface ResourceCollectionOperations<TResource, TError>
   mixes ResourceCreate<TResource, TError>,
     ResourceList<TResource, TError> {}
 
+@validateHasKey(TResource)
 interface ResourceOperations<TResource, TError>
   mixes ResourceInstanceOperations<TResource, TError>,
     ResourceCollectionOperations<TResource, TError> {}
 
+@validateHasKey(TResource)
 interface SingletonResourceRead<TSingleton, TResource, TError> {
   @autoRoute
   @doc("Gets the singleton resource.")
@@ -126,6 +134,7 @@ interface SingletonResourceRead<TSingleton, TResource, TError> {
   Get(...ResourceParameters<TResource>): TSingleton | TError;
 }
 
+@validateHasKey(TResource)
 interface SingletonResourceUpdate<TSingleton, TResource, TError> {
   @autoRoute
   @doc("Updates the singleton resource.")
@@ -141,6 +150,7 @@ interface SingletonResourceOperations<TSingleton, TResource, TError>
   mixes SingletonResourceRead<TSingleton, TResource, TError>,
     SingletonResourceUpdate<TSingleton, TResource, TError> {}
 
+@validateHasKey(TResource)
 interface ExtensionResourceRead<TExtension, TResource, TError> {
   @autoRoute
   @doc("Gets an instance of the extension resource.")

--- a/packages/rest/src/diagnostics.ts
+++ b/packages/rest/src/diagnostics.ts
@@ -45,10 +45,10 @@ const libDefinition = {
         default: "Cannot copy keys from a non-key type (KeysOf<T> or ParentKeysOf<T>)",
       },
     },
-    "missing-key": {
+    "resource-missing-key": {
       severity: "error",
       messages: {
-        default: paramMessage`Type '${"modelName"}' is missing but requires one. Use @key to mark the property key.`,
+        default: paramMessage`Type '${"modelName"}' is used as a resource and therefore must have a key. Use @key to designate a property as the key.`,
       },
     },
     "duplicate-key": {

--- a/packages/rest/src/diagnostics.ts
+++ b/packages/rest/src/diagnostics.ts
@@ -45,6 +45,12 @@ const libDefinition = {
         default: "Cannot copy keys from a non-key type (KeysOf<T> or ParentKeysOf<T>)",
       },
     },
+    "missing-key": {
+      severity: "error",
+      messages: {
+        default: paramMessage`Type '${"modelName"}' is missing but requires one. Use @key to mark the property key.`,
+      },
+    },
     "duplicate-key": {
       severity: "error",
       messages: {

--- a/packages/rest/src/internal-decorators.ts
+++ b/packages/rest/src/internal-decorators.ts
@@ -3,6 +3,7 @@ import { reportDiagnostic } from "./diagnostics.js";
 import { getResourceTypeKey } from "./resource.js";
 
 const validatedMissingKey = Symbol();
+// Workaround for the lack of tempalte constraints https://github.com/microsoft/cadl/issues/377
 export function $validateHasKey(context: DecoratorContext, target: Type, value: Type) {
   if (!validateDecoratorParamType(context.program, target, value, "Model")) {
     return;

--- a/packages/rest/src/internal-decorators.ts
+++ b/packages/rest/src/internal-decorators.ts
@@ -1,0 +1,22 @@
+import { DecoratorContext, Type, validateDecoratorParamType } from "@cadl-lang/compiler";
+import { reportDiagnostic } from "./diagnostics.js";
+import { getResourceTypeKey } from "./resource.js";
+
+const validatedMissingKey = Symbol();
+export function $validateHasKey(context: DecoratorContext, target: Type, value: Type) {
+  if (!validateDecoratorParamType(context.program, target, value, "Model")) {
+    return;
+  }
+  if (context.program.stateSet(validatedMissingKey).has(value)) {
+    return;
+  }
+  const resourceKey = getResourceTypeKey(context.program, value);
+  if (resourceKey === undefined) {
+    reportDiagnostic(context.program, {
+      code: "missing-key",
+      format: { modelName: value.name },
+      target: value,
+    });
+    context.program.stateSet(validatedMissingKey).add(value);
+  }
+}

--- a/packages/rest/src/internal-decorators.ts
+++ b/packages/rest/src/internal-decorators.ts
@@ -13,7 +13,7 @@ export function $validateHasKey(context: DecoratorContext, target: Type, value: 
   const resourceKey = getResourceTypeKey(context.program, value);
   if (resourceKey === undefined) {
     reportDiagnostic(context.program, {
-      code: "missing-key",
+      code: "resource-missing-key",
       format: { modelName: value.name },
       target: value,
     });

--- a/packages/rest/test/test-resource.ts
+++ b/packages/rest/test/test-resource.ts
@@ -266,8 +266,9 @@ describe("rest: resources", () => {
       `
     );
     expectDiagnostics(diagnostics, {
-      code: "@cadl-lang/rest/missing-key",
-      message: "Type 'Dog' is missing but requires one. Use @key to mark the property key.",
+      code: "@cadl-lang/rest/resource-missing-key",
+      message:
+        "Type 'Dog' is used as a resource and therefore must have a key. Use @key to designate a property as the key.",
     });
   });
 });

--- a/packages/rest/test/test-resource.ts
+++ b/packages/rest/test/test-resource.ts
@@ -1,6 +1,6 @@
 import { expectDiagnostics } from "@cadl-lang/compiler/testing";
 import { deepStrictEqual } from "assert";
-import { compileOperations, getRoutesFor } from "./test-host.js";
+import { compileOperations, createRestTestRunner, getRoutesFor } from "./test-host.js";
 
 describe("rest: resources", () => {
   it("resources: generates standard operations for resource types and their children", async () => {
@@ -252,5 +252,22 @@ describe("rest: resources", () => {
         params: ["thingId", "subthingId"],
       },
     ]);
+  });
+
+  it("emit diagnostic if missing @key decorator on resource", async () => {
+    const runner = await createRestTestRunner();
+    const diagnostics = await runner.diagnose(
+      `
+      using Cadl.Rest.Resource;
+
+      interface Dogs mixes ResourceOperations<Dog, {}> {}
+
+      model Dog {}
+      `
+    );
+    expectDiagnostics(diagnostics, {
+      code: "@cadl-lang/rest/missing-key",
+      message: "Type 'Dog' is missing but requires one. Use @key to mark the property key.",
+    });
   });
 });


### PR DESCRIPTION
fix  #220

This adds a decorator to validate the condition of the template param. Until we have better generic constraints there isn't  much else we can do.

The error will show up on the resource itself instead of the mixes which is where it would have made sense but right now there isn't a good way to do that.
![image](https://user-images.githubusercontent.com/1031227/160649836-bfd65990-adcc-44c9-a80e-498755327419.png)
