### PR TITLE
Add RouteOptions and AutoRouteOptions to customize generated routes

### DIFF
--- a/common/changes/@cadl-lang/rest/auto-route-customization_2022-03-30-08-53.json
+++ b/common/changes/@cadl-lang/rest/auto-route-customization_2022-03-30-08-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add RouteOptions and AutoRouteOptions types to enable customization of automatic route generation when calling getAllRoutes",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/src/resource.ts
+++ b/packages/rest/src/resource.ts
@@ -19,6 +19,7 @@ export interface ResourceKey {
 }
 
 const resourceKeysKey = Symbol("resourceKeys");
+const resourceTypeForKeyParamKey = Symbol("resourceTypeForKeyParam");
 
 export function setResourceTypeKey(
   program: Program,
@@ -64,6 +65,25 @@ export function getResourceTypeKey(program: Program, resourceType: ModelType): R
   return resourceKey;
 }
 
+export function $resourceTypeForKeyParam(
+  { program }: DecoratorContext,
+  entity: Type,
+  resourceType: Type
+) {
+  if (!validateDecoratorTarget(program, entity, "@resourceTypeForKeyParam", "ModelProperty")) {
+    return;
+  }
+
+  program.stateMap(resourceTypeForKeyParamKey).set(entity, resourceType);
+}
+
+export function getResourceTypeForKeyParam(
+  program: Program,
+  param: ModelTypeProperty
+): ModelType | undefined {
+  return program.stateMap(resourceTypeForKeyParamKey).get(param);
+}
+
 function cloneKeyProperties(context: DecoratorContext, target: ModelType, resourceType: ModelType) {
   const { program } = context;
   // Add parent keys first
@@ -79,10 +99,16 @@ function cloneKeyProperties(context: DecoratorContext, target: ModelType, resour
 
     const newProp = program.checker!.cloneType(keyProperty);
     newProp.name = keyName;
-    newProp.decorators.push({
-      decorator: $path,
-      args: [],
-    });
+    newProp.decorators.push(
+      {
+        decorator: $path,
+        args: [],
+      },
+      {
+        decorator: $resourceTypeForKeyParam,
+        args: [resourceType],
+      }
+    );
     $path(context, newProp, undefined as any);
 
     target.properties.set(keyName, newProp);

--- a/packages/rest/src/route.ts
+++ b/packages/rest/src/route.ts
@@ -24,6 +24,22 @@ import { getAction, getResourceOperation, getSegment } from "./rest.js";
 
 export type OperationContainer = NamespaceType | InterfaceType;
 
+export interface FilteredRouteParam {
+  routeParamString?: string;
+  excludeFromOperationParams?: boolean;
+}
+
+export interface AutoRouteOptions {
+  routeParamFilter?: (
+    op: OperationType,
+    param: ModelTypeProperty
+  ) => FilteredRouteParam | undefined;
+}
+
+export interface RouteOptions {
+  autoRouteOptions?: AutoRouteOptions;
+}
+
 export interface HttpOperationParameter {
   type: "query" | "path" | "header";
   name: string;
@@ -63,6 +79,22 @@ export function $routeReset({ program }: DecoratorContext, entity: Type, path: s
     path,
     isReset: true,
   });
+}
+
+const routeOptionsKey = Symbol("routeOptions");
+export function setRouteOptionsForNamespace(
+  program: Program,
+  namespace: NamespaceType,
+  options: RouteOptions
+) {
+  program.stateMap(routeOptionsKey).set(namespace, options);
+}
+
+function getRouteOptionsForNamespace(
+  program: Program,
+  namespace: NamespaceType
+): RouteOptions | undefined {
+  return program.stateMap(routeOptionsKey).get(namespace);
 }
 
 const routeContainerKey = Symbol("routeContainer");
@@ -214,7 +246,8 @@ function generatePathFromParameters(
   program: Program,
   operation: OperationType,
   pathFragments: string[],
-  parameters: HttpOperationParameters
+  parameters: HttpOperationParameters,
+  options: RouteOptions
 ) {
   const filteredParameters: HttpOperationParameter[] = [];
   for (const httpParam of parameters.parameters) {
@@ -222,12 +255,22 @@ function generatePathFromParameters(
     if (type === "path") {
       addSegmentFragment(program, param, pathFragments);
 
-      // Add the path variable for the parameter
-      if (param.type.kind === "String") {
-        pathFragments.push(`/${param.type.value}`);
-        continue; // Skip adding to the parameter list
+      const filteredParam = options.autoRouteOptions?.routeParamFilter?.(operation, param);
+      if (filteredParam?.routeParamString) {
+        pathFragments.push(`/${filteredParam.routeParamString}`);
+
+        if (filteredParam?.excludeFromOperationParams === true) {
+          // Skip the rest of the loop so that we don't add the parameter to the final list
+          continue;
+        }
       } else {
-        pathFragments.push(`/{${param.name}}`);
+        // Add the path variable for the parameter
+        if (param.type.kind === "String") {
+          pathFragments.push(`/${param.type.value}`);
+          continue; // Skip adding to the parameter list
+        } else {
+          pathFragments.push(`/{${param.name}}`);
+        }
       }
     }
 
@@ -245,15 +288,17 @@ function generatePathFromParameters(
 function getPathForOperation(
   program: Program,
   operation: OperationType,
-  routeFragments: string[]
+  routeFragments: string[],
+  options: RouteOptions
 ): { path: string; pathFragment?: string; parameters: HttpOperationParameters } {
   const parameters: HttpOperationParameters = getOperationParameters(program, operation);
 
   const pathFragments = [...routeFragments];
   const routePath = getRoutePath(program, operation);
   if (isAutoRoute(program, operation)) {
-    // The operation exists within an @autoRoute scope, generate the path
-    generatePathFromParameters(program, operation, pathFragments, parameters);
+    // The operation exists within an @autoRoute scope, generate the path.  This
+    // mutates the pathFragments and parameters lists that are passed in!
+    generatePathFromParameters(program, operation, pathFragments, parameters, options);
   } else {
     // Prepend any explicit route path
     if (routePath) {
@@ -332,7 +377,8 @@ function buildRoutes(
   program: Program,
   container: OperationContainer,
   routeFragments: string[],
-  visitedOperations: Set<OperationType>
+  visitedOperations: Set<OperationType>,
+  options: RouteOptions
 ): OperationDetails[] {
   // Get the route info for this container, if any
   const baseRoute = getRoutePath(program, container);
@@ -347,7 +393,7 @@ function buildRoutes(
       continue;
     }
 
-    const route = getPathForOperation(program, op, parentFragments);
+    const route = getPathForOperation(program, op, parentFragments, options);
     const verb = getVerbForOperation(program, op, route.parameters);
     const responses = getResponsesForOperation(program, op);
     operations.push({
@@ -371,7 +417,7 @@ function buildRoutes(
     ];
 
     const childRoutes = children.flatMap((child) =>
-      buildRoutes(program, child, parentFragments, visitedOperations)
+      buildRoutes(program, child, parentFragments, visitedOperations, options)
     );
     for (const child of childRoutes) [operations.push(child)];
   }
@@ -382,9 +428,15 @@ function buildRoutes(
 export function getRoutesForContainer(
   program: Program,
   container: OperationContainer,
-  visitedOperations: Set<OperationType>
+  visitedOperations: Set<OperationType>,
+  options?: RouteOptions
 ): OperationDetails[] {
-  return buildRoutes(program, container, [], visitedOperations);
+  const routeOptions =
+    options ??
+    (container.kind === "Namespace" ? getRouteOptionsForNamespace(program, container) : {}) ??
+    {};
+
+  return buildRoutes(program, container, [], visitedOperations, routeOptions);
 }
 
 function isUninstantiatedTemplateInterface(maybeInterface: Type): boolean {
@@ -396,7 +448,7 @@ function isUninstantiatedTemplateInterface(maybeInterface: Type): boolean {
   );
 }
 
-export function getAllRoutes(program: Program): OperationDetails[] {
+export function getAllRoutes(program: Program, options?: RouteOptions): OperationDetails[] {
   let operations: OperationDetails[] = [];
 
   const serviceNamespace = getServiceNamespace(program);
@@ -416,7 +468,8 @@ export function getAllRoutes(program: Program): OperationDetails[] {
     const newOps = getRoutesForContainer(
       program,
       container as OperationContainer,
-      visitedOperations
+      visitedOperations,
+      options
     );
 
     // Make sure we don't visit the same operations again

--- a/packages/rest/test/test-host.ts
+++ b/packages/rest/test/test-host.ts
@@ -7,7 +7,7 @@ import {
   TestHost,
 } from "@cadl-lang/compiler/testing";
 import { HttpVerb } from "../src/http.js";
-import { getAllRoutes, HttpOperationParameter } from "../src/route.js";
+import { getAllRoutes, HttpOperationParameter, RouteOptions } from "../src/route.js";
 import { RestTestLibrary } from "../src/testing/index.js";
 
 export async function createRestTestHost(): Promise<TestHost> {
@@ -31,8 +31,11 @@ export interface RouteDetails {
   params: string[];
 }
 
-export async function getRoutesFor(code: string): Promise<RouteDetails[]> {
-  const [routes, diagnostics] = await compileOperations(code);
+export async function getRoutesFor(
+  code: string,
+  routeOptions?: RouteOptions
+): Promise<RouteDetails[]> {
+  const [routes, diagnostics] = await compileOperations(code, routeOptions);
   expectDiagnosticEmpty(diagnostics);
   return routes.map((route) => ({
     ...route,
@@ -52,12 +55,13 @@ export interface OperationDetails {
 }
 
 export async function compileOperations(
-  code: string
+  code: string,
+  routeOptions?: RouteOptions
 ): Promise<[OperationDetails[], readonly Diagnostic[]]> {
   const runner = await createRestTestRunner();
 
   await runner.compileAndDiagnose(code, { noEmit: true });
-  const routes = getAllRoutes(runner.program);
+  const routes = getAllRoutes(runner.program, routeOptions);
   const details = routes.map((r) => {
     return {
       verb: r.verb,

--- a/packages/rest/test/test-routes.ts
+++ b/packages/rest/test/test-routes.ts
@@ -409,4 +409,34 @@ describe("rest: routes", () => {
       expectDiagnosticEmpty(diagnostics);
     });
   });
+
+  it("allows customization of path parameters in generated routes", async () => {
+    const routes = await getRoutesFor(
+      `
+      @get
+      @autoRoute
+      op TestRoute(
+        @path
+        @segment("things")
+        thingId: string;
+
+        @path
+        @segment("subthings")
+        subThingId: string;
+      ): string;
+      `,
+      {
+        autoRouteOptions: {
+          routeParamFilter: (_, param) => {
+            return {
+              routeParamString: param.name === "subThingId" ? "bar" : "{foo}",
+              excludeFromOperationParams: true,
+            };
+          },
+        },
+      }
+    );
+
+    deepStrictEqual(routes, [{ verb: "get", path: "/things/{foo}/subthings/bar", params: [] }]);
+  });
 });


### PR DESCRIPTION
This change adds a new `RouteOptions` parameter to `getAllRoutes` and `getRoutesForContainer` which (for now) exposes an `AutoRouteOptions` interface for customizing how route parameters are generated for `autoRoute` operations.

This enables emitters to customize route generation by allowing route parameters (the `{param}` syntax) to be renamed or replaced with static values based on library-specific metadata that is attached to the parameter or operation.

The caller can also decide whether certain route parameters should appear in the final set of operation parameters.

This ultimately enables me to add support for ARM singleton resource types in Azure/cadl-azure#1319.

/cc @johanste