### PR TITLE
Fix formatting of comment between decorator and property

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-format-comment-prop_2022-03-31-15-26.json
+++ b/common/changes/@cadl-lang/compiler/fix-format-comment-prop_2022-03-31-15-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix formatting of comment between decorator and property",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/formatter/print/comment-handler.ts
+++ b/packages/compiler/formatter/print/comment-handler.ts
@@ -60,8 +60,10 @@ function addStatementDecoratorComment(comment: CommentNode) {
     precedingNode &&
     precedingNode.kind === SyntaxKind.DecoratorExpression &&
     enclosingNode &&
-    "decorators" in enclosingNode &&
-    enclosingNode.decorators.length > 0
+    (enclosingNode.kind === SyntaxKind.NamespaceStatement ||
+      enclosingNode.kind === SyntaxKind.ModelStatement ||
+      enclosingNode.kind === SyntaxKind.EnumStatement ||
+      enclosingNode.kind === SyntaxKind.UnionStatement)
   ) {
     util.addLeadingComment(enclosingNode, comment);
     return true;

--- a/packages/compiler/test/formatter/formatter.ts
+++ b/packages/compiler/test/formatter/formatter.ts
@@ -420,6 +420,25 @@ model Bar {}
 `,
       });
     });
+
+    it("format comment between decorator and model property", () => {
+      assertFormat({
+        code: `
+model Bar {
+  @foo
+// comment
+myProp: string;
+}
+`,
+        expected: `
+model Bar {
+  @foo
+  // comment
+  myProp: string;
+}
+`,
+      });
+    });
   });
 
   describe("alias union", () => {


### PR DESCRIPTION
Previous PR that fix the formatting of statement afffected the formatting of property as the failure in the core bump in the cadl-azure repo shows https://github.com/Azure/cadl-azure/pull/1330
This was formatting the left into the right
![image](https://user-images.githubusercontent.com/1031227/161092523-74d8adfd-570f-44bc-ba38-05f1f15dfad1.png)
