### PR TITLE
Add workaround for npx bug doubling `\` in command args

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-backslash-escape_2022-04-05-20-46.json
+++ b/common/changes/@cadl-lang/compiler/fix-backslash-escape_2022-04-05-20-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add workaround for npx bug causing issue with backslash in cli on windows",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/cli.ts
+++ b/packages/compiler/core/cli.ts
@@ -299,8 +299,9 @@ async function getCompilerOptions(args: {
   emit?: string[];
   "diagnostic-level": string;
 }): Promise<CompilerOptions> {
-  // Ensure output path
-  const outputPath = resolvePath(args["output-path"]);
+  // Workaround for https://github.com/npm/cli/issues/3680
+  const pathArg = args["output-path"].replace(/\\\\/g, "\\");
+  const outputPath = resolvePath(process.cwd(), pathArg);
   await mkdirp(outputPath);
 
   const miscOptions: any = {};


### PR DESCRIPTION
fix https://github.com/Azure/cadl-azure/issues/1334