### PR TITLE
Add ability to self reference library in imports and emitters config

### DIFF
--- a/common/changes/@cadl-lang/compiler/feature-emit-self_2022-04-06-22-42.json
+++ b/common/changes/@cadl-lang/compiler/feature-emit-self_2022-04-06-22-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add ability to import library or emitter defined in parent folder. Adds the ability to use the actual emitter name in a samples folder of that emitter",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/test/libraries/library-dev/package.json
+++ b/packages/compiler/test/libraries/library-dev/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "my-cadl-library",
+  "type": "module",
+  "cadlMain": "./src/main.cadl"
+}

--- a/packages/compiler/test/libraries/library-dev/samples/main.cadl
+++ b/packages/compiler/test/libraries/library-dev/samples/main.cadl
@@ -1,0 +1,3 @@
+import "my-cadl-library";
+
+op test(): MyCadlLibrary.Test;

--- a/packages/compiler/test/libraries/library-dev/src/main.cadl
+++ b/packages/compiler/test/libraries/library-dev/src/main.cadl
@@ -1,0 +1,3 @@
+namespace MyCadlLibrary {
+  model Test {}
+}

--- a/packages/compiler/test/libraries/test-libraries.ts
+++ b/packages/compiler/test/libraries/test-libraries.ts
@@ -3,11 +3,14 @@ import { NodeHost } from "../../core/node-host.js";
 import { createProgram } from "../../core/program.js";
 import { createTestHost, expectDiagnosticEmpty, expectDiagnostics } from "../../testing/index.js";
 
-const libs = ["simple"];
+const libs = [
+  "simple", // Load a library in `node_modules`
+  "library-dev/samples", // Load library defined in parent folder.
+];
 
 describe("compiler: libraries", () => {
   for (const lib of libs) {
-    describe(lib, () => {
+    describe.only(lib, () => {
       it("compiles without error", async () => {
         const mainFile = fileURLToPath(
           new URL(`../../../test/libraries/${lib}/main.cadl`, import.meta.url)

--- a/packages/compiler/test/libraries/test-libraries.ts
+++ b/packages/compiler/test/libraries/test-libraries.ts
@@ -10,7 +10,7 @@ const libs = [
 
 describe("compiler: libraries", () => {
   for (const lib of libs) {
-    describe.only(lib, () => {
+    describe(lib, () => {
       it("compiles without error", async () => {
         const mainFile = fileURLToPath(
           new URL(`../../../test/libraries/${lib}/main.cadl`, import.meta.url)


### PR DESCRIPTION
fix #284
Adds the ability to use the actual emitter name in a samples folder of that emitter

## Problem this solve

When writing a library or emitter you might want to have a samples folder within the package(not as a separate package like we have in this monorepo).
Now in the samples you want to be able to reference to your library by its name but this is currently not possible so the workaround is to have the full path to the entrypoint of the library.

### Before

```
/package.json # name: tsEmitter
/src
  /tsEmitter.ts # Emitter entrypoint
/samples
  main.cadl
  cadl-project.json # -> to use the tsEmitter you have to have `emitters: ../dist/src/tsEmitters.js`
```

### Now
```
/package.json # name: tsEmitter
/src
  /tsEmitter.ts # Emitter entrypoint
/samples
  main.cadl
  cadl-project.json # -> can now have `emitters: tsEmitter`
```


The problem is the same with `import` you could now reference the library `import "tsEmitter"` instead of `import "../lib/main.cadl"`