### PR TITLE
Don't do default type checking when property type is errorType

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-default-errortype_2022-04-08-16-57.json
+++ b/common/changes/@cadl-lang/compiler/fix-default-errortype_2022-04-08-16-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Do not validate default assignment when property type is an error type. Prevent additional unrelated error to the original problem with the property type.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -1644,6 +1644,9 @@ export function createChecker(program: Program): Checker {
   }
 
   function checkDefault(defaultType: Type, type: Type): Type {
+    if (isErrorType(type)) {
+      return errorType;
+    }
     switch (type.kind) {
       case "Model":
         return checkDefaultForModelType(defaultType, type);

--- a/packages/compiler/test/checker/model.ts
+++ b/packages/compiler/test/checker/model.ts
@@ -1,5 +1,5 @@
-import { match, ok, strictEqual } from "assert";
-import { ModelType, Type } from "../../core/types.js";
+import { deepStrictEqual, match, ok, strictEqual } from "assert";
+import { ModelType, ModelTypeProperty, Type } from "../../core/types.js";
 import {
   createTestHost,
   expectDiagnosticEmpty,
@@ -99,6 +99,28 @@ describe("compiler: models", () => {
     ]);
   });
 
+  describe("assign default values", () => {
+    const testCases: [string, string, any][] = [
+      ["boolean", `false`, { kind: "Boolean", value: false }],
+      ["boolean", `true`, { kind: "Boolean", value: true }],
+      ["string", `"foo"`, { kind: "String", value: "foo" }],
+      ["int32", `123`, { kind: "Number", value: 123 }],
+    ];
+
+    for (const [type, defaultValue, expectedValue] of testCases) {
+      it(`foo?: ${type} = ${defaultValue}`, async () => {
+        testHost.addCadlFile(
+          "main.cadl",
+          `
+          model A { @test foo?: ${type} = ${defaultValue} }
+          `
+        );
+        const { foo } = (await testHost.compile("main.cadl")) as { foo: ModelTypeProperty };
+        deepStrictEqual({ ...foo.default }, expectedValue);
+      });
+    }
+  });
+
   describe("doesn't allow a default of different type than the property type", () => {
     const testCases: [string, string, RegExp][] = [
       ["string", "123", /Default must be a string/],
@@ -121,6 +143,19 @@ describe("compiler: models", () => {
         match(diagnostics[0].message, errorRegex);
       });
     }
+  });
+
+  it(`doesn't emit unsuported-default diagnostic when type is an error`, async () => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+        model A { foo?: bool = false }
+      `
+    );
+    const diagnostics = await testHost.diagnose("main.cadl");
+    expectDiagnostics(diagnostics, [
+      { code: "unknown-identifier", message: "Unknown identifier bool" },
+    ]);
   });
 
   it("provides parent model of properties", async () => {


### PR DESCRIPTION
Resolve issue where it would emit `unsupported-default` error when the property type was an unknown symbol.

https://github.com/Azure/cadl-azure/issues/1362