### PR TITLE
Fix: Instantiated template types only used in `is` or `spread` shouldn't be included as derived types in OpenAPI3

### DIFF
--- a/common/changes/@cadl-lang/openapi3/fix-unused-instantiated-types_2022-04-08-18-32.json
+++ b/common/changes/@cadl-lang/openapi3/fix-unused-instantiated-types_2022-04-08-18-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -797,6 +797,15 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     }
   }
 
+  function includeDerivedModel(model: ModelType): boolean {
+    return (
+      !isTemplate(model) &&
+      (model.templateArguments === undefined ||
+        model.templateArguments?.length === 0 ||
+        model.derivedModels.length > 0)
+    );
+  }
+
   function getSchemaForModel(model: ModelType) {
     let modelSchema: OpenAPI3Schema & Required<Pick<OpenAPI3Schema, "properties">> = {
       type: "object",
@@ -804,7 +813,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       description: getDoc(program, model),
     };
 
-    const derivedModels = model.derivedModels.filter((x) => !isTemplate(x));
+    const derivedModels = model.derivedModels.filter(includeDerivedModel);
     // getSchemaOrRef on all children to push them into components.schemas
     for (const child of derivedModels) {
       getSchemaOrRef(child);

--- a/packages/openapi3/test/test-openapi-output.ts
+++ b/packages/openapi3/test/test-openapi-output.ts
@@ -172,6 +172,29 @@ describe("openapi3: definitions", () => {
     });
   });
 
+  it("shouldn't emit instantiated template child types that are only used in is", async () => {
+    const res = await openApiFor(
+      `
+      model Parent {
+        x?: int32;
+      };
+      model TParent<T> extends Parent {
+        t: T;
+      }
+      model Child is TParent<string> {
+        y?: int32;
+      }
+      namespace Test {
+        @route("/") op test(): Parent;
+      }
+      `
+    );
+    ok(
+      !("TParent_string" in res.components.schemas),
+      "Parent instantiated templated type shouldn't be includd in OpenAPI"
+    );
+  });
+
   it("defines models with properties extended from models", async () => {
     const res = await oapiForModel(
       "Bar",


### PR DESCRIPTION
Another issue from the derivedModels