### PR TITLE
Missing formatter syntax

### DIFF
--- a/common/changes/@cadl-lang/compiler/missing-formatter-syntax_2022-04-09-00-31.json
+++ b/common/changes/@cadl-lang/compiler/missing-formatter-syntax_2022-04-09-00-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Added formatting to a few more missing syntax(`array`, `tuple`, `template parameters`)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -2226,8 +2226,6 @@ export function visitChildren<T>(node: Node, cb: NodeCb<T>): T | undefined {
         visitEach(cb, node.templateParameters) ||
         visitNode(cb, node.value)
       );
-    case SyntaxKind.NamedImport:
-      return visitNode(cb, node.id);
     case SyntaxKind.TypeReference:
       return visitNode(cb, node.target) || visitEach(cb, node.arguments);
     case SyntaxKind.TupleExpression:

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -382,7 +382,6 @@ export enum SyntaxKind {
   JsSourceFile,
   ImportStatement,
   Identifier,
-  NamedImport,
   DecoratorExpression,
   DirectiveExpression,
   MemberExpression,
@@ -502,7 +501,6 @@ export type Node =
   | ModelPropertyNode
   | UnionVariantNode
   | OperationStatementNode
-  | NamedImportNode
   | EnumMemberNode
   | ModelSpreadPropertyNode
   | DecoratorExpressionNode
@@ -592,11 +590,6 @@ export interface ImportStatementNode extends BaseNode {
 export interface IdentifierNode extends BaseNode {
   readonly kind: SyntaxKind.Identifier;
   readonly sv: string;
-}
-
-export interface NamedImportNode extends BaseNode {
-  readonly kind: SyntaxKind.NamedImport;
-  readonly id: IdentifierNode;
 }
 
 export interface DecoratorExpressionNode extends BaseNode {

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -1,7 +1,9 @@
 import prettier, { AstPath, Doc, Printer } from "prettier";
 import {
   AliasStatementNode,
+  ArrayExpressionNode,
   BlockComment,
+  BooleanLiteralNode,
   CadlScriptNode,
   Comment,
   DecoratorExpressionNode,
@@ -11,6 +13,7 @@ import {
   InterfaceStatementNode,
   IntersectionExpressionNode,
   LineComment,
+  MemberExpressionNode,
   ModelExpressionNode,
   ModelPropertyNode,
   ModelSpreadPropertyNode,
@@ -23,7 +26,9 @@ import {
   Statement,
   StringLiteralNode,
   SyntaxKind,
+  TemplateParameterDeclarationNode,
   TextRange,
+  TupleExpressionNode,
   TypeReferenceNode,
   UnionExpressionNode,
   UnionStatementNode,
@@ -98,6 +103,8 @@ export function printNode(
       return printStringLiteral(path as AstPath<StringLiteralNode>, options);
     case SyntaxKind.NumericLiteral:
       return printNumberLiteral(path as AstPath<NumericLiteralNode>, options);
+    case SyntaxKind.BooleanLiteral:
+      return printBooleanLiteral(path as AstPath<BooleanLiteralNode>, options);
     case SyntaxKind.ModelExpression:
       return printModelExpression(path as AstPath<ModelExpressionNode>, options, print);
     case SyntaxKind.ModelProperty:
@@ -110,15 +117,71 @@ export function printNode(
       return printUnion(path as AstPath<UnionExpressionNode>, options, print);
     case SyntaxKind.IntersectionExpression:
       return printIntersection(path as AstPath<IntersectionExpressionNode>, options, print);
+    case SyntaxKind.ArrayExpression:
+      return printArray(path as AstPath<ArrayExpressionNode>, options, print);
+    case SyntaxKind.TupleExpression:
+      return printTuple(path as AstPath<TupleExpressionNode>, options, print);
+    case SyntaxKind.MemberExpression:
+      return printMemberExpression(path as AstPath<MemberExpressionNode>, options, print);
     case SyntaxKind.EnumMember:
       return printEnumMember(path as AstPath<EnumMemberNode>, options, print);
     case SyntaxKind.UnionVariant:
       return printUnionVariant(path as AstPath<UnionVariantNode>, options, print);
     case SyntaxKind.TypeReference:
       return printTypeReference(path as AstPath<TypeReferenceNode>, options, print);
+    case SyntaxKind.TemplateParameterDeclaration:
+      return printTemplateParameterDeclaration(
+        path as AstPath<TemplateParameterDeclarationNode>,
+        options,
+        print
+      );
     case SyntaxKind.ModelSpreadProperty:
       return printModelSpread(path as AstPath<ModelSpreadPropertyNode>, options, print);
+    case SyntaxKind.VoidKeyword:
+      return "void";
+    case SyntaxKind.NeverKeyword:
+      return "never";
+    // TODO: projection formatting
+    case SyntaxKind.Projection:
+    case SyntaxKind.ProjectionParameterDeclaration:
+    case SyntaxKind.ProjectionModelSelector:
+    case SyntaxKind.ProjectionOperationSelector:
+    case SyntaxKind.ProjectionUnionSelector:
+    case SyntaxKind.ProjectionInterfaceSelector:
+    case SyntaxKind.ProjectionEnumSelector:
+    case SyntaxKind.ProjectionExpressionStatement:
+    case SyntaxKind.ProjectionIfExpression:
+    case SyntaxKind.ProjectionBlockExpression:
+    case SyntaxKind.ProjectionMemberExpression:
+    case SyntaxKind.ProjectionLogicalExpression:
+    case SyntaxKind.ProjectionEqualityExpression:
+    case SyntaxKind.ProjectionUnaryExpression:
+    case SyntaxKind.ProjectionRelationalExpression:
+    case SyntaxKind.ProjectionArithmeticExpression:
+    case SyntaxKind.ProjectionCallExpression:
+    case SyntaxKind.ProjectionLambdaExpression:
+    case SyntaxKind.ProjectionLambdaParameterDeclaration:
+    case SyntaxKind.ProjectionModelExpression:
+    case SyntaxKind.ProjectionModelProperty:
+    case SyntaxKind.ProjectionModelSpreadProperty:
+    case SyntaxKind.ProjectionTupleExpression:
+    case SyntaxKind.ProjectionStatement:
+    case SyntaxKind.ProjectionDecoratorReferenceExpression:
+    case SyntaxKind.Return:
+      return getRawText(node, options);
+    // END-TODO: projection formatting
+
+    case SyntaxKind.JsSourceFile:
+    case SyntaxKind.EmptyStatement:
+    case SyntaxKind.InvalidStatement:
+      return getRawText(node, options);
+    // default:
+    //   return getRawText(node, options);
     default:
+      // Dummy const to ensure we handle all node types.
+      // If you get an error here, add a case for the new node type
+      // you added..
+      const _assertNever: never = node;
       return getRawText(node, options);
   }
 }
@@ -568,6 +631,42 @@ function isModelNode(node: Node) {
   return node.kind === SyntaxKind.ModelExpression;
 }
 
+export function printArray(
+  path: AstPath<ArrayExpressionNode>,
+  options: object,
+  print: PrettierChildPrint
+): Doc {
+  return [path.call(print, "elementType"), "[]"];
+}
+
+export function printTuple(
+  path: AstPath<TupleExpressionNode>,
+  options: object,
+  print: PrettierChildPrint
+): Doc {
+  return group([
+    "[",
+    indent(
+      join(
+        ", ",
+        path.map((arg) => [softline, print(arg)], "values")
+      )
+    ),
+    ifBreak(","),
+    softline,
+    "]",
+  ]);
+}
+
+export function printMemberExpression(
+  path: AstPath<MemberExpressionNode>,
+  options: object,
+  print: PrettierChildPrint
+): Doc {
+  const node = path.getValue();
+  return [node.base ? [path.call(print, "base"), "."] : "", path.call(print, "id")];
+}
+
 export function printModelExpression(
   path: AstPath<ModelExpressionNode>,
   options: CadlPrettierOptions,
@@ -835,6 +934,15 @@ export function printTypeReference(
   return [type, template];
 }
 
+function printTemplateParameterDeclaration(
+  path: AstPath<TemplateParameterDeclarationNode>,
+  options: CadlPrettierOptions,
+  print: PrettierChildPrint
+): Doc {
+  const node = path.getValue();
+  return [path.call(print, "id"), node.default ? [" = ", path.call(print, "default")] : ""];
+}
+
 function printModelSpread(
   path: prettier.AstPath<ModelSpreadPropertyNode>,
   options: CadlPrettierOptions,
@@ -857,6 +965,14 @@ export function printNumberLiteral(
 ): prettier.doc.builders.Doc {
   const node = path.getValue();
   return getRawText(node, options);
+}
+
+export function printBooleanLiteral(
+  path: prettier.AstPath<BooleanLiteralNode>,
+  options: CadlPrettierOptions
+): prettier.doc.builders.Doc {
+  const node = path.getValue();
+  return node.value ? "true" : "false";
 }
 
 /**

--- a/packages/compiler/test/formatter/formatter.ts
+++ b/packages/compiler/test/formatter/formatter.ts
@@ -964,4 +964,101 @@ interface Foo {
       });
     });
   });
+
+  describe("templated types", () => {
+    it("format parameter declarations", () => {
+      assertFormat({
+        code: `
+model Foo<   T  , K
+> {
+}`,
+        expected: `
+model Foo<T, K> {}`,
+      });
+    });
+
+    it("format parameter declarations with defaults", () => {
+      assertFormat({
+        code: `
+model Foo<   T  ="abc",    K =        134
+> {
+}`,
+        expected: `
+model Foo<T = "abc", K = 134> {}`,
+      });
+    });
+  });
+
+  describe("array expression", () => {
+    it("format an array expression", () => {
+      assertFormat({
+        code: `
+alias Foo = string       [];
+`,
+        expected: `
+alias Foo = string[];
+`,
+      });
+    });
+  });
+
+  describe("tuple expression", () => {
+    it("format a single line tuple", () => {
+      assertFormat({
+        code: `
+alias Foo = [string, 
+  "abc",           134];
+`,
+        expected: `
+alias Foo = [string, "abc", 134];
+`,
+      });
+    });
+    it("format a long tuple over multi line", () => {
+      assertFormat({
+        code: `
+alias Foo = ["very long text that will overflow 1","very long text that will overflow 2", "very long text that will overflow 3" ];
+`,
+        expected: `
+alias Foo = [
+  "very long text that will overflow 1",
+  "very long text that will overflow 2",
+  "very long text that will overflow 3",
+];
+`,
+      });
+    });
+  });
+
+  describe("member expression", () => {
+    it("a simple member expression", () => {
+      assertFormat({
+        code: `
+model Foo {
+  p: Some .     bar;
+}
+`,
+        expected: `
+model Foo {
+  p: Some.bar;
+}
+`,
+      });
+    });
+    it("nested member expression", () => {
+      assertFormat({
+        code: `
+model Foo {
+  p: Some . 
+  Nested.     bar;
+}
+`,
+        expected: `
+model Foo {
+  p: Some.Nested.bar;
+}
+`,
+      });
+    });
+  });
 });


### PR DESCRIPTION
Did a pass of missing formatter implementation for the syntax node.

Explicitly excluded the projection as a TODO as I believe not doing the formatting there was by design.