### PR TITLE
Tweak versioning for linting

### DIFF
--- a/common/changes/@cadl-lang/versioning/tweak-versioning-for-linting_2022-04-12-21-03.json
+++ b/common/changes/@cadl-lang/versioning/tweak-versioning-for-linting_2022-04-12-21-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "Updated versioning data getter to return `undefined` instead of `-1`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}


### PR DESCRIPTION
Not sure why it was returning a number when the value stored in the state map was always a string. Instead return `undefined` if there is no versioning information and let the consumer decide what to do with it.

Needed for https://github.com/Azure/cadl-azure/pull/1376