### PR TITLE
Validate Rest resource interface `TError` is an error model

### DIFF
--- a/common/changes/@cadl-lang/rest/validate-rest-resource-error_2022-04-14-16-06.json
+++ b/common/changes/@cadl-lang/rest/validate-rest-resource-error_2022-04-14-16-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add validation to `Resource` interface to ensure `TError` is an error type",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -34,6 +34,7 @@ model ResourceCollectionParameters<TResource> {
 }
 
 @validateHasKey(TResource)
+@validateIsError(TError)
 interface ResourceRead<TResource, TError> {
   @autoRoute
   @doc("Gets an instance of the resource.")
@@ -68,6 +69,7 @@ interface ResourceCreate<TResource, TError> {
 }
 
 @validateHasKey(TResource)
+@validateIsError(TError)
 interface ResourceUpdate<TResource, TError> {
   @autoRoute
   @doc("Updates an existing instance of the resource.")
@@ -86,6 +88,7 @@ model ResourceDeletedResponse {
 }
 
 @validateHasKey(TResource)
+@validateIsError(TError)
 interface ResourceDelete<TResource, TError> {
   @autoRoute
   @doc("Deletes an existing instance of the resource.")
@@ -110,22 +113,26 @@ interface ResourceList<TResource, TError> {
 }
 
 @validateHasKey(TResource)
+@validateIsError(TError)
 interface ResourceInstanceOperations<TResource, TError>
   mixes ResourceRead<TResource, TError>,
     ResourceUpdate<TResource, TError>,
     ResourceDelete<TResource, TError> {}
 
 @validateHasKey(TResource)
+@validateIsError(TError)
 interface ResourceCollectionOperations<TResource, TError>
   mixes ResourceCreate<TResource, TError>,
     ResourceList<TResource, TError> {}
 
 @validateHasKey(TResource)
+@validateIsError(TError)
 interface ResourceOperations<TResource, TError>
   mixes ResourceInstanceOperations<TResource, TError>,
     ResourceCollectionOperations<TResource, TError> {}
 
 @validateHasKey(TResource)
+@validateIsError(TError)
 interface SingletonResourceRead<TSingleton, TResource, TError> {
   @autoRoute
   @doc("Gets the singleton resource.")
@@ -135,6 +142,7 @@ interface SingletonResourceRead<TSingleton, TResource, TError> {
 }
 
 @validateHasKey(TResource)
+@validateIsError(TError)
 interface SingletonResourceUpdate<TSingleton, TResource, TError> {
   @autoRoute
   @doc("Updates the singleton resource.")
@@ -151,6 +159,7 @@ interface SingletonResourceOperations<TSingleton, TResource, TError>
     SingletonResourceUpdate<TSingleton, TResource, TError> {}
 
 @validateHasKey(TResource)
+@validateIsError(TError)
 interface ExtensionResourceRead<TExtension, TResource, TError> {
   @autoRoute
   @doc("Gets an instance of the extension resource.")

--- a/packages/rest/src/diagnostics.ts
+++ b/packages/rest/src/diagnostics.ts
@@ -51,6 +51,12 @@ const libDefinition = {
         default: paramMessage`Type '${"modelName"}' is used as a resource and therefore must have a key. Use @key to designate a property as the key.`,
       },
     },
+    "resource-missing-error": {
+      severity: "error",
+      messages: {
+        default: paramMessage`Type '${"modelName"}' is used as an error and therefore must have the @error decorator applied.`,
+      },
+    },
     "duplicate-key": {
       severity: "error",
       messages: {

--- a/packages/rest/src/internal-decorators.ts
+++ b/packages/rest/src/internal-decorators.ts
@@ -8,7 +8,7 @@ import { reportDiagnostic } from "./diagnostics.js";
 import { getResourceTypeKey } from "./resource.js";
 
 const validatedMissingKey = Symbol("validatedMissing");
-// Workaround for the lack of tempalte constraints https://github.com/microsoft/cadl/issues/377
+// Workaround for the lack of template constraints https://github.com/microsoft/cadl/issues/377
 export function $validateHasKey(context: DecoratorContext, target: Type, value: Type) {
   if (!validateDecoratorParamType(context.program, target, value, "Model")) {
     return;
@@ -28,7 +28,7 @@ export function $validateHasKey(context: DecoratorContext, target: Type, value: 
 }
 
 const validatedErrorKey = Symbol("validatedError");
-// Workaround for the lack of tempalte constraints https://github.com/microsoft/cadl/issues/377
+// Workaround for the lack of template constraints https://github.com/microsoft/cadl/issues/377
 export function $validateIsError(context: DecoratorContext, target: Type, value: Type) {
   if (!validateDecoratorParamType(context.program, target, value, "Model")) {
     return;

--- a/packages/rest/src/internal-decorators.ts
+++ b/packages/rest/src/internal-decorators.ts
@@ -1,4 +1,9 @@
-import { DecoratorContext, Type, validateDecoratorParamType } from "@cadl-lang/compiler";
+import {
+  DecoratorContext,
+  isErrorModel,
+  Type,
+  validateDecoratorParamType,
+} from "@cadl-lang/compiler";
 import { reportDiagnostic } from "./diagnostics.js";
 import { getResourceTypeKey } from "./resource.js";
 
@@ -19,5 +24,25 @@ export function $validateHasKey(context: DecoratorContext, target: Type, value: 
       target: value,
     });
     context.program.stateSet(validatedMissingKey).add(value);
+  }
+}
+
+const validatedErrorKey = Symbol("validatedError");
+// Workaround for the lack of tempalte constraints https://github.com/microsoft/cadl/issues/377
+export function $validateIsError(context: DecoratorContext, target: Type, value: Type) {
+  if (!validateDecoratorParamType(context.program, target, value, "Model")) {
+    return;
+  }
+  if (context.program.stateSet(validatedErrorKey).has(value)) {
+    return;
+  }
+  const isError = isErrorModel(context.program, value);
+  if (!isError) {
+    reportDiagnostic(context.program, {
+      code: "resource-missing-error",
+      format: { modelName: value.name },
+      target: value,
+    });
+    context.program.stateSet(validatedErrorKey).add(value);
   }
 }

--- a/packages/rest/test/test-resource.ts
+++ b/packages/rest/test/test-resource.ts
@@ -22,7 +22,7 @@ describe("rest: resources", () => {
           subthingId: string;
         }
 
-        model Error {}
+        @error model Error {}
 
         interface Things mixes ResourceOperations<Thing, Error> {}
         interface Subthings mixes ResourceOperations<Subthing, Error> {}
@@ -140,7 +140,7 @@ describe("rest: resources", () => {
           data: string;
         }
 
-        model Error {}
+        @error model Error {}
 
         interface Things mixes ResourceRead<Thing, Error> {}
         interface ThingsSingleton mixes SingletonResourceOperations<Singleton, Thing, Error> {}
@@ -192,7 +192,7 @@ describe("rest: resources", () => {
           exthingId: string;
         }
 
-        model Error {}
+        @error model Error {}
 
         interface ThingsExtension mixes ExtensionResourceOperations<Exthing, Thing, Error> {}
         interface SubthingsExtension mixes ExtensionResourceOperations<Exthing, Subthing, Error> {}

--- a/packages/rest/test/test-resource.ts
+++ b/packages/rest/test/test-resource.ts
@@ -260,15 +260,37 @@ describe("rest: resources", () => {
       `
       using Cadl.Rest.Resource;
 
-      interface Dogs mixes ResourceOperations<Dog, {}> {}
+      interface Dogs mixes ResourceOperations<Dog, Error> {}
 
       model Dog {}
+      @error model Error {code: string}
       `
     );
     expectDiagnostics(diagnostics, {
       code: "@cadl-lang/rest/resource-missing-key",
       message:
         "Type 'Dog' is used as a resource and therefore must have a key. Use @key to designate a property as the key.",
+    });
+  });
+
+  it("emit diagnostic if missing @error decorator on error", async () => {
+    const runner = await createRestTestRunner();
+    const diagnostics = await runner.diagnose(
+      `
+      using Cadl.Rest.Resource;
+
+      interface Dogs mixes ResourceOperations<Dog, Error> {}
+      
+      model Dog {
+        @key foo: string
+      }
+      model Error {code: string}
+      `
+    );
+    expectDiagnostics(diagnostics, {
+      code: "@cadl-lang/rest/resource-missing-error",
+      message:
+        "Type 'Error' is used as an error and therefore must have the @error decorator applied.",
     });
   });
 });


### PR DESCRIPTION
Similar change to the validation of the `TResource` param having a key this makes sure the `TError` param have @error on it. Otherwise this result in some duplicate response error later as both the TResource and TError param would result in having `200` status code.

This issue was uncovered here https://github.com/Azure/cadl-azure/pull/1370#issuecomment-1098543388

Example or errors you would get before this
```
/home/vsts/work/1/s/core/packages/rest/lib/resource.cadl:37:35 - error @cadl-lang/rest/duplicate-response: Multiple return types for content type application/json and status code 200
/home/vsts/work/1/s/core/packages/rest/lib/resource.cadl:50:45 - error @cadl-lang/rest/duplicate-response: Multiple return types for content type application/json and status code 200
/home/vsts/work/1/s/core/packages/rest/lib/resource.cadl:60:37 - error @cadl-lang/rest/duplicate-response: Multiple return types for content type application/json and status code 200
/home/vsts/work/1/s/core/packages/rest/lib/resource.cadl:71:37 - error @cadl-lang/rest/duplicate-response: Multiple return types for content type application/json and status code 200
```