### PR TITLE
Add OmitProperties type and @withoutOmittedProperties decorator

### DIFF
--- a/common/changes/@cadl-lang/compiler/omit-properties_2022-04-14-17-26.json
+++ b/common/changes/@cadl-lang/compiler/omit-properties_2022-04-14-17-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add OmitProperties type and @withoutOmittedProperties decorator",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -404,6 +404,42 @@ export function $withUpdateableProperties({ program }: DecoratorContext, target:
   });
 }
 
+// -- @withoutOmittedProperties decorator ----------------------
+
+export function $withoutOmittedProperties(
+  { program }: DecoratorContext,
+  target: Type,
+  omitProperties: Type
+) {
+  if (omitProperties.kind == "TemplateParameter") {
+    // Silently return because this is a templated type
+    return;
+  }
+
+  if (!validateDecoratorTarget(program, target, "@withoutOmittedProperties", "Model")) {
+    return;
+  }
+
+  if (!validateDecoratorParamType(program, target, omitProperties, ["String", "Union"])) {
+    return;
+  }
+
+  // Get the property or properties to omit
+  const omitNames = new Set<string>();
+  if (omitProperties.kind === "Union") {
+    for (const value of omitProperties.options) {
+      if (value.kind === "String") {
+        omitNames.add(value.value);
+      }
+    }
+  } else {
+    omitNames.add(omitProperties);
+  }
+
+  // Remove all properties to be omitted
+  mapFilterOut(target.properties, (key, _) => omitNames.has(key));
+}
+
 // -- @withoutDefaultValues decorator ----------------------
 
 export function $withoutDefaultValues({ program }: DecoratorContext, target: Type) {

--- a/packages/compiler/lib/lib.cadl
+++ b/packages/compiler/lib/lib.cadl
@@ -92,6 +92,12 @@ model UpdateableProperties<T> {
   ...T;
 }
 
+@doc("The template for omitting properties.")
+@withoutOmittedProperties(TStringOrTuple)
+model OmitProperties<T, TStringOrTuple> {
+  ...T;
+}
+
 @withoutDefaultValues
 model OmitDefaults<T> {
   ...T;

--- a/packages/compiler/test/decorators/decorators.ts
+++ b/packages/compiler/test/decorators/decorators.ts
@@ -1,4 +1,4 @@
-import { ok, strictEqual } from "assert";
+import { deepStrictEqual, ok, strictEqual } from "assert";
 import { ModelType } from "../../core/index.js";
 import {
   getDoc,
@@ -253,6 +253,43 @@ describe("compiler: built-in decorators", () => {
 
       ok(prop.kind === "ModelProperty", "should be a model property");
       strictEqual(getKeyName(runner.program, prop), "alternateName");
+    });
+  });
+
+  describe("@withoutOmittedProperties", () => {
+    it("removes a model property when given a string literal", async () => {
+      const { TestModel } = await runner.compile(
+        `
+        model OriginalModel {
+          removeMe: string;
+          notMe: string;
+        }
+
+        @test
+        model TestModel is OmitProperties<OriginalModel, "removeMe"> {
+        }`
+      );
+
+      const properties = TestModel.kind === "Model" ? Array.from(TestModel.properties.keys()) : [];
+      deepStrictEqual(properties, ["notMe"]);
+    });
+
+    it("removes model properties when given a union containing strings", async () => {
+      const { TestModel } = await runner.compile(
+        `
+        model OriginalModel {
+          removeMe: string;
+          removeMeToo: string;
+          notMe: string;
+        }
+
+        @test
+        model TestModel is OmitProperties<OriginalModel, "removeMe" | "removeMeToo"> {
+        }`
+      );
+
+      const properties = TestModel.kind === "Model" ? Array.from(TestModel.properties.keys()) : [];
+      deepStrictEqual(properties, ["notMe"]);
     });
   });
 });


### PR DESCRIPTION
This PR adds a new decorator `@withoutOmittedProperties` and matching type `OmitProperties` which make it possible to omit specific properties from a model type just by wrapping it.  For example:

```
model OriginalModel {
  removeMe: string;
  removeMeToo: string;
  notMe: string;
}

model TestModel is OmitProperties<OriginalModel, ["removeMe", "removeMeToo"]> {
}
```

I implemented it on a suggestion from @timotheeguerin in PR Azure/cadl-azure#1356.