### PR TITLE
In OmitProperties, compare omitted property names case-insensitively

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-omit-properties_2022-04-15-11-57.json
+++ b/common/changes/@cadl-lang/compiler/fix-omit-properties_2022-04-15-11-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Ensure that property names are compared case-insensitively when omitting properties",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -429,15 +429,15 @@ export function $withoutOmittedProperties(
   if (omitProperties.kind === "Union") {
     for (const value of omitProperties.options) {
       if (value.kind === "String") {
-        omitNames.add(value.value);
+        omitNames.add(value.value.toLowerCase());
       }
     }
   } else {
-    omitNames.add(omitProperties);
+    omitNames.add((omitProperties as string).toLowerCase());
   }
 
   // Remove all properties to be omitted
-  mapFilterOut(target.properties, (key, _) => omitNames.has(key));
+  mapFilterOut(target.properties, (key, _) => omitNames.has(key.toLowerCase()));
 }
 
 // -- @withoutDefaultValues decorator ----------------------

--- a/packages/compiler/test/decorators/decorators.ts
+++ b/packages/compiler/test/decorators/decorators.ts
@@ -279,12 +279,12 @@ describe("compiler: built-in decorators", () => {
         `
         model OriginalModel {
           removeMe: string;
-          removeMeToo: string;
+          RemoveMeToo: string;
           notMe: string;
         }
 
         @test
-        model TestModel is OmitProperties<OriginalModel, "removeMe" | "removeMeToo"> {
+        model TestModel is OmitProperties<OriginalModel, "removeMe" | "rEmoveMeToo"> {
         }`
       );
 


### PR DESCRIPTION
In my previous PR #446, I forgot to compare property names case-insensitively when looking for properties to omit in `@withoutOmittedProperties` / `OmitProperties`.  I added this missing behavior and tweaked one of the tests I added to ensure that it works correctly.