### PR TITLE
Reorder tags and `x-*` extensions in emitted operations

### DIFF
--- a/common/changes/@cadl-lang/openapi3/openapi-emitter-tweaks_2022-04-15-12-49.json
+++ b/common/changes/@cadl-lang/openapi3/openapi-emitter-tweaks_2022-04-15-12-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Rearrange some aspects of operation output in the OpenAPI emitter",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -278,22 +278,6 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
     }
     currentEndpoint = currentPath[verb];
 
-    const operationId = getOperationId(program, op);
-    if (operationId) {
-      currentEndpoint.operationId = operationId;
-    } else {
-      // Synthesize an operation ID
-      currentEndpoint.operationId = (groupName.length > 0 ? `${groupName}_` : "") + op.name;
-    }
-    applyExternalDocs(op, currentEndpoint);
-
-    // allow operation extensions
-    attachExtensions(program, op, currentEndpoint);
-    currentEndpoint.summary = getSummary(program, op);
-    currentEndpoint.description = getDoc(program, op);
-    currentEndpoint.parameters = [];
-    currentEndpoint.responses = {};
-
     const currentTags = getAllTags(program, op);
     if (currentTags) {
       currentEndpoint.tags = currentTags;
@@ -303,9 +287,26 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       }
     }
 
+    const operationId = getOperationId(program, op);
+    if (operationId) {
+      currentEndpoint.operationId = operationId;
+    } else {
+      // Synthesize an operation ID
+      currentEndpoint.operationId = (groupName.length > 0 ? `${groupName}_` : "") + op.name;
+    }
+    applyExternalDocs(op, currentEndpoint);
+
+    // Set up basic endpoint fields
+    currentEndpoint.summary = getSummary(program, op);
+    currentEndpoint.description = getDoc(program, op);
+    currentEndpoint.parameters = [];
+    currentEndpoint.responses = {};
+
     emitEndpointParameters(op, op.parameters, parameters.parameters);
     emitRequestBody(op, op.parameters, parameters);
     emitResponses(operation.responses);
+
+    attachExtensions(program, op, currentEndpoint);
   }
 
   function emitResponses(responses: HttpOperationResponse[]) {

--- a/packages/samples/test/output/grpc-kiosk-example/openapi.json
+++ b/packages/samples/test/output/grpc-kiosk-example/openapi.json
@@ -12,6 +12,9 @@
   "paths": {
     "/v1/kiosks": {
       "post": {
+        "tags": [
+          "Display"
+        ],
         "operationId": "Display_createKiosk",
         "description": "Create a kiosk. This enrolls the kiosk for sign display.",
         "parameters": [],
@@ -37,9 +40,6 @@
             }
           }
         },
-        "tags": [
-          "Display"
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -51,6 +51,9 @@
         }
       },
       "get": {
+        "tags": [
+          "Display"
+        ],
         "operationId": "Display_listKiosks",
         "description": "List active kiosks.",
         "parameters": [],
@@ -75,14 +78,14 @@
               }
             }
           }
-        },
-        "tags": [
-          "Display"
-        ]
+        }
       }
     },
     "/v1/kiosks/{id}": {
       "get": {
+        "tags": [
+          "Display"
+        ],
         "operationId": "Display_getKiosk",
         "description": "Get a kiosk.",
         "parameters": [
@@ -117,12 +120,12 @@
               }
             }
           }
-        },
-        "tags": [
-          "Display"
-        ]
+        }
       },
       "delete": {
+        "tags": [
+          "Display"
+        ],
         "operationId": "Display_deleteKiosk",
         "description": "Delete a kiosk.",
         "parameters": [
@@ -150,14 +153,14 @@
               }
             }
           }
-        },
-        "tags": [
-          "Display"
-        ]
+        }
       }
     },
     "/v1/signs": {
       "post": {
+        "tags": [
+          "Display"
+        ],
         "operationId": "Display_createSign",
         "description": "Create a sign. This enrolls the sign for sign display.",
         "parameters": [],
@@ -183,9 +186,6 @@
             }
           }
         },
-        "tags": [
-          "Display"
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -197,6 +197,9 @@
         }
       },
       "get": {
+        "tags": [
+          "Display"
+        ],
         "operationId": "Display_listSigns",
         "description": "List active signs.",
         "parameters": [],
@@ -211,14 +214,14 @@
               }
             }
           }
-        },
-        "tags": [
-          "Display"
-        ]
+        }
       }
     },
     "/v1/signs/{id}": {
       "get": {
+        "tags": [
+          "Display"
+        ],
         "operationId": "Display_getSign",
         "description": "Get a sign.",
         "parameters": [
@@ -253,12 +256,12 @@
               }
             }
           }
-        },
-        "tags": [
-          "Display"
-        ]
+        }
       },
       "delete": {
+        "tags": [
+          "Display"
+        ],
         "operationId": "Display_deleteSign",
         "description": "Delete a sign.",
         "parameters": [
@@ -286,14 +289,14 @@
               }
             }
           }
-        },
-        "tags": [
-          "Display"
-        ]
+        }
       }
     },
     "/v1/signs/{sign_id}": {
       "post": {
+        "tags": [
+          "Display"
+        ],
         "operationId": "Display_setSignIdForKioskIds",
         "description": "Set a sign for display on one or more kiosks.",
         "parameters": [
@@ -316,9 +319,6 @@
             }
           }
         },
-        "tags": [
-          "Display"
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -337,6 +337,9 @@
     },
     "/v1/kiosks/{kiosk_id}/sign": {
       "get": {
+        "tags": [
+          "Display"
+        ],
         "operationId": "Display_getSignIdForKioskId",
         "description": "Get the sign that should be displayed on a kiosk.",
         "parameters": [
@@ -371,10 +374,7 @@
               }
             }
           }
-        },
-        "tags": [
-          "Display"
-        ]
+        }
       }
     }
   },

--- a/packages/samples/test/output/grpc-library-example/openapi.json
+++ b/packages/samples/test/output/grpc-library-example/openapi.json
@@ -12,6 +12,9 @@
   "paths": {
     "/v1/shelves": {
       "post": {
+        "tags": [
+          "LibraryService"
+        ],
         "operationId": "LibraryService_createShelf",
         "description": "Creates a shelf, and returns the new Shelf.",
         "parameters": [],
@@ -37,9 +40,6 @@
             }
           }
         },
-        "tags": [
-          "LibraryService"
-        ],
         "requestBody": {
           "description": "The shelf to create.",
           "content": {
@@ -52,6 +52,9 @@
         }
       },
       "get": {
+        "tags": [
+          "LibraryService"
+        ],
         "operationId": "LibraryService_listShelves",
         "description": "Lists shelves. The order is unspecified but deterministic. Newly created\nshelves will not necessarily be added to the end of this list.",
         "parameters": [
@@ -83,14 +86,14 @@
               }
             }
           }
-        },
-        "tags": [
-          "LibraryService"
-        ]
+        }
       }
     },
     "/v1/shelves/{name}": {
       "get": {
+        "tags": [
+          "LibraryService"
+        ],
         "operationId": "LibraryService_getShelf",
         "description": "Gets a shelf. Returns NOT_FOUND if the shelf does not exist.",
         "parameters": [
@@ -119,12 +122,12 @@
               }
             }
           }
-        },
-        "tags": [
-          "LibraryService"
-        ]
+        }
       },
       "delete": {
+        "tags": [
+          "LibraryService"
+        ],
         "operationId": "LibraryService_deleteShelf",
         "description": "Deletes a shelf. Returns NOT_FOUND if the shelf does not exist.",
         "parameters": [
@@ -146,14 +149,14 @@
               }
             }
           }
-        },
-        "tags": [
-          "LibraryService"
-        ]
+        }
       }
     },
     "/v1/shelves/{name}:merge": {
       "post": {
+        "tags": [
+          "LibraryService"
+        ],
         "operationId": "LibraryService_mergeShelves",
         "description": "Merges two shelves by adding all books from the shelf named\n`other_shelf_name` to shelf `name`, and deletes\n`other_shelf_name`. Returns the updated shelf.\nThe book ids of the moved books may not be the same as the original books.\nReturns NOT_FOUND if either shelf does not exist.\nThis call is a no-op if the specified shelves are the same.",
         "parameters": [
@@ -183,9 +186,6 @@
             }
           }
         },
-        "tags": [
-          "LibraryService"
-        ],
         "requestBody": {
           "description": "The name of the shelf we're removing books from and deleting.",
           "content": {
@@ -200,6 +200,9 @@
     },
     "/v1/shelves/{name}/books": {
       "post": {
+        "tags": [
+          "LibraryService"
+        ],
         "operationId": "LibraryService_createBook",
         "description": "Creates a book, and returns the new Book.",
         "parameters": [
@@ -229,9 +232,6 @@
             }
           }
         },
-        "tags": [
-          "LibraryService"
-        ],
         "requestBody": {
           "description": "The book to create.",
           "content": {
@@ -244,6 +244,9 @@
         }
       },
       "get": {
+        "tags": [
+          "LibraryService"
+        ],
         "operationId": "LibraryService_listBooks",
         "description": "Lists books in a shelf. The order is unspecified but deterministic. Newly\ncreated books will not necessarily be added to the end of this list.\nReturns NOT_FOUND if the shelf does not exist.",
         "parameters": [
@@ -278,14 +281,14 @@
               }
             }
           }
-        },
-        "tags": [
-          "LibraryService"
-        ]
+        }
       }
     },
     "/v1/shelves/shelf_name/books/{name}": {
       "get": {
+        "tags": [
+          "LibraryService"
+        ],
         "operationId": "LibraryService_getBook",
         "description": "Gets a book. Returns NOT_FOUND if the book does not exist.",
         "parameters": [
@@ -314,12 +317,12 @@
               }
             }
           }
-        },
-        "tags": [
-          "LibraryService"
-        ]
+        }
       },
       "delete": {
+        "tags": [
+          "LibraryService"
+        ],
         "operationId": "LibraryService_deleteBook",
         "description": "Deletes a book. Returns NOT_FOUND if the book does not exist.",
         "parameters": [
@@ -341,10 +344,7 @@
               }
             }
           }
-        },
-        "tags": [
-          "LibraryService"
-        ]
+        }
       }
     }
   },

--- a/packages/samples/test/output/tags/openapi.json
+++ b/packages/samples/test/output/tags/openapi.json
@@ -33,6 +33,10 @@
   "paths": {
     "/foo/{id}": {
       "get": {
+        "tags": [
+          "foo",
+          "tag1"
+        ],
         "operationId": "Foo_read",
         "description": "includes namespace tag",
         "parameters": [
@@ -50,13 +54,14 @@
           "204": {
             "description": "No Content"
           }
-        },
-        "tags": [
-          "foo",
-          "tag1"
-        ]
+        }
       },
       "post": {
+        "tags": [
+          "foo",
+          "tag1",
+          "tag2"
+        ],
         "operationId": "Foo_create",
         "description": "includes namespace tag and two operations tags",
         "parameters": [
@@ -74,12 +79,7 @@
           "204": {
             "description": "No Content"
           }
-        },
-        "tags": [
-          "foo",
-          "tag1",
-          "tag2"
-        ]
+        }
       }
     },
     "/bar": {
@@ -107,6 +107,9 @@
     },
     "/bar/{id}": {
       "post": {
+        "tags": [
+          "tag3"
+        ],
         "operationId": "Bar_create",
         "description": "one operation tag",
         "parameters": [
@@ -124,14 +127,17 @@
           "204": {
             "description": "No Content"
           }
-        },
-        "tags": [
-          "tag3"
-        ]
+        }
       }
     },
     "/nested/{id}": {
       "post": {
+        "tags": [
+          "outer",
+          "inner",
+          "moreInner",
+          "innerOp"
+        ],
         "operationId": "NestedMoreInner_createOther",
         "parameters": [
           {
@@ -148,13 +154,7 @@
           "204": {
             "description": "No Content"
           }
-        },
-        "tags": [
-          "outer",
-          "inner",
-          "moreInner",
-          "innerOp"
-        ]
+        }
       }
     }
   },

--- a/packages/samples/test/output/testserver/body-string/openapi.json
+++ b/packages/samples/test/output/testserver/body-string/openapi.json
@@ -12,6 +12,9 @@
   "paths": {
     "/string/null": {
       "get": {
+        "tags": [
+          "String Operations"
+        ],
         "operationId": "String_getNull",
         "description": "Get null string value",
         "parameters": [],
@@ -38,12 +41,12 @@
               }
             }
           }
-        },
-        "tags": [
-          "String Operations"
-        ]
+        }
       },
       "put": {
+        "tags": [
+          "String Operations"
+        ],
         "operationId": "String_putNull",
         "description": "Put null string value",
         "parameters": [],
@@ -62,9 +65,6 @@
             }
           }
         },
-        "tags": [
-          "String Operations"
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -80,6 +80,9 @@
     },
     "/string/empty": {
       "get": {
+        "tags": [
+          "String Operations"
+        ],
         "operationId": "String_getEmpty",
         "description": "Get empty string value",
         "parameters": [],
@@ -107,12 +110,12 @@
               }
             }
           }
-        },
-        "tags": [
-          "String Operations"
-        ]
+        }
       },
       "put": {
+        "tags": [
+          "String Operations"
+        ],
         "operationId": "String_putEmpty",
         "description": "Put empty string value",
         "parameters": [],
@@ -131,9 +134,6 @@
             }
           }
         },
-        "tags": [
-          "String Operations"
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -150,6 +150,9 @@
     },
     "/string/mbcs": {
       "get": {
+        "tags": [
+          "String Operations"
+        ],
         "operationId": "String_getMbcs",
         "description": "Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'",
         "parameters": [],
@@ -177,12 +180,12 @@
               }
             }
           }
-        },
-        "tags": [
-          "String Operations"
-        ]
+        }
       },
       "put": {
+        "tags": [
+          "String Operations"
+        ],
         "operationId": "String_putMbCs",
         "description": "Put mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'",
         "parameters": [],
@@ -201,9 +204,6 @@
             }
           }
         },
-        "tags": [
-          "String Operations"
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -220,6 +220,9 @@
     },
     "/string/whitespace": {
       "get": {
+        "tags": [
+          "String Operations"
+        ],
         "operationId": "String_getWhitespace",
         "description": "Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'",
         "parameters": [],
@@ -247,12 +250,12 @@
               }
             }
           }
-        },
-        "tags": [
-          "String Operations"
-        ]
+        }
       },
       "put": {
+        "tags": [
+          "String Operations"
+        ],
         "operationId": "String_putWhitespace",
         "description": "Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'",
         "parameters": [],
@@ -271,9 +274,6 @@
             }
           }
         },
-        "tags": [
-          "String Operations"
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -290,6 +290,9 @@
     },
     "/string/base64Encoding": {
       "get": {
+        "tags": [
+          "String Operations"
+        ],
         "operationId": "String_getBase64Encoding",
         "description": "Get value that is base64 encoded",
         "parameters": [],
@@ -315,12 +318,12 @@
               }
             }
           }
-        },
-        "tags": [
-          "String Operations"
-        ]
+        }
       },
       "put": {
+        "tags": [
+          "String Operations"
+        ],
         "operationId": "String_putBase64Encoding",
         "description": "Put value that is base64 encoded",
         "parameters": [],
@@ -339,9 +342,6 @@
             }
           }
         },
-        "tags": [
-          "String Operations"
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -356,6 +356,9 @@
     },
     "/string/enum/empty": {
       "get": {
+        "tags": [
+          "String Operations"
+        ],
         "operationId": "Enums_getNotExpandable",
         "description": "Get non expandable string enum value",
         "parameters": [],
@@ -380,12 +383,12 @@
               }
             }
           }
-        },
-        "tags": [
-          "String Operations"
-        ]
+        }
       },
       "put": {
+        "tags": [
+          "String Operations"
+        ],
         "operationId": "Enums_putNotExpandable",
         "description": "Put non expandable string enum value",
         "parameters": [],
@@ -404,9 +407,6 @@
             }
           }
         },
-        "tags": [
-          "String Operations"
-        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -420,6 +420,9 @@
     },
     "/string/enum/constant": {
       "get": {
+        "tags": [
+          "String Operations"
+        ],
         "operationId": "Enums_getConstant",
         "description": "Gets value 'green-color' from a constant",
         "parameters": [],
@@ -444,12 +447,12 @@
               }
             }
           }
-        },
-        "tags": [
-          "String Operations"
-        ]
+        }
       },
       "put": {
+        "tags": [
+          "String Operations"
+        ],
         "operationId": "Enums_putConstant",
         "description": "Sends value 'green-color' from a constant",
         "parameters": [],
@@ -468,9 +471,6 @@
             }
           }
         },
-        "tags": [
-          "String Operations"
-        ],
         "requestBody": {
           "content": {
             "application/json": {


### PR DESCRIPTION
This is the `@cadl-lang/openapi3` counterpart to Azure/cadl-azure#1357 which reorders the `tags` and `x-*` extensions metadata attached to operation nodes in OpenAPI output.  It places the `tags` node right at the beginning of the operation and any added extensions at the very end.  

The goal here is to have a more consistent output ordering with the `@azure-tools/cadl-autorest` emitter so that comparison of the output of both emitters is easier.