### PR TITLE
Provide a playground link for each PR

### DIFF
--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -26,6 +26,6 @@ jobs:
           azureSubscription: "Azure SDK Playground"
           destination: "AzureBlob"
           storage: "cadlplayground"
-          blobPrefix: /prs/$(System.PullRequest.PullRequestId)/
+          blobPrefix: prs/$(System.PullRequest.PullRequestId)/
           containerName: "$web"
         displayName: "Update playground"

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -26,6 +26,6 @@ jobs:
           azureSubscription: "Azure SDK Playground"
           destination: "AzureBlob"
           storage: "cadlplayground"
-          blobPrefix: prs/$(System.PullRequest.PullRequestId)/
+          blobPrefix: prs/$(System.PullRequest.PullRequestNumber)/
           containerName: "$web"
         displayName: "Update playground"

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -1,9 +1,10 @@
+title: Cadl Pull Request Try It
 trigger: none
 pr:
   - main
 
 jobs:
-  - job: publish-playground
+  - job: publish_playground
     displayName: Publish playground
     pool:
       vmImage: ubuntu-latest

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -1,3 +1,4 @@
+title:
 trigger: none
 pr:
   - main
@@ -6,7 +7,7 @@ jobs:
   - job: publish_playground
     displayName: Publish playground
     pool:
-      vmImage: ubuntu-latest
+      vmImage: windows-latest
 
     steps:
       - task: NodeTool@0

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -3,7 +3,8 @@ pr:
   - main
 
 jobs:
-  - job: Publish playground
+  - job: publish-playground
+    displayName: Publish playground
     pool:
       vmImage: ubuntu-latest
 

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -30,15 +30,7 @@ jobs:
       #     containerName: "$web"
       #   displayName: "Update playground"
 
-      - script: |
-          USER_ID="azure=pipelines"
-          COMMENTS_URL=https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/comments?per_page=100
-          echo "Getting comments using $COMMENTS_URL"
-          if curl -s "$LABEL_URL" | grep "\"login\": \"$USER_ID\""
-          then
-            echo "Azure pipelines already made a comment. Skipping"
-            echo "##vso[task.setvariable variable=SKIP_COMMENT;]true"
-          fi
+      - script: node eng/scripts/check-for-tryit-comment.js
         displayName: Check already commented
 
       - task: GitHubComment@0

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -1,4 +1,3 @@
-title:
 trigger: none
 pr:
   - main

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -9,26 +9,26 @@ jobs:
       vmImage: windows-latest
 
     steps:
-      # - task: NodeTool@0
-      #   inputs:
-      #     versionSpec: 16.x
-      #   displayName: Install Node.js
+      - task: NodeTool@0
+        inputs:
+          versionSpec: 16.x
+        displayName: Install Node.js
 
-      # - script: npx @microsoft/rush install
-      #   displayName: Install JavaScript Dependencies
+      - script: npx @microsoft/rush install
+        displayName: Install JavaScript Dependencies
 
-      # - script: npx @microsoft/rush rebuild --verbose
-      #   displayName: Build
+      - script: npx @microsoft/rush rebuild --verbose
+        displayName: Build
 
-      # - task: AzureFileCopy@4
-      #   inputs:
-      #     sourcePath: "packages/playground/dist/*"
-      #     azureSubscription: "Azure SDK Playground"
-      #     destination: "AzureBlob"
-      #     storage: "cadlplayground"
-      #     blobPrefix: prs/$(System.PullRequest.PullRequestNumber)/
-      #     containerName: "$web"
-      #   displayName: "Update playground"
+      - task: AzureFileCopy@4
+        inputs:
+          sourcePath: "packages/playground/dist/*"
+          azureSubscription: "Azure SDK Playground"
+          destination: "AzureBlob"
+          storage: "cadlplayground"
+          blobPrefix: prs/$(System.PullRequest.PullRequestNumber)/
+          containerName: "$web"
+        displayName: "Update playground"
 
       - script: node eng/scripts/check-for-tryit-comment.js
         displayName: Check already commented

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -1,4 +1,3 @@
-title: Cadl Pull Request Try It
 trigger: none
 pr:
   - main

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -37,5 +37,5 @@ jobs:
         inputs:
           gitHubConnection: "Azure"
           repositoryName: "$(Build.Repository.Name)"
-          comment: You can try those changes at https://cadlplayground.z22.web.core.windows.net/prs/$(System.PullRequest.PullRequestNumber)/
+          comment: "You can try those changes at https://cadlplayground.z22.web.core.windows.net/prs/$(System.PullRequest.PullRequestNumber)/"
         condition: and(succeeded(), ne(variables['SKIP_COMMENT'], 'true'))

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - task: GitHubComment@0
         inputs:
-          gitHubConnection: "Azure"
+          gitHubConnection: "internal (1)"
           repositoryName: "$(Build.Repository.Name)"
           comment: "You can try those changes at https://cadlplayground.z22.web.core.windows.net/prs/$(System.PullRequest.PullRequestNumber)/"
         condition: and(succeeded(), ne(variables['SKIP_COMMENT'], 'true'))

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -29,3 +29,20 @@ jobs:
           blobPrefix: prs/$(System.PullRequest.PullRequestNumber)/
           containerName: "$web"
         displayName: "Update playground"
+
+      - script: |
+          USER_ID="azure=pipelines"
+          COMMENTS_URL=https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/comments?per_page=100
+          echo "Getting comments using $COMMENTS_URL"
+          if curl -s "$LABEL_URL" | grep "\"login\": \"$USER_ID\""
+          then
+            echo "Azure pipelines already made a comment. Skipping"
+            echo "##vso[task.setvariable variable=SKIP_COMMENT;]true"
+          fi
+
+      - task: GitHubComment@0
+        inputs:
+          gitHubConnection: "Azure"
+          repositoryName: "$(Build.Repository.Name)"
+          comment: You can try those changes at https://cadlplayground.z22.web.core.windows.net/prs/$(System.PullRequest.PullRequestNumber)/
+        condition: and(succeeded(), $(SKIP_COMMENT))

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -9,26 +9,26 @@ jobs:
       vmImage: windows-latest
 
     steps:
-      - task: NodeTool@0
-        inputs:
-          versionSpec: 16.x
-        displayName: Install Node.js
+      # - task: NodeTool@0
+      #   inputs:
+      #     versionSpec: 16.x
+      #   displayName: Install Node.js
 
-      - script: npx @microsoft/rush install
-        displayName: Install JavaScript Dependencies
+      # - script: npx @microsoft/rush install
+      #   displayName: Install JavaScript Dependencies
 
-      - script: npx @microsoft/rush rebuild --verbose
-        displayName: Build
+      # - script: npx @microsoft/rush rebuild --verbose
+      #   displayName: Build
 
-      - task: AzureFileCopy@4
-        inputs:
-          sourcePath: "packages/playground/dist/*"
-          azureSubscription: "Azure SDK Playground"
-          destination: "AzureBlob"
-          storage: "cadlplayground"
-          blobPrefix: prs/$(System.PullRequest.PullRequestNumber)/
-          containerName: "$web"
-        displayName: "Update playground"
+      # - task: AzureFileCopy@4
+      #   inputs:
+      #     sourcePath: "packages/playground/dist/*"
+      #     azureSubscription: "Azure SDK Playground"
+      #     destination: "AzureBlob"
+      #     storage: "cadlplayground"
+      #     blobPrefix: prs/$(System.PullRequest.PullRequestNumber)/
+      #     containerName: "$web"
+      #   displayName: "Update playground"
 
       - script: |
           USER_ID="azure=pipelines"
@@ -39,10 +39,11 @@ jobs:
             echo "Azure pipelines already made a comment. Skipping"
             echo "##vso[task.setvariable variable=SKIP_COMMENT;]true"
           fi
+        displayName: Check already commented
 
       - task: GitHubComment@0
         inputs:
           gitHubConnection: "Azure"
           repositoryName: "$(Build.Repository.Name)"
           comment: You can try those changes at https://cadlplayground.z22.web.core.windows.net/prs/$(System.PullRequest.PullRequestNumber)/
-        condition: and(succeeded(), $(SKIP_COMMENT))
+        condition: and(succeeded(), ne(variables['SKIP_COMMENT'], 'true'))

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -37,5 +37,5 @@ jobs:
         inputs:
           gitHubConnection: "internal (1)"
           repositoryName: "$(Build.Repository.Name)"
-          comment: "You can try those changes at https://cadlplayground.z22.web.core.windows.net/prs/$(System.PullRequest.PullRequestNumber)/"
+          comment: "You can try these changes at https://cadlplayground.z22.web.core.windows.net/prs/$(System.PullRequest.PullRequestNumber)/"
         condition: and(succeeded(), ne(variables['SKIP_COMMENT'], 'true'))

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -1,0 +1,30 @@
+trigger: none
+pr:
+  - main
+
+jobs:
+  - job: Publish playground
+    pool:
+      vmImage: ubuntu-latest
+
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: 16.x
+        displayName: Install Node.js
+
+      - script: npx @microsoft/rush install
+        displayName: Install JavaScript Dependencies
+
+      - script: npx @microsoft/rush rebuild --verbose
+        displayName: Build
+
+      - task: AzureFileCopy@4
+        inputs:
+          sourcePath: "packages/playground/dist/*"
+          azureSubscription: "Azure SDK Playground"
+          destination: "AzureBlob"
+          storage: "cadlplayground"
+          blobPrefix: /prs/$(System.PullRequest.PullRequestId)/
+          containerName: "$web"
+        displayName: "Update playground"

--- a/eng/scripts/check-for-tryit-comment.js
+++ b/eng/scripts/check-for-tryit-comment.js
@@ -1,0 +1,63 @@
+// @ts-check
+import https from "https";
+
+main().catch((e) => {
+  console.error(e);
+  // @ts-ignore
+  process.exit(1);
+});
+
+async function main() {
+  const repo = process.env["BUILD_REPOSITORY_ID"];
+  const prNumber = process.env["SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"];
+
+  console.log("Looking for comments in", { repo, prNumber });
+  const url = `https://api.github.com/repos/${repo}/issues/${prNumber}/comments?per_page=100`;
+  const result = await request("GET", url);
+  const data = JSON.parse(result);
+  const azoComments = data.filter((x) => x.user?.login === "azure-pipelines");
+  if (azoComments.length > 1) {
+    console.log("##vso[task.setvariable variable=SKIP_COMMENT;]true");
+  }
+}
+
+async function request(method, url, postData) {
+  const lib = https;
+  const value = new URL(url);
+
+  console.log("URL", value);
+  const params = {
+    method,
+    host: value.host,
+    port: 443,
+    path: value.pathname,
+    headers: {
+      "User-Agent": "nodejs",
+    },
+  };
+  console.log("P", params);
+
+  return new Promise((resolve, reject) => {
+    const req = lib.request(params, (res) => {
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        return reject(new Error(`Status Code: ${res.statusCode}`));
+      }
+
+      const data = [];
+
+      res.on("data", (chunk) => {
+        data.push(chunk);
+      });
+
+      res.on("end", () => resolve(Buffer.concat(data).toString()));
+    });
+
+    req.on("error", reject);
+
+    if (postData) {
+      req.write(postData);
+    }
+
+    req.end();
+  });
+}

--- a/eng/scripts/check-for-tryit-comment.js
+++ b/eng/scripts/check-for-tryit-comment.js
@@ -1,6 +1,7 @@
 // @ts-check
 import https from "https";
 
+const AZP_USERID = "azure-pipelines[bot]";
 main().catch((e) => {
   console.error(e);
   // @ts-ignore
@@ -15,7 +16,7 @@ async function main() {
   const url = `https://api.github.com/repos/${repo}/issues/${prNumber}/comments?per_page=100`;
   const result = await request("GET", url);
   const data = JSON.parse(result);
-  const azoComments = data.filter((x) => x.user?.login === "azure-pipelines");
+  const azoComments = data.filter((x) => x.user?.login === AZP_USERID);
   if (azoComments.length > 1) {
     console.log("##vso[task.setvariable variable=SKIP_COMMENT;]true");
   }


### PR DESCRIPTION
fix #451 

Made a new pipeline in private repo that run on pull request and has permission to publish to the storage account. Trigger is only enabled for contributor or with `/azp run` command for other forks.

Playground link for this PR https://cadlplayground.z22.web.core.windows.net/prs/452/

Added automatic comment and a basic way to check if it was already commented on before 