### PR TITLE
Fix issue with detecting existing comment for tryit url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,3 +221,14 @@ the command line following the steps above, or build its Release
 configuration in Visual Studio, then you can install it by
 double-clicking on packages/cadl-vs/Microsoft.Cadl.VisualStudio.vsix
 that gets produced.
+
+# Pull request
+
+## Trigger Cadl Playground Try It build
+
+For contributors of the repo the build will trigger automatically but for other's forks it will need a manual trigger from a contributor.
+As a contributor you can run the following command to trigger the build and create a cadl playground link for this PR.
+
+```
+/azp run Cadl Pull Request Try It
+```

--- a/eng/pipelines/pr-tryit.yaml
+++ b/eng/pipelines/pr-tryit.yaml
@@ -37,5 +37,5 @@ jobs:
         inputs:
           gitHubConnection: "internal (1)"
           repositoryName: "$(Build.Repository.Name)"
-          comment: "You can try these changes at https://cadlplayground.z22.web.core.windows.net/prs/$(System.PullRequest.PullRequestNumber)/"
+          comment: "<!-- _CADL_TRYIT_COMMENT_ -->\nYou can try these changes at https://cadlplayground.z22.web.core.windows.net/prs/$(System.PullRequest.PullRequestNumber)/"
         condition: and(succeeded(), ne(variables['SKIP_COMMENT'], 'true'))

--- a/eng/scripts/check-for-tryit-comment.js
+++ b/eng/scripts/check-for-tryit-comment.js
@@ -17,8 +17,11 @@ async function main() {
   const result = await request("GET", url);
   const data = JSON.parse(result);
   const azoComments = data.filter((x) => x.user?.login === AZP_USERID);
-  console.log(`Found ${azoComments.length} comments from Azure Pipelines.`);
-  if (azoComments.length > 0) {
+  console.log(`Found ${azoComments.length} comment(s) from Azure Pipelines.`);
+
+  const tryItComments = data.filter((x) => x.body.includes("_CADL_TRYIT_COMMENT_"));
+  console.log(`Found ${azoComments.length} Cadl Try It comment(s)`);
+  if (tryItComments.length > 0) {
     console.log("##vso[task.setvariable variable=SKIP_COMMENT;]true");
   }
 }
@@ -37,7 +40,7 @@ async function request(method, url, postData) {
       "User-Agent": "nodejs",
     },
   };
-  console.log("P", params);
+  console.log("Params", params);
 
   return new Promise((resolve, reject) => {
     const req = lib.request(params, (res) => {


### PR DESCRIPTION
Don't just check from comment from Azure Pipelines as there can be others but check for hidden metadata in the tryit comment.