### PR TITLE
Formatter: remove quotes of property names when not needed

### DIFF
--- a/common/changes/@cadl-lang/compiler/feature-formatter-unquote-uneeded_2022-04-19-18-21.json
+++ b/common/changes/@cadl-lang/compiler/feature-formatter-unquote-uneeded_2022-04-19-18-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Formatter: remove quotes in model properties when not needed",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -776,11 +776,7 @@ export function printModelProperty(
     }
   );
   let id: Doc;
-  if (
-    node.id.kind === SyntaxKind.StringLiteral &&
-    options.quoteProps === "as-needed" &&
-    isStringSafeToUnquote(node.id, options)
-  ) {
+  if (node.id.kind === SyntaxKind.StringLiteral && isStringSafeToUnquote(node.id, options)) {
     id = node.id.value;
   } else {
     id = path.call(print, "id");

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -1,4 +1,5 @@
 import prettier, { AstPath, Doc, Printer } from "prettier";
+import { createScanner, Token } from "../../core/scanner.js";
 import {
   AliasStatementNode,
   ArrayExpressionNode,
@@ -774,14 +775,42 @@ export function printModelProperty(
       tryInline: true,
     }
   );
+  let id: Doc;
+  if (
+    node.id.kind === SyntaxKind.StringLiteral &&
+    options.quoteProps === "as-needed" &&
+    isStringSafeToUnquote(node.id, options)
+  ) {
+    id = node.id.value;
+  } else {
+    id = path.call(print, "id");
+  }
   return [
     multiline && isNotFirst ? hardline : "",
     decorators,
-    path.call(print, "id"),
+    id,
     node.optional ? "?: " : ": ",
     path.call(print, "value"),
     node.default ? [" = ", path.call(print, "default")] : "",
   ];
+}
+
+function isStringSafeToUnquote(id: StringLiteralNode, options: CadlPrettierOptions): boolean {
+  const unquotedRawText = getRawText(id, options).slice(1, -1);
+  if (id.value !== unquotedRawText) {
+    return false;
+  }
+  let hasError = false;
+  const scanner = createScanner(id.value, (d) => (hasError = true));
+  if (scanner.scan() !== Token.Identifier) {
+    return false;
+  }
+
+  if (scanner.scan() !== Token.EndOfFile) {
+    return false;
+  }
+
+  return !hasError;
 }
 
 function isModelExpressionInBlock(path: AstPath<ModelExpressionNode>) {

--- a/packages/compiler/test/formatter/formatter.ts
+++ b/packages/compiler/test/formatter/formatter.ts
@@ -233,6 +233,23 @@ model Foo {
 `,
       });
     });
+
+    it("remove unncessary quotes", () => {
+      assertFormat({
+        code: `
+model Foo {
+  "abc": string;
+  "this-needs-quotes": int32;
+}
+`,
+        expected: `
+model Foo {
+  abc: string;
+  "this-needs-quotes": int32;
+}
+`,
+      });
+    });
   });
 
   describe("comments", () => {

--- a/packages/samples/versioning/main.cadl
+++ b/packages/samples/versioning/main.cadl
@@ -7,8 +7,8 @@ import "./library.cadl";
 @versionedDependency(
   Library,
   {
-    "v1": "1.0",
-    "v2": "1.1",
+    v1: "1.0",
+    v2: "1.1",
   }
 )
 namespace VersionedApi;


### PR DESCRIPTION
fix #156

Not supporting prettier `quote` option that also provide `preserve` and `consitent` options as I feel like unless we get real demand and need for it there is no need to provide choice in the formatter and we can stay opinionated.