### PR TITLE
Move Page<T> to Cadl.Rest, add `pagedByProperty` decorator

### DIFF
--- a/packages/rest/lib/paging.cadl
+++ b/packages/rest/lib/paging.cadl
@@ -1,0 +1,13 @@
+import "../dist/src/paging.js";
+
+namespace Cadl.Rest;
+
+@doc("Paged collection of {name} items", T)
+@pagedByProperty("nextLink")
+model Page<T> {
+  @doc("The items on this page")
+  value: T[];
+
+  @doc("The link to the next page of items")
+  nextLink?: string;
+}

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -1,4 +1,5 @@
 import "./http.cadl";
+import "./paging.cadl";
 import "../dist/src/resource.js";
 import "../dist/src/internal-decorators.js";
 
@@ -94,15 +95,6 @@ interface ResourceDelete<TResource, TError> {
   @doc("Deletes an existing instance of the resource.")
   @deletesResource(TResource)
   delete(...ResourceParameters<TResource>): ResourceDeletedResponse | TError;
-}
-
-@doc("Paged response")
-model Page<T> {
-  @doc("The items on this page")
-  value: T[];
-
-  @doc("The link to the next page of items")
-  nextLink?: string;
 }
 
 interface ResourceList<TResource, TError> {

--- a/packages/rest/lib/rest.cadl
+++ b/packages/rest/lib/rest.cadl
@@ -1,5 +1,7 @@
 import "../dist/src/rest.js";
 import "../dist/src/route.js";
+import "../dist/src/paging.js";
 
 import "./http.cadl";
 import "./resource.cadl";
+import "./paging.cadl";

--- a/packages/rest/src/lib.ts
+++ b/packages/rest/src/lib.ts
@@ -7,3 +7,5 @@ export * from "./rest.js";
 export * as rest from "./rest.js";
 export * from "./route.js";
 export * as route from "./route.js";
+export * from "./paging.js";
+export * as paging from "./paging.js";

--- a/packages/rest/src/paging.ts
+++ b/packages/rest/src/paging.ts
@@ -1,0 +1,38 @@
+import { DecoratorContext, Program, Type, validateDecoratorParamType, validateDecoratorTarget } from "@cadl-lang/compiler";
+
+const pagedByPropertyKey = Symbol("pageable");
+
+export function $pagedByProperty(
+  { program }: DecoratorContext,
+  entity: Type,
+  propertyName: string = "nextLink"
+): void {
+  if (
+    !validateDecoratorTarget(program, entity, "@pagedByProperty", "Model") ||
+    !validateDecoratorParamType(program, entity, propertyName, "String")
+  ) {
+    return;
+  }
+
+  program.stateMap(pagedByPropertyKey).set(entity, propertyName);
+}
+
+export function getPagedByProperty(program: Program, entity: Type): string | undefined {
+  // This decorator only works on model types
+  if (entity.kind !== "Model") return undefined;
+
+  // First look at the type itself and any types in its 'extends' chain
+  let pagePropertyName = program.stateMap(pagedByPropertyKey).get(entity);
+  let parentType = entity.baseModel;
+  while (!pagePropertyName && parentType) {
+    pagePropertyName = program.stateMap(pagedByPropertyKey).get(parentType);
+    parentType = parentType.baseModel;
+  }
+
+  // If we didn't find it in the inheritance chain, check the first template argument
+  if (pagePropertyName === undefined && entity.templateArguments && entity.templateArguments.length > 0) {
+    pagePropertyName = getPagedByProperty(program, entity.templateArguments[0]);
+  }
+
+  return pagePropertyName;
+}

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -176,11 +176,11 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Paged response",
+            "description": "Paged collection of Pet items",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Cadl.Rest.Resource.Page_Pet"
+                  "$ref": "#/components/schemas/Cadl.Rest.Page_Pet"
                 }
               }
             }
@@ -264,11 +264,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Paged response",
+            "description": "Paged collection of Checkup items",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Cadl.Rest.Resource.Page_Checkup"
+                  "$ref": "#/components/schemas/Cadl.Rest.Page_Checkup"
                 }
               }
             }
@@ -428,11 +428,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Paged response",
+            "description": "Paged collection of Toy items",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Cadl.Rest.Resource.Page_Toy"
+                  "$ref": "#/components/schemas/Cadl.Rest.Page_Toy"
                 }
               }
             }
@@ -603,11 +603,11 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Paged response",
+            "description": "Paged collection of Checkup items",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Cadl.Rest.Resource.Page_Checkup"
+                  "$ref": "#/components/schemas/Cadl.Rest.Page_Checkup"
                 }
               }
             }
@@ -786,11 +786,11 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Paged response",
+            "description": "Paged collection of Owner items",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Cadl.Rest.Resource.Page_Owner"
+                  "$ref": "#/components/schemas/Cadl.Rest.Page_Owner"
                 }
               }
             }
@@ -874,11 +874,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Paged response",
+            "description": "Paged collection of Checkup items",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Cadl.Rest.Resource.Page_Checkup"
+                  "$ref": "#/components/schemas/Cadl.Rest.Page_Checkup"
                 }
               }
             }
@@ -1072,7 +1072,7 @@
           "message"
         ]
       },
-      "Cadl.Rest.Resource.Page_Pet": {
+      "Cadl.Rest.Page_Pet": {
         "type": "object",
         "properties": {
           "value": {
@@ -1088,7 +1088,7 @@
             "description": "The link to the next page of items"
           }
         },
-        "description": "Paged response",
+        "description": "Paged collection of Pet items",
         "required": [
           "value"
         ]
@@ -1113,7 +1113,7 @@
           "notes"
         ]
       },
-      "Cadl.Rest.Resource.Page_Checkup": {
+      "Cadl.Rest.Page_Checkup": {
         "type": "object",
         "properties": {
           "value": {
@@ -1129,7 +1129,7 @@
             "description": "The link to the next page of items"
           }
         },
-        "description": "Paged response",
+        "description": "Paged collection of Checkup items",
         "required": [
           "value"
         ]
@@ -1176,7 +1176,7 @@
           "name"
         ]
       },
-      "Cadl.Rest.Resource.Page_Toy": {
+      "Cadl.Rest.Page_Toy": {
         "type": "object",
         "properties": {
           "value": {
@@ -1192,7 +1192,7 @@
             "description": "The link to the next page of items"
           }
         },
-        "description": "Paged response",
+        "description": "Paged collection of Toy items",
         "required": [
           "value"
         ]
@@ -1218,7 +1218,7 @@
           "age"
         ]
       },
-      "Cadl.Rest.Resource.Page_Owner": {
+      "Cadl.Rest.Page_Owner": {
         "type": "object",
         "properties": {
           "value": {
@@ -1234,7 +1234,7 @@
             "description": "The link to the next page of items"
           }
         },
-        "description": "Paged response",
+        "description": "Paged collection of Owner items",
         "required": [
           "value"
         ]


### PR DESCRIPTION
This PR exposes the `Page<T>` type from `Cadl.Rest` instead of `Cadl.Rest.Resource` so that it can be used at multiple levels of our library structure (`Cadl.Rest`, `Azure.Core`, and `Azure.ResourceManager`).

It also replaces the old `pageable` decorator with a `pagedByProperty` decorator which marks a model type to denote that one of its properties contains a link to the next page of results.  I made the decorator more specific since there are many ways paging can be implemented (property with link, property with page token, query param with page token, reference to another operation, etc), so instead of designing a complete solution for that now we can just focus on one implementation.

The idea here is that any of our libraries can use `Page<T>` which is marked with `pagedByProperty("nextLink")` and an emitter that understands how to use this paging information can emit code or OpenAPI specs with it (`cadl-autorest` support is added in PR Azure/cadl-azure#1401).

The end result of this change is that we can now add `x-ms-pageable` metadata in Swagger spec output for any kind of REST-style spec authored in Cadl.

/cc @johanste