### PR TITLE
Add PR number and update style if playground is buillt in PR

### DIFF
--- a/common/changes/@cadl-lang/compiler/playground-pr-links_2022-04-21-20-37.json
+++ b/common/changes/@cadl-lang/compiler/playground-pr-links_2022-04-21-20-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/manifest.ts
+++ b/packages/compiler/core/manifest.ts
@@ -4,7 +4,21 @@ import manifest from "../manifest.js";
 
 export const cadlVersion = manifest.version;
 
-export const MANIFEST = {
-  version: manifest.version,
-  commit: manifest.commit,
-};
+export interface CadlManifest {
+  /**
+   * Version of the cadl compiler.
+   */
+  version: string;
+
+  /**
+   * Full commit sha.
+   */
+  commit: string;
+
+  /**
+   * Number of the pull request, if the build was from a pull request.
+   */
+  pr?: number;
+}
+
+export const MANIFEST: CadlManifest = manifest;

--- a/packages/compiler/scripts/generate-manifest.js
+++ b/packages/compiler/scripts/generate-manifest.js
@@ -17,12 +17,18 @@ function getCommit() {
   return execSync("git rev-parse HEAD").toString().trim();
 }
 
+function getPrNumber() {
+  // Set by Azure DevOps.
+  return process.env["SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"];
+}
+
 function main() {
   const pkg = loadPackageJson();
 
   const manifest = {
     version: pkg.version,
     commit: getCommit(),
+    pr: getPrNumber(),
   };
 
   if (!existsSync(distDir)) {

--- a/packages/playground/src/components/footer.tsx
+++ b/packages/playground/src/components/footer.tsx
@@ -1,17 +1,39 @@
 import { MANIFEST } from "@cadl-lang/compiler";
-import { FunctionComponent } from "react";
+import { FunctionComponent, PropsWithChildren } from "react";
 
 export const Footer: FunctionComponent = () => {
+  const prItem = MANIFEST.pr ? (
+    <FooterItem link={`https://github.com/microsoft/cadl/pull/${MANIFEST.pr}`}>
+      <span>PR </span>
+      <span>{MANIFEST.pr}</span>
+    </FooterItem>
+  ) : (
+    <></>
+  );
   return (
-    <div className="footer">
-      <div className="item">
+    <div className={`footer ${MANIFEST.pr ? "in-pr" : ""}`}>
+      {prItem}
+      <FooterItem>
         <span>Cadl Version </span>
         <span>{MANIFEST.version}</span>
-      </div>
-      <div className="item">
+      </FooterItem>
+      <FooterItem link={`https://github.com/microsoft/cadl/commit/${MANIFEST.commit}`}>
         <span>Commit </span>
         <span>{MANIFEST.commit.slice(0, 6)}</span>
-      </div>
+      </FooterItem>
     </div>
+  );
+};
+
+interface FooterItemProps {
+  link?: string;
+}
+const FooterItem: FunctionComponent<PropsWithChildren<FooterItemProps>> = ({ children, link }) => {
+  return link ? (
+    <a className="item" href={link} target="_blank">
+      {children}
+    </a>
+  ) : (
+    <div className="item">{children}</div>
   );
 };

--- a/packages/playground/src/style.css
+++ b/packages/playground/src/style.css
@@ -27,7 +27,7 @@ body {
   font-size: 14px;
 }
 #grid > .footer.in-pr {
-  background-color: #cc9600;
+  background-color: #CE662A;
 }
 
 #grid > .footer > .item {
@@ -40,7 +40,7 @@ body {
   background-color: #063a5c;
 }
 #grid > .footer.in-pr > a.item:hover {
-  background-color: #7c5e0b;
+  background-color: #b46e45;
 }
 
 #commandBar {

--- a/packages/playground/src/style.css
+++ b/packages/playground/src/style.css
@@ -22,15 +22,25 @@ body {
   grid-column-start: 1;
   grid-column-end: 3;
   grid-row: 3;
-  background: #007acc;
-  color: #fefefe;
+  background-color: #007acc;
   display: flex;
-  font-size: 12px;
+  font-size: 14px;
+}
+#grid > .footer.in-pr {
+  background-color: #cc9600;
 }
 
 #grid > .footer > .item {
+  text-decoration: none;
+  color: #fefefe;
   border-right: 1px solid #d5d5d5;
   padding: 0 5px;
+}
+#grid > .footer > a.item:hover {
+  background-color: #063a5c;
+}
+#grid > .footer.in-pr > a.item:hover {
+  background-color: #7c5e0b;
 }
 
 #commandBar {


### PR DESCRIPTION
ADd the pr number to the compiler manifest when built in a pr. 

Update the style when in the PR mode
![image](https://user-images.githubusercontent.com/1031227/164548889-a60b05c1-c9b5-4aaa-946f-851bb7a8156a.png)

Provide navigation links to the commit and PR from the footer

![image](https://user-images.githubusercontent.com/1031227/164548998-fc84a4c0-748f-4e48-82aa-f11310184a69.png)
(Image above is when hovering the item)