### PR TITLE
Fix compiler dogfood on windows

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-compiler-dogfood-win_2022-04-26-22-23.json
+++ b/common/changes/@cadl-lang/compiler/fix-compiler-dogfood-win_2022-04-26-22-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/internal-build-utils/fix-compiler-dogfood-win_2022-04-26-22-23.json
+++ b/common/changes/@cadl-lang/internal-build-utils/fix-compiler-dogfood-win_2022-04-26-22-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/internal-build-utils",
+      "comment": "Add `xplatCmd` helper method ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/internal-build-utils"
+}

--- a/packages/compiler/scripts/dogfood.js
+++ b/packages/compiler/scripts/dogfood.js
@@ -1,7 +1,13 @@
 // @ts-check
-import { run } from "@cadl-lang/internal-build-utils";
+import { run, xplatCmd } from "@cadl-lang/internal-build-utils";
 import { readFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
 
-const version = JSON.parse(readFileSync("package.json", "utf-8")).version;
-await run("npm", ["pack"]);
-await run("npm", ["install", "-g", `cadl-lang-compiler-${version}.tgz`]);
+const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const version = JSON.parse(readFileSync(resolve(pkgRoot, "package.json"), "utf-8")).version;
+
+console.log("Packing...");
+await run(xplatCmd("npm"), ["pack"]);
+console.log("Installing...");
+await run(xplatCmd("npm"), ["install", "-g", `cadl-lang-compiler-${version}.tgz`]);

--- a/packages/internal-build-utils/src/common.ts
+++ b/packages/internal-build-utils/src/common.ts
@@ -6,6 +6,15 @@ export class CommandFailedError extends Error {
   }
 }
 
+/**
+ * Return the correct executable name if on unix or windows(with .cmd extension)
+ * @param cmd to run
+ * @returns
+ */
+export function xplatCmd(cmd: string) {
+  return process.platform === "win32" ? `${cmd}.cmd` : cmd;
+}
+
 export interface RunOptions extends SpawnOptions {
   silent?: boolean;
   encoding?: string;


### PR DESCRIPTION
One more issue with the recent changes. Dogfood command was broken on windows due to the executable name not including `.cmd` extension