### PR TITLE
Refactor: rename `mixes` to `extends` for interfaces 

### DIFF
--- a/common/changes/@cadl-lang/compiler/feature-mixes-extends_2022-04-27-21-11.json
+++ b/common/changes/@cadl-lang/compiler/feature-mixes-extends_2022-04-27-21-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Rename `mixes` to `extends` for interfaces",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/rest/feature-mixes-extends_2022-04-27-21-11.json
+++ b/common/changes/@cadl-lang/rest/feature-mixes-extends_2022-04-27-21-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Uptake `mixes` -> `extends` rename",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/versioning/feature-mixes-extends_2022-04-27-21-11.json
+++ b/common/changes/@cadl-lang/versioning/feature-mixes-extends_2022-04-27-21-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "Uptake `mixes` -> `extends` rename",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/common/changes/cadl-vscode/feature-mixes-extends_2022-04-27-21-11.json
+++ b/common/changes/cadl-vscode/feature-mixes-extends_2022-04-27-21-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vscode",
+      "comment": "Uptake `mixes` -> `extends` rename",
+      "type": "minor"
+    }
+  ],
+  "packageName": "cadl-vscode"
+}

--- a/docs/spec.html
+++ b/docs/spec.html
@@ -2809,7 +2809,7 @@ li.menu-search-result-term:before {
 </emu-production>
 <emu-production name="InterfaceHeritage" id="prod-InterfaceHeritage">
     <emu-nt><a href="#prod-InterfaceHeritage">InterfaceHeritage</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="fy0l4eik">
-        <emu-t>mixes</emu-t>
+        <emu-t>extends</emu-t>
         <emu-nt id="_ref_111"><a href="#prod-ReferenceExpressionList">ReferenceExpressionList</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="s2k4ex-k"><emu-nt>InterfaceBody</emu-nt></emu-rhs>

--- a/docs/spec.html
+++ b/docs/spec.html
@@ -2808,7 +2808,7 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="InterfaceHeritage" id="prod-InterfaceHeritage">
-    <emu-nt><a href="#prod-InterfaceHeritage">InterfaceHeritage</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="fy0l4eik">
+    <emu-nt><a href="#prod-InterfaceHeritage">InterfaceHeritage</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ie0hgn59">
         <emu-t>extends</emu-t>
         <emu-nt id="_ref_111"><a href="#prod-ReferenceExpressionList">ReferenceExpressionList</a></emu-nt>
     </emu-rhs>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -386,10 +386,10 @@ interface B {
 
 ```
 
-And the keyword `mixes` can be used to compose operations from other interfaces into a new interface:
+And the keyword `extends` can be used to compose operations from other interfaces into a new interface:
 
 ```cadl
-interface C mixes A, B {
+interface C extends A, B {
   c(): string;
 }
 

--- a/packages/cadl-vscode/src/tmlanguage.ts
+++ b/packages/cadl-vscode/src/tmlanguage.ts
@@ -447,7 +447,7 @@ const interfaceMember: BeginEndRule = {
 const interfaceHeritage: BeginEndRule = {
   key: "interface-heritage",
   scope: meta,
-  begin: "\\b(mixes)\\b",
+  begin: "\\b(extends)\\b",
   beginCaptures: {
     "1": { scope: "keyword.other.cadl" },
   },
@@ -479,7 +479,7 @@ const interfaceStatement: BeginEndRule = {
   end: `(?<=\\})|${universalEnd}`,
   patterns: [
     token,
-    interfaceHeritage, // before expression or mixes will look like type name
+    interfaceHeritage, // before expression or extends will look like type name
     interfaceBody, // before expression or { will match model expression
     expression, // enough to match name and type parameters
   ],

--- a/packages/cadl-vscode/test/interface.test.ts
+++ b/packages/cadl-vscode/test/interface.test.ts
@@ -12,24 +12,24 @@ describe("vscode: tmlanguage: interfaces", () => {
     ]);
   });
 
-  it("interface with single mixes", async () => {
-    const tokens = await tokenize("interface Foo mixes Bar {}");
+  it("interface with single extends", async () => {
+    const tokens = await tokenize("interface Foo extends Bar {}");
     deepStrictEqual(tokens, [
       Token.keywords.interface,
       Token.identifiers.type("Foo"),
-      Token.keywords.mixes,
+      Token.keywords.extends,
       Token.identifiers.type("Bar"),
       Token.punctuation.openBrace,
       Token.punctuation.closeBrace,
     ]);
   });
 
-  it("interface with multiple mixes", async () => {
-    const tokens = await tokenize("interface Foo mixes Bar1, Bar2 {}");
+  it("interface with multiple extends", async () => {
+    const tokens = await tokenize("interface Foo extends Bar1, Bar2 {}");
     deepStrictEqual(tokens, [
       Token.keywords.interface,
       Token.identifiers.type("Foo"),
-      Token.keywords.mixes,
+      Token.keywords.extends,
       Token.identifiers.type("Bar1"),
       Token.punctuation.comma,
       Token.identifiers.type("Bar2"),
@@ -51,15 +51,15 @@ describe("vscode: tmlanguage: interfaces", () => {
     ]);
   });
 
-  it("template interface with mixes", async () => {
-    const tokens = await tokenize("interface Foo<T> mixes Bar<T> {}");
+  it("template interface with extends", async () => {
+    const tokens = await tokenize("interface Foo<T> extends Bar<T> {}");
     deepStrictEqual(tokens, [
       Token.keywords.interface,
       Token.identifiers.type("Foo"),
       Token.punctuation.typeParameters.begin,
       Token.identifiers.type("T"),
       Token.punctuation.typeParameters.end,
-      Token.keywords.mixes,
+      Token.keywords.extends,
       Token.identifiers.type("Bar"),
       Token.punctuation.typeParameters.begin,
       Token.identifiers.type("T"),

--- a/packages/cadl-vscode/test/utils.ts
+++ b/packages/cadl-vscode/test/utils.ts
@@ -119,7 +119,6 @@ export const Token = {
     alias: createToken("alias", "keyword.other.cadl"),
     extends: createToken("extends", "keyword.other.cadl"),
     is: createToken("is", "keyword.other.cadl"),
-    mixes: createToken("mixes", "keyword.other.cadl"),
     other: (text: string) => createToken(text, "keyword.other.cadl"),
   },
   meta: (text: string, meta: string) => createToken(text, `meta.${meta}.cadl`),

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -2011,10 +2011,12 @@ export function createChecker(program: Program): Checker {
       name: node.id.sv,
     });
 
-    for (const mixinNode of node.mixes) {
+    for (const mixinNode of node.extends) {
       const mixinType = getTypeForNode(mixinNode);
       if (mixinType.kind !== "Interface") {
-        program.reportDiagnostic(createDiagnostic({ code: "mixes-interface", target: mixinNode }));
+        program.reportDiagnostic(
+          createDiagnostic({ code: "extends-interface", target: mixinNode })
+        );
         continue;
       }
 
@@ -2022,7 +2024,7 @@ export function createChecker(program: Program): Checker {
         if (interfaceType.operations.has(newMember.name)) {
           program.reportDiagnostic(
             createDiagnostic({
-              code: "mixes-interface-duplicate",
+              code: "extends-interface-duplicate",
               format: { name: newMember.name },
               target: mixinNode,
             })

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -135,7 +135,6 @@ const diagnostics = {
       statement: "Statement expected.",
       property: "Property expected.",
       enumMember: "Enum member expected.",
-      mixesNotExtends: "`extends` is unexpected. Did you mean `mixes`?",
     },
   },
   "trailing-token": {
@@ -312,16 +311,16 @@ const diagnostics = {
       default: paramMessage`Type '${"value"}' is not assignable to type '${"targetType"}'`,
     },
   },
-  "mixes-interface": {
+  "extends-interface": {
     severity: "error",
     messages: {
       default: "Interfaces can only mix other interfaces",
     },
   },
-  "mixes-interface-duplicate": {
+  "extends-interface-duplicate": {
     severity: "error",
     messages: {
-      default: paramMessage`Interface mixes cannot have duplicate members. The duplicate member is named ${"name"}`,
+      default: paramMessage`Interface extends cannot have duplicate members. The duplicate member is named ${"name"}`,
     },
   },
   "interface-duplicate": {

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -499,22 +499,13 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
     const id = parseIdentifier();
     const templateParameters = parseTemplateParameterList();
 
-    let mixes: TypeReferenceNode[] = [];
+    let extendList: TypeReferenceNode[] = [];
     if (token() === Token.ExtendsKeyword) {
-      // error condition
-      const target = { pos: tokenPos(), end: tokenEnd() };
       nextToken();
-      mixes = parseList(ListKind.Heritage, parseReferenceExpression);
-      // issue error *after* parseList so that we flag the interface as having an error, and not the first list element.
-      error({ code: "token-expected", messageId: "mixesNotExtends", target });
+      extendList = parseList(ListKind.Heritage, parseReferenceExpression);
     } else if (token() === Token.Identifier) {
-      if (tokenValue() !== "mixes") {
-        error({ code: "token-expected", format: { token: "'mixes' or '{'" } });
-        nextToken();
-      } else {
-        nextToken();
-        mixes = parseList(ListKind.Heritage, parseReferenceExpression);
-      }
+      error({ code: "token-expected", format: { token: "'extends' or '{'" } });
+      nextToken();
     }
 
     const operations = parseList(ListKind.InterfaceMembers, parseInterfaceMember);
@@ -524,7 +515,7 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
       id,
       templateParameters,
       operations,
-      mixes,
+      extends: extendList,
       decorators,
       ...finishNode(pos),
     };
@@ -2179,7 +2170,7 @@ export function visitChildren<T>(node: Node, cb: NodeCallback<T>): T | undefined
         visitEach(cb, node.decorators) ||
         visitNode(cb, node.id) ||
         visitEach(cb, node.templateParameters) ||
-        visitEach(cb, node.mixes) ||
+        visitEach(cb, node.extends) ||
         visitEach(cb, node.operations)
       );
     case SyntaxKind.UsingStatement:

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -686,7 +686,7 @@ export interface ModelStatementNode extends BaseNode, DeclarationNode, TemplateD
 export interface InterfaceStatementNode extends BaseNode, DeclarationNode, TemplateDeclarationNode {
   readonly kind: SyntaxKind.InterfaceStatement;
   readonly operations: readonly OperationStatementNode[];
-  readonly mixes: readonly TypeReferenceNode[];
+  readonly extends: readonly TypeReferenceNode[];
   readonly decorators: readonly DecoratorExpressionNode[];
 }
 

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -498,31 +498,31 @@ export function printInterfaceStatement(
   const id = path.call(print, "id");
   const { decorators } = printDecorators(path, options, print, { tryInline: false });
   const generic = printTemplateParameters(path, options, print, "templateParameters");
-  const mixes = printInterfaceMixes(path, options, print);
+  const extendList = printInterfaceExtends(path, options, print);
 
   return [
     decorators,
     "interface ",
     id,
     generic,
-    mixes,
+    extendList,
     " ",
     printInterfaceMembers(path, options, print),
   ];
 }
 
-function printInterfaceMixes(
+function printInterfaceExtends(
   path: AstPath<InterfaceStatementNode>,
   options: CadlPrettierOptions,
   print: PrettierChildPrint
 ): prettier.Doc {
   const node = path.getValue();
-  if (node.mixes.length === 0) {
+  if (node.extends.length === 0) {
     return "";
   }
 
-  const keyword = "mixes ";
-  return [group(indent([line, keyword, indent(join([",", line], path.map(print, "mixes")))]))];
+  const keyword = "extends ";
+  return [group(indent([line, keyword, indent(join([",", line], path.map(print, "extends")))]))];
 }
 
 export function printInterfaceMembers(

--- a/packages/compiler/test/checker/interface.ts
+++ b/packages/compiler/test/checker/interface.ts
@@ -86,7 +86,7 @@ describe("compiler: interfaces", () => {
       "main.cadl",
       `
       interface Bar<T> { bar(): T }
-      @test interface Foo<T> mixes Bar<T> {
+      @test interface Foo<T> extends Bar<T> {
         foo(): T;
       }
 
@@ -109,7 +109,7 @@ describe("compiler: interfaces", () => {
       `
       interface Bar<T> { bar(): T }
       interface Baz<T> { baz(): T }
-      @test interface Foo<T> mixes Bar<T>, Baz<T> {
+      @test interface Foo<T> extends Bar<T>, Baz<T> {
         foo(): T;
       }
 
@@ -127,7 +127,7 @@ describe("compiler: interfaces", () => {
     strictEqual((Foo.operations.get("bar")!.returnType as ModelType).name, "int32");
   });
 
-  it("doesn't copy interface decorators down when using mixes", async () => {
+  it("doesn't copy interface decorators down when using extends", async () => {
     const blues = new Set<Type>();
     testHost.addJsFile("test.js", {
       $blue(p: any, t: InterfaceType) {
@@ -140,7 +140,7 @@ describe("compiler: interfaces", () => {
       `
       import "./test.js";
       @blue interface Foo { foo(): int32 }
-      @test interface Bar mixes Foo {
+      @test interface Bar extends Foo {
         bar(): int32;
       }
       `
@@ -169,7 +169,7 @@ describe("compiler: interfaces", () => {
       `
       import "./test.js";
       interface Foo { @blue foo(): int32 }
-      @test interface Bar mixes Foo {}
+      @test interface Bar extends Foo {}
       `
     );
 
@@ -187,14 +187,14 @@ describe("compiler: interfaces", () => {
       `
       interface Bar { bar(): int32 }
       interface Baz { bar(): int32 }
-      @test interface Foo mixes Bar, Baz { }
+      @test interface Foo extends Bar, Baz { }
       `
     );
 
     const diagnostics = await testHost.diagnose("./");
     expectDiagnostics(diagnostics, {
-      code: "mixes-interface-duplicate",
-      message: "Interface mixes cannot have duplicate members. The duplicate member is named bar",
+      code: "extends-interface-duplicate",
+      message: "Interface extends cannot have duplicate members. The duplicate member is named bar",
     });
   });
 
@@ -203,7 +203,7 @@ describe("compiler: interfaces", () => {
       "main.cadl",
       `
       interface Bar { bar(): int32 }
-      @test interface Foo mixes Bar { bar(): string }
+      @test interface Foo extends Bar { bar(): string }
       `
     );
 
@@ -220,13 +220,13 @@ describe("compiler: interfaces", () => {
       "main.cadl",
       `
       model Bar { }
-      @test interface Foo mixes Bar { bar(): string }
+      @test interface Foo extends Bar { bar(): string }
       `
     );
 
     const diagnostics = await testHost.diagnose("./");
     expectDiagnostics(diagnostics, {
-      code: "mixes-interface",
+      code: "extends-interface",
       message: "Interfaces can only mix other interfaces",
     });
   });

--- a/packages/compiler/test/formatter/scenarios/inputs/interface.cadl
+++ b/packages/compiler/test/formatter/scenarios/inputs/interface.cadl
@@ -7,12 +7,12 @@ Foo {
   y (x: int32, y: int32): int32
 }
 
-interface Bar    mixes
+interface Bar    extends
 ResourceOperations<BarResource> {
   blerp(n: int32): string;
 }
 
-interface Baz mixes ResourceRead<BarResource>,
+interface Baz extends ResourceRead<BarResource>,
 
 ResourceCreate<BarResource>,     ResourceDelete<BarResource>
   {

--- a/packages/compiler/test/formatter/scenarios/outputs/interface.cadl
+++ b/packages/compiler/test/formatter/scenarios/outputs/interface.cadl
@@ -3,12 +3,12 @@ interface Foo {
   y(x: int32, y: int32): int32;
 }
 
-interface Bar mixes ResourceOperations<BarResource> {
+interface Bar extends ResourceOperations<BarResource> {
   blerp(n: int32): string;
 }
 
 interface Baz
-  mixes ResourceRead<BarResource>,
+  extends ResourceRead<BarResource>,
     ResourceCreate<BarResource>,
     ResourceDelete<BarResource> {
   glorp(n: int32): string;

--- a/packages/compiler/test/test-parser.ts
+++ b/packages/compiler/test/test-parser.ts
@@ -142,7 +142,6 @@ describe("compiler: syntax", () => {
     ]);
 
     parseErrorEach([
-      ["interface Foo<T> extends Bar<T> {}", [/extends/]],
       ["interface X {", [/'}' expected/]],
       ["interface X { foo(): string; interface Y", [/'}' expected/]],
       ["interface X { foo(a: string", [/'\)' expected/]],

--- a/packages/compiler/test/test-parser.ts
+++ b/packages/compiler/test/test-parser.ts
@@ -134,15 +134,15 @@ describe("compiler: syntax", () => {
     parseEach([
       "interface Foo { }",
       "interface Foo<T> { }",
-      "interface Foo<T> mixes Bar<T> { }",
-      "interface Foo mixes Bar, Baz<T> { }",
+      "interface Foo<T> extends Bar<T> { }",
+      "interface Foo extends Bar, Baz<T> { }",
       "interface Foo { foo(): int32; }",
       "interface Foo { foo(): int32; bar(): int32; }",
       "interface Foo { op foo(): int32; op bar(): int32; baz(): int32; }",
     ]);
 
     parseErrorEach([
-      ["interface Foo<T> extends Bar<T> {}", [/mixes/]],
+      ["interface Foo<T> extends Bar<T> {}", [/extends/]],
       ["interface X {", [/'}' expected/]],
       ["interface X { foo(): string; interface Y", [/'}' expected/]],
       ["interface X { foo(a: string", [/'\)' expected/]],

--- a/packages/playground/src/samples.ts
+++ b/packages/playground/src/samples.ts
@@ -41,7 +41,7 @@ model Widget {
   message: string;
 }
 
-interface WidgetService mixes Resource.ResourceOperations<Widget, Error> {
+interface WidgetService extends Resource.ResourceOperations<Widget, Error> {
   @get @route("customGet") customGet(): Widget;
 }`,
   "Versioned Rest Framework": `import "@cadl-lang/rest";
@@ -68,7 +68,7 @@ model Widget {
   message: string;
 }
 
-interface WidgetService mixes Resource.ResourceOperations<Widget, Error> {
+interface WidgetService extends Resource.ResourceOperations<Widget, Error> {
   @added("v2")
   @get
   @route("customGet")

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -115,20 +115,20 @@ interface ResourceList<TResource, TError> {
 @validateHasKey(TResource)
 @validateIsError(TError)
 interface ResourceInstanceOperations<TResource, TError>
-  mixes ResourceRead<TResource, TError>,
+  extends ResourceRead<TResource, TError>,
     ResourceUpdate<TResource, TError>,
     ResourceDelete<TResource, TError> {}
 
 @validateHasKey(TResource)
 @validateIsError(TError)
 interface ResourceCollectionOperations<TResource, TError>
-  mixes ResourceCreate<TResource, TError>,
+  extends ResourceCreate<TResource, TError>,
     ResourceList<TResource, TError> {}
 
 @validateHasKey(TResource)
 @validateIsError(TError)
 interface ResourceOperations<TResource, TError>
-  mixes ResourceInstanceOperations<TResource, TError>,
+  extends ResourceInstanceOperations<TResource, TError>,
     ResourceCollectionOperations<TResource, TError> {}
 
 @validateHasKey(TResource)
@@ -155,7 +155,7 @@ interface SingletonResourceUpdate<TSingleton, TResource, TError> {
 }
 
 interface SingletonResourceOperations<TSingleton, TResource, TError>
-  mixes SingletonResourceRead<TSingleton, TResource, TError>,
+  extends SingletonResourceRead<TSingleton, TResource, TError>,
     SingletonResourceUpdate<TSingleton, TResource, TError> {}
 
 @validateHasKey(TResource)
@@ -220,14 +220,14 @@ interface ExtensionResourceList<TExtension, TResource, TError> {
 }
 
 interface ExtensionResourceInstanceOperations<TExtension, TResource, TError>
-  mixes ExtensionResourceRead<TExtension, TResource, TError>,
+  extends ExtensionResourceRead<TExtension, TResource, TError>,
     ExtensionResourceUpdate<TExtension, TResource, TError>,
     ExtensionResourceDelete<TExtension, TResource, TError> {}
 
 interface ExtensionResourceCollectionOperations<TExtension, TResource, TError>
-  mixes ExtensionResourceCreate<TExtension, TResource, TError>,
+  extends ExtensionResourceCreate<TExtension, TResource, TError>,
     ExtensionResourceList<TExtension, TResource, TError> {}
 
 interface ExtensionResourceOperations<TExtension, TResource, TError>
-  mixes ExtensionResourceInstanceOperations<TExtension, TResource, TError>,
+  extends ExtensionResourceInstanceOperations<TExtension, TResource, TError>,
     ExtensionResourceCollectionOperations<TExtension, TResource, TError> {}

--- a/packages/rest/test/test-resource.ts
+++ b/packages/rest/test/test-resource.ts
@@ -24,8 +24,8 @@ describe("rest: resources", () => {
 
         @error model Error {}
 
-        interface Things mixes ResourceOperations<Thing, Error> {}
-        interface Subthings mixes ResourceOperations<Subthing, Error> {}
+        interface Things extends ResourceOperations<Thing, Error> {}
+        interface Subthings extends ResourceOperations<Subthing, Error> {}
       }
       `
     );
@@ -142,8 +142,8 @@ describe("rest: resources", () => {
 
         @error model Error {}
 
-        interface Things mixes ResourceRead<Thing, Error> {}
-        interface ThingsSingleton mixes SingletonResourceOperations<Singleton, Thing, Error> {}
+        interface Things extends ResourceRead<Thing, Error> {}
+        interface ThingsSingleton extends SingletonResourceOperations<Singleton, Thing, Error> {}
       }
       `
     );
@@ -194,8 +194,8 @@ describe("rest: resources", () => {
 
         @error model Error {}
 
-        interface ThingsExtension mixes ExtensionResourceOperations<Exthing, Thing, Error> {}
-        interface SubthingsExtension mixes ExtensionResourceOperations<Exthing, Subthing, Error> {}
+        interface ThingsExtension extends ExtensionResourceOperations<Exthing, Thing, Error> {}
+        interface SubthingsExtension extends ExtensionResourceOperations<Exthing, Subthing, Error> {}
       }
       `
     );
@@ -260,7 +260,7 @@ describe("rest: resources", () => {
       `
       using Cadl.Rest.Resource;
 
-      interface Dogs mixes ResourceOperations<Dog, Error> {}
+      interface Dogs extends ResourceOperations<Dog, Error> {}
 
       model Dog {}
       @error model Error {code: string}
@@ -279,7 +279,7 @@ describe("rest: resources", () => {
       `
       using Cadl.Rest.Resource;
 
-      interface Dogs mixes ResourceOperations<Dog, Error> {}
+      interface Dogs extends ResourceOperations<Dog, Error> {}
       
       model Dog {
         @key foo: string

--- a/packages/samples/rest/petstore/petstore.cadl
+++ b/packages/samples/rest/petstore/petstore.cadl
@@ -61,28 +61,28 @@ model Insurance {
   deductible: int32;
 }
 
-interface Pets mixes ResourceOperations<Pet, PetStoreError> {}
+interface Pets extends ResourceOperations<Pet, PetStoreError> {}
 
 interface PetCheckups
-  mixes ExtensionResourceCreateOrUpdate<Checkup, Pet, PetStoreError>,
+  extends ExtensionResourceCreateOrUpdate<Checkup, Pet, PetStoreError>,
     ExtensionResourceList<Checkup, Pet, PetStoreError> {}
 
-interface PetInsurance mixes SingletonResourceOperations<Insurance, Pet, PetStoreError> {}
+interface PetInsurance extends SingletonResourceOperations<Insurance, Pet, PetStoreError> {}
 
-interface Toys mixes ResourceRead<Toy, PetStoreError> {
+interface Toys extends ResourceRead<Toy, PetStoreError> {
   @listsResource(Toy)
   list(...ParentKeysOf<Toy>, @query nameFilter: string): Page<Toy> | PetStoreError;
 }
-interface ToyInsurance mixes SingletonResourceOperations<Insurance, Toy, PetStoreError> {}
+interface ToyInsurance extends SingletonResourceOperations<Insurance, Toy, PetStoreError> {}
 
 interface Checkups
-  mixes ResourceCreateOrUpdate<Checkup, PetStoreError>,
+  extends ResourceCreateOrUpdate<Checkup, PetStoreError>,
     ResourceList<Checkup, PetStoreError> {}
 
-interface Owners mixes ResourceOperations<Owner, PetStoreError> {}
+interface Owners extends ResourceOperations<Owner, PetStoreError> {}
 
 interface OwnerCheckups
-  mixes ExtensionResourceCreateOrUpdate<Checkup, Owner, PetStoreError>,
+  extends ExtensionResourceCreateOrUpdate<Checkup, Owner, PetStoreError>,
     ExtensionResourceList<Checkup, Owner, PetStoreError> {}
 
-interface OwnerInsurance mixes SingletonResourceOperations<Insurance, Owner, PetStoreError> {}
+interface OwnerInsurance extends SingletonResourceOperations<Insurance, Owner, PetStoreError> {}

--- a/packages/spec/src/spec.emu.html
+++ b/packages/spec/src/spec.emu.html
@@ -304,7 +304,7 @@ InterfaceStatement :
     `interface` Identifier TemplateParameters? InterfaceHeritage? `{` InterfaceBody? `}`
 
 InterfaceHeritage :
-    `mixes` ReferenceExpressionList;
+    `extends` ReferenceExpressionList;
 
 InterfaceBody
     InterfaceMemberList `;`?

--- a/packages/versioning/test/test-versioned-dependencies.ts
+++ b/packages/versioning/test/test-versioned-dependencies.ts
@@ -193,7 +193,7 @@ describe("versioning: reference versioned library", () => {
         namespace DemoService {
           model Foo {}
 
-          interface Test mixes NonVersioned.Foo<Foo> {}
+          interface Test extends NonVersioned.Foo<Foo> {}
         }
 
         namespace NonVersioned {


### PR DESCRIPTION
 fix #481