### PR TITLE
Bump ecmmarkup version to get rid of deprecated packages

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -47,7 +47,7 @@ specifiers:
   change-case: ~4.1.2
   cross-env: ~7.0.3
   debounce: ~1.2.1
-  ecmarkup: ~9.8.1
+  ecmarkup: ~12.0.3
   eslint: ^8.12.0
   eslint-config-prettier: ^8.5.0
   eslint-plugin-prettier: ^4.0.0
@@ -132,7 +132,7 @@ dependencies:
   change-case: 4.1.2
   cross-env: 7.0.3
   debounce: 1.2.1
-  ecmarkup: 9.8.1
+  ecmarkup: 12.0.3
   eslint: 8.13.0
   eslint-config-prettier: 8.5.0_eslint@8.13.0
   eslint-plugin-prettier: 4.0.0_1815ac95b7fb26c13c7d48a8eef62d0f
@@ -852,23 +852,6 @@ packages:
     resolution: {integrity: sha512-jwcSY9pqEmGoDNhfT+0LUmSTyk6zXF/pbgKb7KU7mTfCrWfVCT/ve61cD1CreerDRBSat/s55se0lJXwDSjhuA==}
     dev: false
 
-  /@eslint/eslintrc/0.4.3:
-    resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    dependencies:
-      ajv: 6.12.6
-      debug: 4.3.4
-      espree: 7.3.1
-      globals: 13.13.0
-      ignore: 4.0.6
-      import-fresh: 3.3.0
-      js-yaml: 3.14.1
-      minimatch: 3.1.2
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@eslint/eslintrc/1.2.1:
     resolution: {integrity: sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -882,17 +865,6 @@ packages:
       js-yaml: 4.1.0
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@humanwhocodes/config-array/0.5.0:
-    resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==}
-    engines: {node: '>=10.10.0'}
-    dependencies:
-      '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
-      minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1084,6 +1056,11 @@ packages:
     resolution: {integrity: sha512-JLo+Y592QzIE+q7Dl2pMUtt4q8SKYI5jDrZxrozEQxnGVOyYE+GWK9eLkwTaeN9DDctlaRAQ3TBmzZ1qdLE30A==}
     dev: false
 
+  /@tootallnate/once/2.0.0:
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
+    dev: false
+
   /@types/babel__code-frame/7.0.3:
     resolution: {integrity: sha512-2TN6oiwtNjOezilFVl77zwdNPwQWaDBBCCWWxyo1ctiO3vAtd7H/aB/CBJdw9+kqq3+latD0SXoedIuHySSZWw==}
     dev: false
@@ -1199,7 +1176,7 @@ packages:
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 14.0.27
+      '@types/node': 16.0.3
     dev: false
 
   /@types/scheduler/0.16.2:
@@ -1390,27 +1367,19 @@ packages:
       - supports-color
     dev: false
 
-  /abab/1.0.4:
-    resolution: {integrity: sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=}
-    dev: false
-
   /abab/2.0.5:
     resolution: {integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==}
     dev: false
 
-  /acorn-globals/4.3.4:
-    resolution: {integrity: sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==}
-    dependencies:
-      acorn: 6.4.2
-      acorn-walk: 6.2.0
+  /abab/2.0.6:
+    resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
     dev: false
 
-  /acorn-jsx/5.3.2_acorn@7.4.1:
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+  /acorn-globals/6.0.0:
+    resolution: {integrity: sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==}
     dependencies:
       acorn: 7.4.1
+      acorn-walk: 7.2.0
     dev: false
 
   /acorn-jsx/5.3.2_acorn@8.7.0:
@@ -1421,21 +1390,9 @@ packages:
       acorn: 8.7.0
     dev: false
 
-  /acorn-walk/6.2.0:
-    resolution: {integrity: sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==}
+  /acorn-walk/7.2.0:
+    resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
     engines: {node: '>=0.4.0'}
-    dev: false
-
-  /acorn/5.7.4:
-    resolution: {integrity: sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-    dev: false
-
-  /acorn/6.4.2:
-    resolution: {integrity: sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
     dev: false
 
   /acorn/7.4.1:
@@ -1454,7 +1411,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1490,16 +1447,6 @@ packages:
   /ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-    dev: false
-
-  /ansi-styles/1.0.0:
-    resolution: {integrity: sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=}
-    engines: {node: '>=0.8.0'}
-    dev: false
-
-  /ansi-styles/2.2.1:
-    resolution: {integrity: sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=}
-    engines: {node: '>=0.10.0'}
     dev: false
 
   /ansi-styles/3.2.1:
@@ -1550,33 +1497,19 @@ packages:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: false
 
-  /array-equal/1.0.0:
-    resolution: {integrity: sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=}
+  /array-back/3.1.0:
+    resolution: {integrity: sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==}
+    engines: {node: '>=6'}
+    dev: false
+
+  /array-back/4.0.2:
+    resolution: {integrity: sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==}
+    engines: {node: '>=8'}
     dev: false
 
   /array-union/2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
-    dev: false
-
-  /asn1/0.2.6:
-    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
-    dependencies:
-      safer-buffer: 2.1.2
-    dev: false
-
-  /assert-plus/1.0.0:
-    resolution: {integrity: sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=}
-    engines: {node: '>=0.8'}
-    dev: false
-
-  /astral-regex/2.0.0:
-    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
-    engines: {node: '>=8'}
-    dev: false
-
-  /async-limiter/1.0.1:
-    resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
     dev: false
 
   /asynckit/0.4.0:
@@ -1588,14 +1521,6 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
     requiresBuild: true
-    dev: false
-
-  /aws-sign2/0.7.0:
-    resolution: {integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=}
-    dev: false
-
-  /aws4/1.11.0:
-    resolution: {integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==}
     dev: false
 
   /azure-devops-node-api/11.1.1:
@@ -1617,12 +1542,6 @@ packages:
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-    dev: false
-
-  /bcrypt-pbkdf/1.0.2:
-    resolution: {integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=}
-    dependencies:
-      tweetnacl: 0.14.5
     dev: false
 
   /binary-extensions/2.2.0:
@@ -1749,30 +1668,6 @@ packages:
       no-case: 3.0.4
       tslib: 2.3.1
       upper-case-first: 2.0.2
-    dev: false
-
-  /caseless/0.12.0:
-    resolution: {integrity: sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=}
-    dev: false
-
-  /chalk/0.4.0:
-    resolution: {integrity: sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=}
-    engines: {node: '>=0.8.0'}
-    dependencies:
-      ansi-styles: 1.0.0
-      has-color: 0.1.7
-      strip-ansi: 0.1.1
-    dev: false
-
-  /chalk/1.1.3:
-    resolution: {integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-styles: 2.2.1
-      escape-string-regexp: 1.0.5
-      has-ansi: 2.0.0
-      strip-ansi: 3.0.1
-      supports-color: 2.0.0
     dev: false
 
   /chalk/2.4.2:
@@ -1902,6 +1797,26 @@ packages:
       delayed-stream: 1.0.0
     dev: false
 
+  /command-line-args/5.2.1:
+    resolution: {integrity: sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      array-back: 3.1.0
+      find-replace: 3.0.0
+      lodash.camelcase: 4.3.0
+      typical: 4.0.0
+    dev: false
+
+  /command-line-usage/6.1.3:
+    resolution: {integrity: sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      array-back: 4.0.2
+      chalk: 2.4.2
+      table-layout: 1.0.2
+      typical: 5.2.0
+    dev: false
+
   /commander/6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
@@ -1936,10 +1851,6 @@ packages:
     resolution: {integrity: sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==}
     dependencies:
       safe-buffer: 5.1.2
-    dev: false
-
-  /core-util-is/1.0.2:
-    resolution: {integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=}
     dev: false
 
   /core-util-is/1.0.3:
@@ -1982,8 +1893,13 @@ packages:
     resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
     dev: false
 
-  /cssstyle/0.2.37:
-    resolution: {integrity: sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=}
+  /cssom/0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
+    dev: false
+
+  /cssstyle/2.3.0:
+    resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
+    engines: {node: '>=8'}
     dependencies:
       cssom: 0.3.8
     dev: false
@@ -1992,24 +1908,18 @@ packages:
     resolution: {integrity: sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==}
     dev: false
 
-  /dashdash/1.14.1:
-    resolution: {integrity: sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=}
-    engines: {node: '>=0.10'}
-    dependencies:
-      assert-plus: 1.0.0
-    dev: false
-
   /data-uri-to-buffer/4.0.0:
     resolution: {integrity: sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==}
     engines: {node: '>= 12'}
     dev: false
 
-  /data-urls/1.1.0:
-    resolution: {integrity: sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==}
+  /data-urls/3.0.2:
+    resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
+    engines: {node: '>=12'}
     dependencies:
-      abab: 2.0.5
-      whatwg-mimetype: 2.3.0
-      whatwg-url: 7.1.0
+      abab: 2.0.6
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 11.0.0
     dev: false
 
   /debounce/1.2.1:
@@ -2056,6 +1966,10 @@ packages:
   /decamelize/4.0.0:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
+    dev: false
+
+  /decimal.js/10.3.1:
+    resolution: {integrity: sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==}
     dev: false
 
   /decompress-response/6.0.0:
@@ -2145,10 +2059,11 @@ packages:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
     dev: false
 
-  /domexception/1.0.1:
-    resolution: {integrity: sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==}
+  /domexception/4.0.0:
+    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
+    engines: {node: '>=12'}
     dependencies:
-      webidl-conversions: 4.0.2
+      webidl-conversions: 7.0.0
     dev: false
 
   /domhandler/4.3.1:
@@ -2173,39 +2088,37 @@ packages:
       tslib: 2.3.1
     dev: false
 
-  /ecc-jsbn/0.1.2:
-    resolution: {integrity: sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=}
-    dependencies:
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-    dev: false
-
   /ecmarkdown/7.0.0:
     resolution: {integrity: sha512-hJxPALjSOpSMMcFjSzwzJBk8EWOu20mYlTfV7BnVTh9er0FEaT2eSx16y36YxqQfdFxPUsa0CSH4fLf0qUclKw==}
     dependencies:
       escape-html: 1.0.3
     dev: false
 
-  /ecmarkup/9.8.1:
-    resolution: {integrity: sha512-GxE9Xyycd4UluP1F1dKcuHuj0bYboHCrAveVagd6CFbTNy0JhUexcB0Kko3EevoY2VpTvI4zppUfHHngNywmfw==}
+  /ecmarkup/12.0.3:
+    resolution: {integrity: sha512-iWn/8Az5izJqZzlNari7MONi+4bpUw7iuoktVf9mtxkxxg+da/vYdwk7G0pORM1moceJtVcdu7KEZnMEdgAj5A==}
     engines: {node: '>= 12 || ^11.10.1 || ^10.13 || ^8.10'}
     hasBin: true
     dependencies:
-      chalk: 1.1.3
+      chalk: 4.1.2
+      command-line-args: 5.2.1
+      command-line-usage: 6.1.3
       dedent-js: 1.0.1
       ecmarkdown: 7.0.0
-      eslint: 7.32.0
+      eslint-formatter-codeframe: 7.32.1
       fast-glob: 3.2.11
-      grammarkdown: 3.1.2
+      grammarkdown: 3.2.0
       highlight.js: 11.0.1
       html-escape: 1.0.2
       js-yaml: 3.14.1
-      jsdom: 11.10.0
-      nomnom: 1.8.1
+      jsdom: 19.0.0
+      parse5: 6.0.1
       prex: 0.4.7
       promise-debounce: 1.0.1
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - utf-8-validate
     dev: false
 
   /electron-to-chromium/1.4.106:
@@ -2220,13 +2133,6 @@ packages:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
       once: 1.4.0
-    dev: false
-
-  /enquirer/2.3.6:
-    resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
-    engines: {node: '>=8.6'}
-    dependencies:
-      ansi-colors: 4.1.1
     dev: false
 
   /entities/2.1.0:
@@ -2469,13 +2375,13 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /escodegen/1.14.3:
-    resolution: {integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==}
-    engines: {node: '>=4.0'}
+  /escodegen/2.0.0:
+    resolution: {integrity: sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==}
+    engines: {node: '>=6.0'}
     hasBin: true
     dependencies:
       esprima: 4.0.1
-      estraverse: 4.3.0
+      estraverse: 5.3.0
       esutils: 2.0.3
       optionator: 0.8.3
     optionalDependencies:
@@ -2489,6 +2395,14 @@ packages:
       eslint: '>=7.0.0'
     dependencies:
       eslint: 8.13.0
+    dev: false
+
+  /eslint-formatter-codeframe/7.32.1:
+    resolution: {integrity: sha512-DK/3Q3+zVKq/7PdSYiCxPrsDF8H/TRMK5n8Hziwr4IMkMy+XiKSwbpj25AdajS63I/B61Snetq4uVvX9fOLyAg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+    dependencies:
+      '@babel/code-frame': 7.12.11
+      chalk: 4.1.2
     dev: false
 
   /eslint-plugin-prettier/4.0.0_1815ac95b7fb26c13c7d48a8eef62d0f:
@@ -2524,13 +2438,6 @@ packages:
       estraverse: 5.3.0
     dev: false
 
-  /eslint-utils/2.1.0:
-    resolution: {integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==}
-    engines: {node: '>=6'}
-    dependencies:
-      eslint-visitor-keys: 1.3.0
-    dev: false
-
   /eslint-utils/3.0.0_eslint@8.13.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
@@ -2541,11 +2448,6 @@ packages:
       eslint-visitor-keys: 2.1.0
     dev: false
 
-  /eslint-visitor-keys/1.3.0:
-    resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
-    engines: {node: '>=4'}
-    dev: false
-
   /eslint-visitor-keys/2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
     engines: {node: '>=10'}
@@ -2554,55 +2456,6 @@ packages:
   /eslint-visitor-keys/3.3.0:
     resolution: {integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: false
-
-  /eslint/7.32.0:
-    resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    hasBin: true
-    dependencies:
-      '@babel/code-frame': 7.12.11
-      '@eslint/eslintrc': 0.4.3
-      '@humanwhocodes/config-array': 0.5.0
-      ajv: 6.12.6
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4
-      doctrine: 3.0.0
-      enquirer: 2.3.6
-      escape-string-regexp: 4.0.0
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
-      eslint-visitor-keys: 2.1.0
-      espree: 7.3.1
-      esquery: 1.4.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 6.0.1
-      functional-red-black-tree: 1.0.1
-      glob-parent: 5.1.2
-      globals: 13.13.0
-      ignore: 4.0.6
-      import-fresh: 3.3.0
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      js-yaml: 3.14.1
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.4.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.2
-      natural-compare: 1.4.0
-      optionator: 0.9.1
-      progress: 2.0.3
-      regexpp: 3.2.0
-      semver: 7.3.6
-      strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
-      table: 6.8.0
-      text-table: 0.2.0
-      v8-compile-cache: 2.3.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /eslint/8.13.0:
@@ -2647,15 +2500,6 @@ packages:
       v8-compile-cache: 2.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /espree/7.3.1:
-    resolution: {integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    dependencies:
-      acorn: 7.4.1
-      acorn-jsx: 5.3.2_acorn@7.4.1
-      eslint-visitor-keys: 1.3.0
     dev: false
 
   /espree/9.3.1:
@@ -2733,27 +2577,18 @@ packages:
       jest-regex-util: 27.5.1
     dev: false
 
-  /extend/3.0.2:
-    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-    dev: false
-
   /extract-zip/2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
     hasBin: true
     dependencies:
-      debug: 4.3.3
+      debug: 4.3.4
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
       '@types/yauzl': 2.10.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /extsprintf/1.3.0:
-    resolution: {integrity: sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=}
-    engines: {'0': node >=0.6.0}
     dev: false
 
   /fast-deep-equal/3.1.3:
@@ -2817,6 +2652,13 @@ packages:
       to-regex-range: 5.0.1
     dev: false
 
+  /find-replace/3.0.0:
+    resolution: {integrity: sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==}
+    engines: {node: '>=4.0.0'}
+    dependencies:
+      array-back: 3.1.0
+    dev: false
+
   /find-up/5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -2850,13 +2692,9 @@ packages:
       signal-exit: 3.0.7
     dev: false
 
-  /forever-agent/0.6.1:
-    resolution: {integrity: sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=}
-    dev: false
-
-  /form-data/2.3.3:
-    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
-    engines: {node: '>= 0.12'}
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -2930,12 +2768,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       pump: 3.0.0
-    dev: false
-
-  /getpass/0.1.7:
-    resolution: {integrity: sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=}
-    dependencies:
-      assert-plus: 1.0.0
     dev: false
 
   /github-from-package/0.0.0:
@@ -3025,35 +2857,17 @@ packages:
       '@esfx/cancelable': 1.0.0-pre.30
     dev: false
 
+  /grammarkdown/3.2.0:
+    resolution: {integrity: sha512-pEVUvG2Kxv/PwM3Dm3kFEU1/GHRkNcFWmk/zkqN/y0uoQtPaZ+5VaBacMQAaFOIL9WGYjHXtqpkT5YRvySsISQ==}
+    hasBin: true
+    dependencies:
+      '@esfx/async-canceltoken': 1.0.0-pre.30
+      '@esfx/cancelable': 1.0.0-pre.30
+    dev: false
+
   /growl/1.10.5:
     resolution: {integrity: sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==}
     engines: {node: '>=4.x'}
-    dev: false
-
-  /har-schema/2.0.0:
-    resolution: {integrity: sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=}
-    engines: {node: '>=4'}
-    dev: false
-
-  /har-validator/5.1.5:
-    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
-    engines: {node: '>=6'}
-    deprecated: this library is no longer supported
-    dependencies:
-      ajv: 6.12.6
-      har-schema: 2.0.0
-    dev: false
-
-  /has-ansi/2.0.0:
-    resolution: {integrity: sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-regex: 2.1.1
-    dev: false
-
-  /has-color/0.1.7:
-    resolution: {integrity: sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=}
-    engines: {node: '>=0.10.0'}
     dev: false
 
   /has-flag/3.0.0:
@@ -3106,10 +2920,11 @@ packages:
       lru-cache: 6.0.0
     dev: false
 
-  /html-encoding-sniffer/1.0.2:
-    resolution: {integrity: sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==}
+  /html-encoding-sniffer/3.0.0:
+    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
+    engines: {node: '>=12'}
     dependencies:
-      whatwg-encoding: 1.0.5
+      whatwg-encoding: 2.0.0
     dev: false
 
   /html-escape/1.0.2:
@@ -3129,13 +2944,15 @@ packages:
       entities: 2.2.0
     dev: false
 
-  /http-signature/1.2.0:
-    resolution: {integrity: sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=}
-    engines: {node: '>=0.8', npm: '>=1.3.7'}
+  /http-proxy-agent/5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
     dependencies:
-      assert-plus: 1.0.0
-      jsprim: 1.4.2
-      sshpk: 1.17.0
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /https-proxy-agent/5.0.0:
@@ -3143,13 +2960,13 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.3
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /iconv-lite/0.4.24:
-    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+  /iconv-lite/0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
@@ -3157,11 +2974,6 @@ packages:
 
   /ieee754/1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-    dev: false
-
-  /ignore/4.0.6:
-    resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
-    engines: {node: '>= 4'}
     dev: false
 
   /ignore/5.2.0:
@@ -3258,14 +3070,14 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /is-potential-custom-element-name/1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+    dev: false
+
   /is-reference/1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
     dependencies:
       '@types/estree': 0.0.51
-    dev: false
-
-  /is-typedarray/1.0.0:
-    resolution: {integrity: sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=}
     dev: false
 
   /is-unicode-supported/0.1.0:
@@ -3286,10 +3098,6 @@ packages:
 
   /isexe/2.0.0:
     resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
-    dev: false
-
-  /isstream/0.1.2:
-    resolution: {integrity: sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=}
     dev: false
 
   /istanbul-lib-coverage/3.2.0:
@@ -3382,39 +3190,46 @@ packages:
       argparse: 2.0.1
     dev: false
 
-  /jsbn/0.1.1:
-    resolution: {integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=}
-    dev: false
-
-  /jsdom/11.10.0:
-    resolution: {integrity: sha512-x5No5FpJgBg3j5aBwA8ka6eGuS5IxbC8FOkmyccKvObtFT0bDMict/LOxINZsZGZSfGdNomLZ/qRV9Bpq/GIBA==}
+  /jsdom/19.0.0:
+    resolution: {integrity: sha512-RYAyjCbxy/vri/CfnjUWJQQtZ3LKlLnDqj+9XLNnJPgEGeirZs3hllKR20re8LUZ6o1b1X4Jat+Qd26zmP41+A==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
     dependencies:
-      abab: 1.0.4
-      acorn: 5.7.4
-      acorn-globals: 4.3.4
-      array-equal: 1.0.0
-      cssom: 0.3.8
-      cssstyle: 0.2.37
-      data-urls: 1.1.0
-      domexception: 1.0.1
-      escodegen: 1.14.3
-      html-encoding-sniffer: 1.0.2
-      left-pad: 1.3.0
-      nwmatcher: 1.4.4
-      parse5: 4.0.0
-      pn: 1.1.0
-      request: 2.88.2
-      request-promise-native: 1.0.9_request@2.88.2
-      sax: 1.2.4
+      abab: 2.0.5
+      acorn: 8.7.0
+      acorn-globals: 6.0.0
+      cssom: 0.5.0
+      cssstyle: 2.3.0
+      data-urls: 3.0.2
+      decimal.js: 10.3.1
+      domexception: 4.0.0
+      escodegen: 2.0.0
+      form-data: 4.0.0
+      html-encoding-sniffer: 3.0.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.0
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.0
+      parse5: 6.0.1
+      saxes: 5.0.1
       symbol-tree: 3.2.4
-      tough-cookie: 2.5.0
+      tough-cookie: 4.0.0
       w3c-hr-time: 1.0.2
-      webidl-conversions: 4.0.2
-      whatwg-encoding: 1.0.5
-      whatwg-mimetype: 2.3.0
-      whatwg-url: 6.5.0
-      ws: 4.1.0
-      xml-name-validator: 3.0.0
+      w3c-xmlserializer: 3.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 10.0.0
+      ws: 8.4.2
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
     dev: false
 
   /jsesc/2.5.2:
@@ -3431,32 +3246,14 @@ packages:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
     dev: false
 
-  /json-schema/0.4.0:
-    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
-    dev: false
-
   /json-stable-stringify-without-jsonify/1.0.1:
     resolution: {integrity: sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=}
-    dev: false
-
-  /json-stringify-safe/5.0.1:
-    resolution: {integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=}
     dev: false
 
   /json5/2.2.1:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
     engines: {node: '>=6'}
     hasBin: true
-    dev: false
-
-  /jsprim/1.4.2:
-    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
-    engines: {node: '>=0.6.0'}
-    dependencies:
-      assert-plus: 1.0.0
-      extsprintf: 1.3.0
-      json-schema: 0.4.0
-      verror: 1.10.0
     dev: false
 
   /keytar/7.9.0:
@@ -3470,11 +3267,6 @@ packages:
   /kleur/3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
-    dev: false
-
-  /left-pad/1.3.0:
-    resolution: {integrity: sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==}
-    deprecated: use String.prototype.padStart()
     dev: false
 
   /leven/3.1.0:
@@ -3511,20 +3303,12 @@ packages:
       p-locate: 5.0.0
     dev: false
 
+  /lodash.camelcase/4.3.0:
+    resolution: {integrity: sha1-soqmKIorn8ZRA1x3EfZathkDMaY=}
+    dev: false
+
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-    dev: false
-
-  /lodash.sortby/4.7.0:
-    resolution: {integrity: sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=}
-    dev: false
-
-  /lodash.truncate/4.4.2:
-    resolution: {integrity: sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=}
-    dev: false
-
-  /lodash/4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: false
 
   /log-symbols/4.1.0:
@@ -3792,14 +3576,6 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /nomnom/1.8.1:
-    resolution: {integrity: sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=}
-    deprecated: Package no longer supported. Contact support@npmjs.com for more info.
-    dependencies:
-      chalk: 0.4.0
-      underscore: 1.6.0
-    dev: false
-
   /normalize-path/3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -3825,12 +3601,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /nwmatcher/1.4.4:
-    resolution: {integrity: sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==}
-    dev: false
-
-  /oauth-sign/0.9.0:
-    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+  /nwsapi/2.2.0:
+    resolution: {integrity: sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==}
     dev: false
 
   /object-assign/4.1.1:
@@ -3942,10 +3714,6 @@ packages:
       parse5: 6.0.1
     dev: false
 
-  /parse5/4.0.0:
-    resolution: {integrity: sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==}
-    dev: false
-
   /parse5/6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
     dev: false
@@ -3990,10 +3758,6 @@ packages:
 
   /pend/1.2.0:
     resolution: {integrity: sha1-elfrVQpng/kRUzH89GY9XI4AelA=}
-    dev: false
-
-  /performance-now/2.1.0:
-    resolution: {integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=}
     dev: false
 
   /picocolors/1.0.0:
@@ -4065,10 +3829,6 @@ packages:
     dependencies:
       base64-js: 1.5.1
       xmlbuilder: 9.0.7
-    dev: false
-
-  /pn/1.1.0:
-    resolution: {integrity: sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==}
     dev: false
 
   /pngjs/4.0.1:
@@ -4215,11 +3975,6 @@ packages:
       side-channel: 1.0.4
     dev: false
 
-  /qs/6.5.3:
-    resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
-    engines: {node: '>=0.6'}
-    dev: false
-
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: false
@@ -4301,59 +4056,14 @@ packages:
       picomatch: 2.3.1
     dev: false
 
+  /reduce-flatten/2.0.0:
+    resolution: {integrity: sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==}
+    engines: {node: '>=6'}
+    dev: false
+
   /regexpp/3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
-    dev: false
-
-  /request-promise-core/1.1.4_request@2.88.2:
-    resolution: {integrity: sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==}
-    engines: {node: '>=0.10.0'}
-    peerDependencies:
-      request: ^2.34
-    dependencies:
-      lodash: 4.17.21
-      request: 2.88.2
-    dev: false
-
-  /request-promise-native/1.0.9_request@2.88.2:
-    resolution: {integrity: sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==}
-    engines: {node: '>=0.12.0'}
-    deprecated: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
-    peerDependencies:
-      request: ^2.34
-    dependencies:
-      request: 2.88.2
-      request-promise-core: 1.1.4_request@2.88.2
-      stealthy-require: 1.1.1
-      tough-cookie: 2.5.0
-    dev: false
-
-  /request/2.88.2:
-    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
-    engines: {node: '>= 6'}
-    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
-    dependencies:
-      aws-sign2: 0.7.0
-      aws4: 1.11.0
-      caseless: 0.12.0
-      combined-stream: 1.0.8
-      extend: 3.0.2
-      forever-agent: 0.6.1
-      form-data: 2.3.3
-      har-validator: 5.1.5
-      http-signature: 1.2.0
-      is-typedarray: 1.0.0
-      isstream: 0.1.2
-      json-stringify-safe: 5.0.1
-      mime-types: 2.1.35
-      oauth-sign: 0.9.0
-      performance-now: 2.1.0
-      qs: 6.5.3
-      safe-buffer: 5.2.1
-      tough-cookie: 2.5.0
-      tunnel-agent: 0.6.0
-      uuid: 3.4.0
     dev: false
 
   /require-directory/2.1.1:
@@ -4425,6 +4135,13 @@ packages:
 
   /sax/1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
+    dev: false
+
+  /saxes/5.0.1:
+    resolution: {integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==}
+    engines: {node: '>=10'}
+    dependencies:
+      xmlchars: 2.2.0
     dev: false
 
   /scheduler/0.21.0:
@@ -4519,15 +4236,6 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
-  /slice-ansi/4.0.0:
-    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      ansi-styles: 4.3.0
-      astral-regex: 2.0.0
-      is-fullwidth-code-point: 3.0.0
-    dev: false
-
   /smart-buffer/4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -4545,7 +4253,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.3
+      debug: 4.3.4
       socks: 2.6.2
     transitivePeerDependencies:
       - supports-color
@@ -4600,32 +4308,11 @@ packages:
     resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
     dev: false
 
-  /sshpk/1.17.0:
-    resolution: {integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-    dependencies:
-      asn1: 0.2.6
-      assert-plus: 1.0.0
-      bcrypt-pbkdf: 1.0.2
-      dashdash: 1.14.1
-      ecc-jsbn: 0.1.2
-      getpass: 0.1.7
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-      tweetnacl: 0.14.5
-    dev: false
-
   /stack-utils/2.0.5:
     resolution: {integrity: sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==}
     engines: {node: '>=10'}
     dependencies:
       escape-string-regexp: 2.0.0
-    dev: false
-
-  /stealthy-require/1.1.1:
-    resolution: {integrity: sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=}
-    engines: {node: '>=0.10.0'}
     dev: false
 
   /string-width/1.0.2:
@@ -4658,12 +4345,6 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /strip-ansi/0.1.1:
-    resolution: {integrity: sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=}
-    engines: {node: '>=0.8.0'}
-    hasBin: true
-    dev: false
-
   /strip-ansi/3.0.1:
     resolution: {integrity: sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=}
     engines: {node: '>=0.10.0'}
@@ -4691,11 +4372,6 @@ packages:
   /strip-json-comments/4.0.0:
     resolution: {integrity: sha512-LzWcbfMbAsEDTRmhjWIioe8GcDRl0fa35YMXFoJKDdiD/quGFmjJjdgPjFJJNwCMaLyQqFIDqCdHD2V4HfLgYA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: false
-
-  /supports-color/2.0.0:
-    resolution: {integrity: sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=}
-    engines: {node: '>=0.8.0'}
     dev: false
 
   /supports-color/5.5.0:
@@ -4728,15 +4404,14 @@ packages:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: false
 
-  /table/6.8.0:
-    resolution: {integrity: sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==}
-    engines: {node: '>=10.0.0'}
+  /table-layout/1.0.2:
+    resolution: {integrity: sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==}
+    engines: {node: '>=8.0.0'}
     dependencies:
-      ajv: 8.9.0
-      lodash.truncate: 4.4.2
-      slice-ansi: 4.0.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
+      array-back: 4.0.2
+      deep-extend: 0.6.0
+      typical: 5.2.0
+      wordwrapjs: 4.0.1
     dev: false
 
   /tar-fs/2.1.1:
@@ -4791,16 +4466,18 @@ packages:
       is-number: 7.0.0
     dev: false
 
-  /tough-cookie/2.5.0:
-    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
-    engines: {node: '>=0.8'}
+  /tough-cookie/4.0.0:
+    resolution: {integrity: sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==}
+    engines: {node: '>=6'}
     dependencies:
       psl: 1.8.0
       punycode: 2.1.1
+      universalify: 0.1.2
     dev: false
 
-  /tr46/1.0.1:
-    resolution: {integrity: sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=}
+  /tr46/3.0.0:
+    resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
+    engines: {node: '>=12'}
     dependencies:
       punycode: 2.1.1
     dev: false
@@ -4832,10 +4509,6 @@ packages:
   /tunnel/0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
-    dev: false
-
-  /tweetnacl/0.14.5:
-    resolution: {integrity: sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=}
     dev: false
 
   /type-check/0.3.2:
@@ -4871,6 +4544,16 @@ packages:
     hasBin: true
     dev: false
 
+  /typical/4.0.0:
+    resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
+    engines: {node: '>=8'}
+    dev: false
+
+  /typical/5.2.0:
+    resolution: {integrity: sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==}
+    engines: {node: '>=8'}
+    dev: false
+
   /uc.micro/1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
     dev: false
@@ -4879,8 +4562,9 @@ packages:
     resolution: {integrity: sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==}
     dev: false
 
-  /underscore/1.6.0:
-    resolution: {integrity: sha1-izixDKze9jM3uLJOT/htRa6lKag=}
+  /universalify/0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
     dev: false
 
   /upper-case-first/2.0.2:
@@ -4909,12 +4593,6 @@ packages:
     resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
     dev: false
 
-  /uuid/3.4.0:
-    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
-    hasBin: true
-    dev: false
-
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
     dev: false
@@ -4926,15 +4604,6 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.8.0
       source-map: 0.7.3
-    dev: false
-
-  /verror/1.10.0:
-    resolution: {integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=}
-    engines: {'0': node >=0.6.0}
-    dependencies:
-      assert-plus: 1.0.0
-      core-util-is: 1.0.2
-      extsprintf: 1.3.0
     dev: false
 
   /vite/2.9.1:
@@ -5038,6 +4707,13 @@ packages:
       browser-process-hrtime: 1.0.0
     dev: false
 
+  /w3c-xmlserializer/3.0.0:
+    resolution: {integrity: sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==}
+    engines: {node: '>=12'}
+    dependencies:
+      xml-name-validator: 4.0.0
+    dev: false
+
   /watch/1.0.2:
     resolution: {integrity: sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=}
     engines: {node: '>=0.1.95'}
@@ -5052,34 +4728,37 @@ packages:
     engines: {node: '>= 8'}
     dev: false
 
-  /webidl-conversions/4.0.2:
-    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+  /webidl-conversions/7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
     dev: false
 
-  /whatwg-encoding/1.0.5:
-    resolution: {integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==}
+  /whatwg-encoding/2.0.0:
+    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
+    engines: {node: '>=12'}
     dependencies:
-      iconv-lite: 0.4.24
+      iconv-lite: 0.6.3
     dev: false
 
-  /whatwg-mimetype/2.3.0:
-    resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
+  /whatwg-mimetype/3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
     dev: false
 
-  /whatwg-url/6.5.0:
-    resolution: {integrity: sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==}
+  /whatwg-url/10.0.0:
+    resolution: {integrity: sha512-CLxxCmdUby142H5FZzn4D8ikO1cmypvXVQktsgosNy4a4BHrDHeciBBGZhb0bNoR5/MltoCatso+vFjjGx8t0w==}
+    engines: {node: '>=12'}
     dependencies:
-      lodash.sortby: 4.7.0
-      tr46: 1.0.1
-      webidl-conversions: 4.0.2
+      tr46: 3.0.0
+      webidl-conversions: 7.0.0
     dev: false
 
-  /whatwg-url/7.1.0:
-    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
+  /whatwg-url/11.0.0:
+    resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
+    engines: {node: '>=12'}
     dependencies:
-      lodash.sortby: 4.7.0
-      tr46: 1.0.1
-      webidl-conversions: 4.0.2
+      tr46: 3.0.0
+      webidl-conversions: 7.0.0
     dev: false
 
   /which/2.0.2:
@@ -5101,6 +4780,14 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /wordwrapjs/4.0.1:
+    resolution: {integrity: sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      reduce-flatten: 2.0.0
+      typical: 5.2.0
+    dev: false
+
   /workerpool/6.2.0:
     resolution: {integrity: sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==}
     dev: false
@@ -5118,13 +4805,6 @@ packages:
     resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
     dev: false
 
-  /ws/4.1.0:
-    resolution: {integrity: sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==}
-    dependencies:
-      async-limiter: 1.0.1
-      safe-buffer: 5.1.2
-    dev: false
-
   /ws/8.4.2:
     resolution: {integrity: sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==}
     engines: {node: '>=10.0.0'}
@@ -5138,8 +4818,9 @@ packages:
         optional: true
     dev: false
 
-  /xml-name-validator/3.0.0:
-    resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}
+  /xml-name-validator/4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
     dev: false
 
   /xml2js/0.4.23:
@@ -5163,6 +4844,10 @@ packages:
   /xmlbuilder/9.0.7:
     resolution: {integrity: sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=}
     engines: {node: '>=4.0'}
+    dev: false
+
+  /xmlchars/2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
     dev: false
 
   /y18n/5.0.8:
@@ -5475,16 +5160,19 @@ packages:
     dev: false
 
   file:projects/spec.tgz:
-    resolution: {integrity: sha512-HE1Vn4K67ZtbJNHmj/G87VDTiKxH0MpY7tZ6UTz9wtbk6JhMoZdyoI7ZmQtSMxkHKuO6CKsnY6EOLaf/ZbIrOw==, tarball: file:projects/spec.tgz}
+    resolution: {integrity: sha512-qUzYW10+9AJa5RGTlh7PKzTtGsXNJXBLc5CWBTC+mZSP/7XymQainKfZgC/lWuUgqHJM78CjJ9IHgiTeg4GtUQ==, tarball: file:projects/spec.tgz}
     name: '@rush-temp/spec'
     version: 0.0.0
     dependencies:
       '@types/mkdirp': 1.0.2
       '@types/node': 16.0.3
-      ecmarkup: 9.8.1
+      ecmarkup: 12.0.3
       watch: 1.0.2
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - utf-8-validate
     dev: false
 
   file:projects/tmlanguage-generator.tgz:

--- a/docs/spec.html
+++ b/docs/spec.html
@@ -210,7 +210,7 @@ Search.prototype.search = function (searchString) {
   if (/^[\d.]*$/.test(searchString)) {
     results = this.biblio.clauses
       .filter(clause => clause.number.substring(0, searchString.length) === searchString)
-      .map(clause => ({ entry: clause }));
+      .map(clause => ({ key: getKey(clause), entry: clause }));
   } else {
     results = [];
 
@@ -898,6 +898,7 @@ let Toolbox = {
       e.preventDefault();
       e.stopPropagation();
       menu.togglePinEntry(this.entry.id);
+      this.$pinLink.textContent = menu._pinnedIds[this.entry.id] ? 'Unpin' : 'Pin';
     });
 
     this.$refsLink = document.createElement('a');
@@ -918,6 +919,7 @@ let Toolbox = {
     sdoBox.deactivate();
     this.active = true;
     this.entry = entry;
+    this.$pinLink.textContent = menu._pinnedIds[entry.id] ? 'Unpin' : 'Pin';
     this.$outer.classList.add('active');
     this.top = el.offsetTop - this.$outer.offsetHeight;
     this.left = el.offsetLeft - 10;
@@ -1111,6 +1113,114 @@ document.addEventListener('keypress', doShortcut);
 document.addEventListener('DOMContentLoaded', () => {
   Toolbox.init();
   referencePane.init();
+});
+
+// preserve state during navigation
+
+function getTocPath(li) {
+  let path = [];
+  let pointer = li;
+  while (true) {
+    let parent = pointer.parentElement;
+    if (parent == null) {
+      return null;
+    }
+    let index = [].indexOf.call(parent.children, pointer);
+    if (index == -1) {
+      return null;
+    }
+    path.unshift(index);
+    pointer = parent.parentElement;
+    if (pointer == null) {
+      return null;
+    }
+    if (pointer.id === 'menu-toc') {
+      break;
+    }
+    if (pointer.tagName !== 'LI') {
+      return null;
+    }
+  }
+  return path;
+}
+
+function activateTocPath(path) {
+  try {
+    let pointer = document.getElementById('menu-toc');
+    for (let index of path) {
+      pointer = pointer.querySelector('ol').children[index];
+    }
+    pointer.classList.add('active');
+  } catch (e) {
+    // pass
+  }
+}
+
+function getActiveTocPaths() {
+  return [...menu.$menu.querySelectorAll('.active')].map(getTocPath).filter(p => p != null);
+}
+
+function loadStateFromSessionStorage() {
+  if (!window.sessionStorage || typeof menu === 'undefined' || window.navigating) {
+    return;
+  }
+  if (sessionStorage.referencePaneState != null) {
+    let state = JSON.parse(sessionStorage.referencePaneState);
+    if (state != null) {
+      if (state.type === 'ref') {
+        let entry = menu.search.biblio.byId[state.id];
+        if (entry != null) {
+          referencePane.showReferencesFor(entry);
+        }
+      } else if (state.type === 'sdo') {
+        let sdos = sdoMap[state.id];
+        if (sdos != null) {
+          referencePane.$headerText.innerHTML = state.html;
+          referencePane.showSDOsBody(sdos, state.id);
+        }
+      }
+      delete sessionStorage.referencePaneState;
+    }
+  }
+
+  if (sessionStorage.activeTocPaths != null) {
+    document
+      .getElementById('menu-toc')
+      .querySelectorAll('.active')
+      .forEach(e => {
+        e.classList.remove('active');
+      });
+    let active = JSON.parse(sessionStorage.activeTocPaths);
+    active.forEach(activateTocPath);
+    delete sessionStorage.activeTocPaths;
+  }
+
+  if (sessionStorage.searchValue != null) {
+    let value = JSON.parse(sessionStorage.searchValue);
+    menu.search.$searchBox.value = value;
+    menu.search.search(value);
+    delete sessionStorage.searchValue;
+  }
+
+  if (sessionStorage.tocScroll != null) {
+    let tocScroll = JSON.parse(sessionStorage.tocScroll);
+    menu.$toc.scrollTop = tocScroll;
+    delete sessionStorage.tocScroll;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadStateFromSessionStorage);
+
+window.addEventListener('pageshow', loadStateFromSessionStorage);
+
+window.addEventListener('beforeunload', () => {
+  if (!window.sessionStorage || typeof menu === 'undefined') {
+    return;
+  }
+  sessionStorage.referencePaneState = JSON.stringify(referencePane.state || null);
+  sessionStorage.activeTocPaths = JSON.stringify(getActiveTocPaths());
+  sessionStorage.searchValue = JSON.stringify(menu.search.$searchBox.value);
+  sessionStorage.tocScroll = JSON.stringify(menu.$toc.scrollTop);
 });
 
 'use strict';
@@ -2420,68 +2530,138 @@ li.menu-search-result-term:before {
 <emu-clause id="lexical-grammar">
 <h1><span class="secnum">1</span> Lexical Grammar</h1>
 <emu-grammar type="definition"><emu-production name="SourceCharacter" id="prod-SourceCharacter">
-    <emu-nt><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="xks4vqzw"><emu-gprose>any Unicode code point</emu-gprose></emu-rhs>
+    <emu-nt><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="xks4vqzw">
+        <emu-gprose>any Unicode code point</emu-gprose>
+    </emu-rhs>
 </emu-production>
 <emu-production name="InputElement" id="prod-InputElement">
-    <emu-nt><a href="#prod-InputElement">InputElement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="orqeuwg2"><emu-nt id="_ref_0"><a href="#prod-Token">Token</a></emu-nt></emu-rhs>
-    <emu-rhs a="kg5yghiq"><emu-nt id="_ref_1"><a href="#prod-Trivia">Trivia</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-InputElement">InputElement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="orqeuwg2">
+        <emu-nt id="_ref_0"><a href="#prod-Token">Token</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="kg5yghiq">
+        <emu-nt id="_ref_1"><a href="#prod-Trivia">Trivia</a></emu-nt>
+    </emu-rhs>
 </emu-production>
 <emu-production name="Token" id="prod-Token">
-    <emu-nt><a href="#prod-Token">Token</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="o5jua5_x"><emu-nt id="_ref_2"><a href="#prod-Keyword">Keyword</a></emu-nt></emu-rhs>
-    <emu-rhs a="bras6mo_"><emu-nt id="_ref_3"><a href="#prod-Identifier">Identifier</a></emu-nt></emu-rhs>
-    <emu-rhs a="pui0b1rt"><emu-nt id="_ref_4"><a href="#prod-NumericLiteral">NumericLiteral</a></emu-nt></emu-rhs>
-    <emu-rhs a="xhtltz00"><emu-nt id="_ref_5"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt></emu-rhs>
-    <emu-rhs a="7hjz1m8p"><emu-nt id="_ref_6"><a href="#prod-Punctuator">Punctuator</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-Token">Token</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="o5jua5_x">
+        <emu-nt id="_ref_2"><a href="#prod-Keyword">Keyword</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="bras6mo_">
+        <emu-nt id="_ref_3"><a href="#prod-Identifier">Identifier</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="pui0b1rt">
+        <emu-nt id="_ref_4"><a href="#prod-NumericLiteral">NumericLiteral</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="xhtltz00">
+        <emu-nt id="_ref_5"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="7hjz1m8p">
+        <emu-nt id="_ref_6"><a href="#prod-Punctuator">Punctuator</a></emu-nt>
+    </emu-rhs>
 </emu-production>
 <emu-production name="Trivia" id="prod-Trivia">
-    <emu-nt><a href="#prod-Trivia">Trivia</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ft16wloj"><emu-nt id="_ref_7"><a href="#prod-Comment">Comment</a></emu-nt></emu-rhs>
-    <emu-rhs a="fctcswat"><emu-nt id="_ref_8"><a href="#prod-WhiteSpace">WhiteSpace</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-Trivia">Trivia</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ft16wloj">
+        <emu-nt id="_ref_7"><a href="#prod-Comment">Comment</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="fctcswat">
+        <emu-nt id="_ref_8"><a href="#prod-WhiteSpace">WhiteSpace</a></emu-nt>
+    </emu-rhs>
 </emu-production>
 <emu-production name="Keyword" id="prod-Keyword">
-    <emu-nt><a href="#prod-Keyword">Keyword</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="nqjh_sxl"><emu-nt id="_ref_9"><a href="#prod-BooleanLiteral">BooleanLiteral</a></emu-nt></emu-rhs>
-    <emu-rhs a="azcs9apw"><emu-t>import</emu-t></emu-rhs>
-    <emu-rhs a="-mdwbm0b"><emu-t>model</emu-t></emu-rhs>
-    <emu-rhs a="lpev-y-g"><emu-t>namespace</emu-t></emu-rhs>
-    <emu-rhs a="ytodrzn0"><emu-t>op</emu-t></emu-rhs>
-    <emu-rhs a="rmwjtwx9"><emu-t>extends</emu-t></emu-rhs>
-    <emu-rhs a="8d2nu2lj"><emu-t>using</emu-t></emu-rhs>
-    <emu-rhs a="71rsbeuh"><emu-t>interface</emu-t></emu-rhs>
-    <emu-rhs a="hgzzvb8j"><emu-t>union</emu-t></emu-rhs>
-    <emu-rhs a="4iwu-ggn"><emu-t>projection</emu-t></emu-rhs>
-    <emu-rhs a="llgnlz3m"><emu-t>void</emu-t></emu-rhs>
-    <emu-rhs a="vpa-nv19"><emu-t>never</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-Keyword">Keyword</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="nqjh_sxl">
+        <emu-nt id="_ref_9"><a href="#prod-BooleanLiteral">BooleanLiteral</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="azcs9apw">
+        <emu-t>import</emu-t>
+    </emu-rhs>
+    <emu-rhs a="-mdwbm0b">
+        <emu-t>model</emu-t>
+    </emu-rhs>
+    <emu-rhs a="lpev-y-g">
+        <emu-t>namespace</emu-t>
+    </emu-rhs>
+    <emu-rhs a="ytodrzn0">
+        <emu-t>op</emu-t>
+    </emu-rhs>
+    <emu-rhs a="rmwjtwx9">
+        <emu-t>extends</emu-t>
+    </emu-rhs>
+    <emu-rhs a="8d2nu2lj">
+        <emu-t>using</emu-t>
+    </emu-rhs>
+    <emu-rhs a="71rsbeuh">
+        <emu-t>interface</emu-t>
+    </emu-rhs>
+    <emu-rhs a="hgzzvb8j">
+        <emu-t>union</emu-t>
+    </emu-rhs>
+    <emu-rhs a="4iwu-ggn">
+        <emu-t>projection</emu-t>
+    </emu-rhs>
+    <emu-rhs a="llgnlz3m">
+        <emu-t>void</emu-t>
+    </emu-rhs>
+    <emu-rhs a="vpa-nv19">
+        <emu-t>never</emu-t>
+    </emu-rhs>
 </emu-production>
 <emu-production name="Identifier" id="prod-Identifier">
-    <emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="exwdmcdi"><emu-nt id="_ref_10"><a href="#prod-IdentifierName">IdentifierName</a></emu-nt> <emu-gmod>but not <emu-nt id="_ref_11"><a href="#prod-Keyword">Keyword</a></emu-nt></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-Identifier">Identifier</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="exwdmcdi">
+        <emu-nt id="_ref_10"><a href="#prod-IdentifierName">IdentifierName</a></emu-nt> <emu-gmod>but not <emu-nt id="_ref_11"><a href="#prod-Keyword">Keyword</a></emu-nt></emu-gmod>
+    </emu-rhs>
 </emu-production>
 <emu-production name="IdentifierName" id="prod-IdentifierName">
-    <emu-nt><a href="#prod-IdentifierName">IdentifierName</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="q0afq8g8"><emu-nt id="_ref_12"><a href="#prod-IdentifierStart">IdentifierStart</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-IdentifierName">IdentifierName</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="q0afq8g8">
+        <emu-nt id="_ref_12"><a href="#prod-IdentifierStart">IdentifierStart</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="amguopqs">
         <emu-nt id="_ref_13"><a href="#prod-IdentifierName">IdentifierName</a></emu-nt>
         <emu-nt id="_ref_14"><a href="#prod-IdentifierContinue">IdentifierContinue</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="IdentifierStart" id="prod-IdentifierStart">
-    <emu-nt><a href="#prod-IdentifierStart">IdentifierStart</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="exubo7yu"><emu-nt id="_ref_15"><a href="#prod-IdentifierContinue">IdentifierContinue</a></emu-nt> <emu-gmod>but not <emu-nt id="_ref_16"><a href="#prod-DecimalDigit">DecimalDigit</a></emu-nt></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-IdentifierStart">IdentifierStart</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="exubo7yu">
+        <emu-nt id="_ref_15"><a href="#prod-IdentifierContinue">IdentifierContinue</a></emu-nt> <emu-gmod>but not <emu-nt id="_ref_16"><a href="#prod-DecimalDigit">DecimalDigit</a></emu-nt></emu-gmod>
+    </emu-rhs>
 </emu-production>
 <emu-production name="IdentifierContinue" id="prod-IdentifierContinue">
-    <emu-nt><a href="#prod-IdentifierContinue">IdentifierContinue</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="7q8tumk4"><emu-nt id="_ref_17"><a href="#prod-AsciiLetter">AsciiLetter</a></emu-nt></emu-rhs>
-    <emu-rhs a="s4me4hlz"><emu-nt id="_ref_18"><a href="#prod-DecimalDigit">DecimalDigit</a></emu-nt></emu-rhs>
-    <emu-rhs a="emlmkqfm"><emu-t>$</emu-t></emu-rhs>
-    <emu-rhs a="b1zllonv"><emu-t>_</emu-t></emu-rhs>
-    <emu-rhs a="bpnwye-j"><emu-gprose>any assigned Unicode code point greater than U+007F that does not have any of the following property values: General_Category=Surrogate, Control or Private_Use, Noncharacter_Code_Point=True, or Pattern_White_Space=True</emu-gprose></emu-rhs>
+    <emu-nt><a href="#prod-IdentifierContinue">IdentifierContinue</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="7q8tumk4">
+        <emu-nt id="_ref_17"><a href="#prod-AsciiLetter">AsciiLetter</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="s4me4hlz">
+        <emu-nt id="_ref_18"><a href="#prod-DecimalDigit">DecimalDigit</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="emlmkqfm">
+        <emu-t>$</emu-t>
+    </emu-rhs>
+    <emu-rhs a="b1zllonv">
+        <emu-t>_</emu-t>
+    </emu-rhs>
+    <emu-rhs a="bpnwye-j">
+        <emu-gprose>any assigned Unicode code point greater than U+007F that does not have any of the following property values: General_Category=Surrogate, Control or Private_Use, Noncharacter_Code_Point=True, or Pattern_White_Space=True</emu-gprose>
+    </emu-rhs>
 </emu-production>
 <emu-production name="AsciiLetter" oneof="" id="prod-AsciiLetter">
     <emu-nt><a href="#prod-AsciiLetter">AsciiLetter</a></emu-nt> <emu-geq>:</emu-geq> <emu-oneof>one of</emu-oneof> <emu-rhs><emu-t>A</emu-t> <emu-t>B</emu-t> <emu-t>C</emu-t> <emu-t>D</emu-t> <emu-t>E</emu-t> <emu-t>F</emu-t> <emu-t>G</emu-t> <emu-t>H</emu-t> <emu-t>I</emu-t> <emu-t>J</emu-t> <emu-t>K</emu-t> <emu-t>L</emu-t> <emu-t>M</emu-t> <emu-t>N</emu-t> <emu-t>O</emu-t> <emu-t>P</emu-t> <emu-t>Q</emu-t> <emu-t>R</emu-t> <emu-t>S</emu-t> <emu-t>T</emu-t> <emu-t>U</emu-t> <emu-t>V</emu-t> <emu-t>W</emu-t> <emu-t>X</emu-t> <emu-t>Y</emu-t> <emu-t>Z</emu-t> <emu-t>a</emu-t> <emu-t>b</emu-t> <emu-t>c</emu-t> <emu-t>d</emu-t> <emu-t>e</emu-t> <emu-t>f</emu-t> <emu-t>g</emu-t> <emu-t>h</emu-t> <emu-t>i</emu-t> <emu-t>j</emu-t> <emu-t>k</emu-t> <emu-t>l</emu-t> <emu-t>m</emu-t> <emu-t>n</emu-t> <emu-t>o</emu-t> <emu-t>p</emu-t> <emu-t>q</emu-t> <emu-t>r</emu-t> <emu-t>s</emu-t> <emu-t>t</emu-t> <emu-t>u</emu-t> <emu-t>v</emu-t> <emu-t>w</emu-t> <emu-t>x</emu-t> <emu-t>y</emu-t> <emu-t>z</emu-t></emu-rhs>
 </emu-production>
 <emu-production name="BooleanLiteral" id="prod-BooleanLiteral">
-    <emu-nt><a href="#prod-BooleanLiteral">BooleanLiteral</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="-jc4xg27"><emu-t>true</emu-t></emu-rhs>
-    <emu-rhs a="i9lgnxtt"><emu-t>false</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-BooleanLiteral">BooleanLiteral</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="-jc4xg27">
+        <emu-t>true</emu-t>
+    </emu-rhs>
+    <emu-rhs a="i9lgnxtt">
+        <emu-t>false</emu-t>
+    </emu-rhs>
 </emu-production>
 <emu-production name="NumericLiteral" id="prod-NumericLiteral">
-    <emu-nt><a href="#prod-NumericLiteral">NumericLiteral</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="gma1bw5s"><emu-nt id="_ref_19"><a href="#prod-DecimalLiteral">DecimalLiteral</a></emu-nt></emu-rhs>
-    <emu-rhs a="hqxkzjla"><emu-nt id="_ref_20"><a href="#prod-HexIntegerLiteral">HexIntegerLiteral</a></emu-nt></emu-rhs>
-    <emu-rhs a="09cd3aiw"><emu-nt id="_ref_21"><a href="#prod-BinaryIntegerLiteral">BinaryIntegerLiteral</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-NumericLiteral">NumericLiteral</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="gma1bw5s">
+        <emu-nt id="_ref_19"><a href="#prod-DecimalLiteral">DecimalLiteral</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="hqxkzjla">
+        <emu-nt id="_ref_20"><a href="#prod-HexIntegerLiteral">HexIntegerLiteral</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="09cd3aiw">
+        <emu-nt id="_ref_21"><a href="#prod-BinaryIntegerLiteral">BinaryIntegerLiteral</a></emu-nt>
+    </emu-rhs>
 </emu-production>
 <emu-production name="DecimalLiteral" id="prod-DecimalLiteral">
     <emu-nt><a href="#prod-DecimalLiteral">DecimalLiteral</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="3xiaxvcb">
@@ -2496,7 +2676,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="DecimalIntegerLiteral" id="prod-DecimalIntegerLiteral">
-    <emu-nt><a href="#prod-DecimalIntegerLiteral">DecimalIntegerLiteral</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bxtox5eb"><emu-nt id="_ref_27"><a href="#prod-DecimalDigits">DecimalDigits</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-DecimalIntegerLiteral">DecimalIntegerLiteral</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bxtox5eb">
+        <emu-nt id="_ref_27"><a href="#prod-DecimalDigits">DecimalDigits</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="o9f-v3mh">
         <emu-t>+</emu-t>
         <emu-nt id="_ref_28"><a href="#prod-DecimalDigits">DecimalDigits</a></emu-nt>
@@ -2507,7 +2689,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="DecimalDigits" id="prod-DecimalDigits">
-    <emu-nt><a href="#prod-DecimalDigits">DecimalDigits</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="s4me4hlz"><emu-nt id="_ref_30"><a href="#prod-DecimalDigit">DecimalDigit</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-DecimalDigits">DecimalDigits</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="s4me4hlz">
+        <emu-nt id="_ref_30"><a href="#prod-DecimalDigit">DecimalDigit</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="nyugv7lw">
         <emu-nt id="_ref_31"><a href="#prod-DecimalDigits">DecimalDigits</a></emu-nt>
         <emu-nt id="_ref_32"><a href="#prod-DecimalDigit">DecimalDigit</a></emu-nt>
@@ -2523,7 +2707,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="DecimalIntegerInteger" id="prod-DecimalIntegerInteger">
-    <emu-nt><a href="#prod-DecimalIntegerInteger">DecimalIntegerInteger</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bxtox5eb"><emu-nt id="_ref_34"><a href="#prod-DecimalDigits">DecimalDigits</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-DecimalIntegerInteger">DecimalIntegerInteger</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bxtox5eb">
+        <emu-nt id="_ref_34"><a href="#prod-DecimalDigits">DecimalDigits</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="o9f-v3mh">
         <emu-t>+</emu-t>
         <emu-nt id="_ref_35"><a href="#prod-DecimalDigits">DecimalDigits</a></emu-nt>
@@ -2540,7 +2726,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="HexDigits" id="prod-HexDigits">
-    <emu-nt><a href="#prod-HexDigits">HexDigits</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="omskcs0d"><emu-nt id="_ref_38"><a href="#prod-HexDigit">HexDigit</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-HexDigits">HexDigits</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="omskcs0d">
+        <emu-nt id="_ref_38"><a href="#prod-HexDigit">HexDigit</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="yciymy2l">
         <emu-nt id="_ref_39"><a href="#prod-HexDigits">HexDigits</a></emu-nt>
         <emu-nt id="_ref_40"><a href="#prod-HexDigit">HexDigit</a></emu-nt>
@@ -2556,7 +2744,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="BinaryDigits" id="prod-BinaryDigits">
-    <emu-nt><a href="#prod-BinaryDigits">BinaryDigits</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="5fhui2lc"><emu-nt id="_ref_42"><a href="#prod-BinaryDigit">BinaryDigit</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-BinaryDigits">BinaryDigits</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="5fhui2lc">
+        <emu-nt id="_ref_42"><a href="#prod-BinaryDigit">BinaryDigit</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="gqp0qw4u">
         <emu-nt id="_ref_43"><a href="#prod-BinaryDigits">BinaryDigits</a></emu-nt>
         <emu-nt id="_ref_44"><a href="#prod-BinaryDigit">BinaryDigit</a></emu-nt>
@@ -2584,7 +2774,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="StringCharacter" id="prod-StringCharacter">
-    <emu-nt><a href="#prod-StringCharacter">StringCharacter</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="qh-v7bpd"><emu-nt id="_ref_49"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not one of <emu-t>"</emu-t> or <emu-t>\</emu-t> or <emu-nt><a href="https://tc39.es/ecma262/#prod-LineTerminator">LineTerminator</a></emu-nt></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-StringCharacter">StringCharacter</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="qh-v7bpd">
+        <emu-nt id="_ref_49"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not one of <emu-t>"</emu-t> or <emu-t>\</emu-t> or <emu-nt>LineTerminator</emu-nt></emu-gmod>
+    </emu-rhs>
     <emu-rhs a="o0wqskax">
         <emu-t>\</emu-t>
         <emu-nt id="_ref_50"><a href="#prod-EscapeCharacter">EscapeCharacter</a></emu-nt>
@@ -2597,7 +2789,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="TripleQuotedStringCharacter" id="prod-TripleQuotedStringCharacter">
-    <emu-nt><a href="#prod-TripleQuotedStringCharacter">TripleQuotedStringCharacter</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ulzuti3k"><emu-nt id="_ref_53"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not one of <emu-t>"</emu-t> or <emu-t>\</emu-t></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-TripleQuotedStringCharacter">TripleQuotedStringCharacter</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ulzuti3k">
+        <emu-nt id="_ref_53"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not one of <emu-t>"</emu-t> or <emu-t>\</emu-t></emu-gmod>
+    </emu-rhs>
     <emu-rhs a="o0wqskax">
         <emu-t>\</emu-t>
         <emu-nt id="_ref_54"><a href="#prod-EscapeCharacter">EscapeCharacter</a></emu-nt>
@@ -2610,21 +2804,47 @@ li.menu-search-result-term:before {
     <emu-nt><a href="#prod-Punctuator">Punctuator</a></emu-nt> <emu-geq>:</emu-geq> <emu-oneof>one of</emu-oneof> <emu-rhs><emu-t>|</emu-t> <emu-t>?</emu-t> <emu-t>=</emu-t> <emu-t>&amp;</emu-t> <emu-t>:</emu-t> <emu-t>,</emu-t> <emu-t>;</emu-t> <emu-t>.</emu-t> <emu-t>&lt;</emu-t> <emu-t>&gt;</emu-t> <emu-t>(</emu-t> <emu-t>)</emu-t> <emu-t>{</emu-t> <emu-t>}</emu-t> <emu-t>[</emu-t> <emu-t>]</emu-t> <emu-t>@</emu-t> <emu-t>...</emu-t> <emu-t>#</emu-t></emu-rhs>
 </emu-production>
 <emu-production name="WhiteSpace" id="prod-WhiteSpace">
-    <emu-nt><a href="#prod-WhiteSpace">WhiteSpace</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="k4soaizl"><emu-gprose>&lt;TAB&gt;</emu-gprose></emu-rhs>
-    <emu-rhs a="eznvjwhz"><emu-gprose>&lt;LF&gt;</emu-gprose></emu-rhs>
-    <emu-rhs a="w_cit1lu"><emu-gprose>&lt;VT&gt;</emu-gprose></emu-rhs>
-    <emu-rhs a="dvfflmsr"><emu-gprose>&lt;FF&gt;</emu-gprose></emu-rhs>
-    <emu-rhs a="q1yr1eki"><emu-gprose>&lt;CR&gt;</emu-gprose></emu-rhs>
-    <emu-rhs a="01dfufyk"><emu-gprose>&lt;SP&gt;</emu-gprose></emu-rhs>
-    <emu-rhs a="_fwb4uzc"><emu-gprose>&lt;NEL&gt;</emu-gprose></emu-rhs>
-    <emu-rhs a="rdfm2xfx"><emu-gprose>&lt;LRM&gt;</emu-gprose></emu-rhs>
-    <emu-rhs a="t_zqlt0-"><emu-gprose>&lt;RLM&gt;</emu-gprose></emu-rhs>
-    <emu-rhs a="eaiqsw9w"><emu-gprose>&lt;LS&gt;</emu-gprose></emu-rhs>
-    <emu-rhs a="z8h10fxn"><emu-gprose>&lt;PS&gt;</emu-gprose></emu-rhs>
+    <emu-nt><a href="#prod-WhiteSpace">WhiteSpace</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="k4soaizl">
+        <emu-gprose>&lt;TAB&gt;</emu-gprose>
+    </emu-rhs>
+    <emu-rhs a="eznvjwhz">
+        <emu-gprose>&lt;LF&gt;</emu-gprose>
+    </emu-rhs>
+    <emu-rhs a="w_cit1lu">
+        <emu-gprose>&lt;VT&gt;</emu-gprose>
+    </emu-rhs>
+    <emu-rhs a="dvfflmsr">
+        <emu-gprose>&lt;FF&gt;</emu-gprose>
+    </emu-rhs>
+    <emu-rhs a="q1yr1eki">
+        <emu-gprose>&lt;CR&gt;</emu-gprose>
+    </emu-rhs>
+    <emu-rhs a="01dfufyk">
+        <emu-gprose>&lt;SP&gt;</emu-gprose>
+    </emu-rhs>
+    <emu-rhs a="_fwb4uzc">
+        <emu-gprose>&lt;NEL&gt;</emu-gprose>
+    </emu-rhs>
+    <emu-rhs a="rdfm2xfx">
+        <emu-gprose>&lt;LRM&gt;</emu-gprose>
+    </emu-rhs>
+    <emu-rhs a="t_zqlt0-">
+        <emu-gprose>&lt;RLM&gt;</emu-gprose>
+    </emu-rhs>
+    <emu-rhs a="eaiqsw9w">
+        <emu-gprose>&lt;LS&gt;</emu-gprose>
+    </emu-rhs>
+    <emu-rhs a="z8h10fxn">
+        <emu-gprose>&lt;PS&gt;</emu-gprose>
+    </emu-rhs>
 </emu-production>
 <emu-production name="Comment" id="prod-Comment">
-    <emu-nt><a href="#prod-Comment">Comment</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="sieyeref"><emu-nt id="_ref_55"><a href="#prod-MultiLineComment">MultiLineComment</a></emu-nt></emu-rhs>
-    <emu-rhs a="sscrkqcd"><emu-nt id="_ref_56"><a href="#prod-SingleLineComment">SingleLineComment</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-Comment">Comment</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="sieyeref">
+        <emu-nt id="_ref_55"><a href="#prod-MultiLineComment">MultiLineComment</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="sscrkqcd">
+        <emu-nt id="_ref_56"><a href="#prod-SingleLineComment">SingleLineComment</a></emu-nt>
+    </emu-rhs>
 </emu-production>
 <emu-production name="MultiLineComment" id="prod-MultiLineComment">
     <emu-nt><a href="#prod-MultiLineComment">MultiLineComment</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="hhzm60cr">
@@ -2654,10 +2874,14 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="MultiLineNotAsteriskChar" id="prod-MultiLineNotAsteriskChar">
-    <emu-nt><a href="#prod-MultiLineNotAsteriskChar">MultiLineNotAsteriskChar</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="lflef8ko"><emu-nt id="_ref_64"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not <emu-t>*</emu-t></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-MultiLineNotAsteriskChar">MultiLineNotAsteriskChar</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="lflef8ko">
+        <emu-nt id="_ref_64"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not <emu-t>*</emu-t></emu-gmod>
+    </emu-rhs>
 </emu-production>
 <emu-production name="MultiLineNotForwardSlashOrAsteriskChar" id="prod-MultiLineNotForwardSlashOrAsteriskChar">
-    <emu-nt><a href="#prod-MultiLineNotForwardSlashOrAsteriskChar">MultiLineNotForwardSlashOrAsteriskChar</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="hdfnrv5z"><emu-nt id="_ref_65"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not one of <emu-t>/</emu-t> or <emu-t>*</emu-t></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-MultiLineNotForwardSlashOrAsteriskChar">MultiLineNotForwardSlashOrAsteriskChar</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="hdfnrv5z">
+        <emu-nt id="_ref_65"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not one of <emu-t>/</emu-t> or <emu-t>*</emu-t></emu-gmod>
+    </emu-rhs>
 </emu-production>
 <emu-production name="SingleLineComment" id="prod-SingleLineComment">
     <emu-nt><a href="#prod-SingleLineComment">SingleLineComment</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="u-3whel6">
@@ -2672,7 +2896,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="SingleLineCommentChar" id="prod-SingleLineCommentChar">
-    <emu-nt><a href="#prod-SingleLineCommentChar">SingleLineCommentChar</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="lvvfp8iw"><emu-nt id="_ref_69"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not <emu-nt><a href="https://tc39.es/ecma262/#prod-LineTerminator">LineTerminator</a></emu-nt></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-SingleLineCommentChar">SingleLineCommentChar</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="lvvfp8iw">
+        <emu-nt id="_ref_69"><a href="#prod-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not <emu-nt>LineTerminator</emu-nt></emu-gmod>
+    </emu-rhs>
 </emu-production>
 </emu-grammar>
 </emu-clause>
@@ -2686,9 +2912,15 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="CadlScriptItem" id="prod-CadlScriptItem">
-    <emu-nt><a href="#prod-CadlScriptItem">CadlScriptItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="sgwx93oj"><emu-nt id="_ref_72"><a href="#prod-BlocklessNamespaceStatement">BlocklessNamespaceStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="zi_5hwi0"><emu-nt id="_ref_73"><a href="#prod-ImportStatement">ImportStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="pyyivtxj"><emu-nt id="_ref_74"><a href="#prod-Statement">Statement</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-CadlScriptItem">CadlScriptItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="sgwx93oj">
+        <emu-nt id="_ref_72"><a href="#prod-BlocklessNamespaceStatement">BlocklessNamespaceStatement</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="zi_5hwi0">
+        <emu-nt id="_ref_73"><a href="#prod-ImportStatement">ImportStatement</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="pyyivtxj">
+        <emu-nt id="_ref_74"><a href="#prod-Statement">Statement</a></emu-nt>
+    </emu-rhs>
 </emu-production>
 <emu-production name="BlocklessNamespaceStatement" id="prod-BlocklessNamespaceStatement">
     <emu-nt><a href="#prod-BlocklessNamespaceStatement">BlocklessNamespaceStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="woshe1r5">
@@ -2712,14 +2944,30 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="Statement" id="prod-Statement">
-    <emu-nt><a href="#prod-Statement">Statement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ngbc4m7o"><emu-nt id="_ref_80"><a href="#prod-ModelStatement">ModelStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="qhwhhau7"><emu-nt id="_ref_81"><a href="#prod-InterfaceStatement">InterfaceStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="_ljtj5og"><emu-nt id="_ref_82"><a href="#prod-NamespaceStatement">NamespaceStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="qlyu8ssa"><emu-nt id="_ref_83"><a href="#prod-OperationStatement">OperationStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="rmuscggd"><emu-nt id="_ref_84"><a href="#prod-UsingStatement">UsingStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="fwtcv5di"><emu-nt id="_ref_85"><a href="#prod-EnumStatement">EnumStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="dzlcgyrg"><emu-nt id="_ref_86"><a href="#prod-AliasStatement">AliasStatement</a></emu-nt></emu-rhs>
-    <emu-rhs a="sg2sawim"><emu-t>;</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-Statement">Statement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ngbc4m7o">
+        <emu-nt id="_ref_80"><a href="#prod-ModelStatement">ModelStatement</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="qhwhhau7">
+        <emu-nt id="_ref_81"><a href="#prod-InterfaceStatement">InterfaceStatement</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="_ljtj5og">
+        <emu-nt id="_ref_82"><a href="#prod-NamespaceStatement">NamespaceStatement</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="qlyu8ssa">
+        <emu-nt id="_ref_83"><a href="#prod-OperationStatement">OperationStatement</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="rmuscggd">
+        <emu-nt id="_ref_84"><a href="#prod-UsingStatement">UsingStatement</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="fwtcv5di">
+        <emu-nt id="_ref_85"><a href="#prod-EnumStatement">EnumStatement</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="dzlcgyrg">
+        <emu-nt id="_ref_86"><a href="#prod-AliasStatement">AliasStatement</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="sg2sawim">
+        <emu-t>;</emu-t>
+    </emu-rhs>
 </emu-production>
 <emu-production name="UsingStatement" id="prod-UsingStatement">
     <emu-nt><a href="#prod-UsingStatement">UsingStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="nfxtjnnc">
@@ -2761,7 +3009,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ModelPropertyList" id="prod-ModelPropertyList">
-    <emu-nt><a href="#prod-ModelPropertyList">ModelPropertyList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ghoz7lyz"><emu-nt id="_ref_96"><a href="#prod-ModelProperty">ModelProperty</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ModelPropertyList">ModelPropertyList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ghoz7lyz">
+        <emu-nt id="_ref_96"><a href="#prod-ModelProperty">ModelProperty</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="vf9tzeyl">
         <emu-nt id="_ref_97"><a href="#prod-ModelPropertyList">ModelPropertyList</a></emu-nt>
         <emu-t>,</emu-t>
@@ -2774,7 +3024,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ModelProperty" id="prod-ModelProperty">
-    <emu-nt><a href="#prod-ModelProperty">ModelProperty</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="gibki9cu"><emu-nt id="_ref_101"><a href="#prod-ModelSpreadProperty">ModelSpreadProperty</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ModelProperty">ModelProperty</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="gibki9cu">
+        <emu-nt id="_ref_101"><a href="#prod-ModelSpreadProperty">ModelSpreadProperty</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="77nrmgnp">
         <emu-nt optional="" id="_ref_102"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-nt id="_ref_103"><a href="#prod-Identifier">Identifier</a></emu-nt>
@@ -2812,14 +3064,18 @@ li.menu-search-result-term:before {
         <emu-t>extends</emu-t>
         <emu-nt id="_ref_111"><a href="#prod-ReferenceExpressionList">ReferenceExpressionList</a></emu-nt>
     </emu-rhs>
-    <emu-rhs a="s2k4ex-k"><emu-nt>InterfaceBody</emu-nt></emu-rhs>
+    <emu-rhs a="s2k4ex-k">
+        <emu-nt>InterfaceBody</emu-nt>
+    </emu-rhs>
     <emu-rhs a="w_aa5rjr">
         <emu-nt id="_ref_112"><a href="#prod-InterfaceMemberList">InterfaceMemberList</a></emu-nt>
         <emu-t optional="">;<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="InterfaceMemberList" id="prod-InterfaceMemberList">
-    <emu-nt><a href="#prod-InterfaceMemberList">InterfaceMemberList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="xakzxkez"><emu-nt id="_ref_113"><a href="#prod-InterfaceMember">InterfaceMember</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-InterfaceMemberList">InterfaceMemberList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="xakzxkez">
+        <emu-nt id="_ref_113"><a href="#prod-InterfaceMember">InterfaceMember</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="erjllshi">
         <emu-nt id="_ref_114"><a href="#prod-InterfaceMemberList">InterfaceMemberList</a></emu-nt>
         <emu-t>;</emu-t>
@@ -2855,7 +3111,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="UnionVariantList" id="prod-UnionVariantList">
-    <emu-nt><a href="#prod-UnionVariantList">UnionVariantList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="cfhz-n9b"><emu-nt id="_ref_123"><a href="#prod-UnionVariant">UnionVariant</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-UnionVariantList">UnionVariantList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="cfhz-n9b">
+        <emu-nt id="_ref_123"><a href="#prod-UnionVariant">UnionVariant</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="b_wjyurc">
         <emu-nt id="_ref_124"><a href="#prod-UnionVariantList">UnionVariantList</a></emu-nt>
         <emu-t>;</emu-t>
@@ -2897,7 +3155,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="EnumMemberList" id="prod-EnumMemberList">
-    <emu-nt><a href="#prod-EnumMemberList">EnumMemberList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="vflanevg"><emu-nt id="_ref_137"><a href="#prod-EnumMember">EnumMember</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-EnumMemberList">EnumMemberList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="vflanevg">
+        <emu-nt id="_ref_137"><a href="#prod-EnumMember">EnumMember</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="7dn-cbj2">
         <emu-nt id="_ref_138"><a href="#prod-EnumMemberList">EnumMemberList</a></emu-nt>
         <emu-t>,</emu-t>
@@ -2939,7 +3199,9 @@ li.menu-search-result-term:before {
         <emu-t>=</emu-t>
         <emu-nt id="_ref_151"><a href="#prod-Expression">Expression</a></emu-nt>
     </emu-rhs>
-    <emu-rhs a="n0rgsga2"><emu-nt>TemplateParameters</emu-nt></emu-rhs>
+    <emu-rhs a="n0rgsga2">
+        <emu-nt>TemplateParameters</emu-nt>
+    </emu-rhs>
     <emu-rhs a="bedwy-8u">
         <emu-t>&lt;</emu-t>
         <emu-nt id="_ref_152"><a href="#prod-TemplateParameterList">TemplateParameterList</a></emu-nt>
@@ -2947,7 +3209,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="TemplateParameterList" id="prod-TemplateParameterList">
-    <emu-nt><a href="#prod-TemplateParameterList">TemplateParameterList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ejiqpl9p"><emu-nt id="_ref_153"><a href="#prod-TemplateParameter">TemplateParameter</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-TemplateParameterList">TemplateParameterList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ejiqpl9p">
+        <emu-nt id="_ref_153"><a href="#prod-TemplateParameter">TemplateParameter</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="sxsfhd-n">
         <emu-nt id="_ref_154"><a href="#prod-TemplateParameterList">TemplateParameterList</a></emu-nt>
         <emu-t>,</emu-t>
@@ -2967,7 +3231,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="IdentifierList" id="prod-IdentifierList">
-    <emu-nt><a href="#prod-IdentifierList">IdentifierList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bras6mo_"><emu-nt id="_ref_159"><a href="#prod-Identifier">Identifier</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-IdentifierList">IdentifierList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bras6mo_">
+        <emu-nt id="_ref_159"><a href="#prod-Identifier">Identifier</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="btxjxlll">
         <emu-nt id="_ref_160"><a href="#prod-IdentifierList">IdentifierList</a></emu-nt>
         <emu-t>,</emu-t>
@@ -2998,10 +3264,14 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="Expression" id="prod-Expression">
-    <emu-nt><a href="#prod-Expression">Expression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="otzlm2nv"><emu-nt id="_ref_169"><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-Expression">Expression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="otzlm2nv">
+        <emu-nt id="_ref_169"><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt>
+    </emu-rhs>
 </emu-production>
 <emu-production name="UnionExpressionOrHigher" id="prod-UnionExpressionOrHigher">
-    <emu-nt><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="l4bpz882"><emu-nt id="_ref_170"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="l4bpz882">
+        <emu-nt id="_ref_170"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="oiwllrbb">
         <emu-t optional="">|<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
         <emu-nt id="_ref_171"><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt>
@@ -3010,7 +3280,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="IntersectionExpressionOrHigher" id="prod-IntersectionExpressionOrHigher">
-    <emu-nt><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="fxst_igc"><emu-nt id="_ref_173"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="fxst_igc">
+        <emu-nt id="_ref_173"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="cgkcj8yb">
         <emu-t optional="">&amp;<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
         <emu-nt id="_ref_174"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt>
@@ -3019,7 +3291,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ArrayExpressionOrHigher" id="prod-ArrayExpressionOrHigher">
-    <emu-nt><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="jvcvemtw"><emu-nt id="_ref_176"><a href="#prod-PrimaryExpression">PrimaryExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="jvcvemtw">
+        <emu-nt id="_ref_176"><a href="#prod-PrimaryExpression">PrimaryExpression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="8k-eixnj">
         <emu-nt id="_ref_177"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt>
         <emu-t>[</emu-t>
@@ -3027,16 +3301,32 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="PrimaryExpression" id="prod-PrimaryExpression">
-    <emu-nt><a href="#prod-PrimaryExpression">PrimaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="kul-a19e"><emu-nt id="_ref_178"><a href="#prod-Literal">Literal</a></emu-nt></emu-rhs>
-    <emu-rhs a="mpejatd_"><emu-nt id="_ref_179"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt></emu-rhs>
-    <emu-rhs a="k5j7cutc"><emu-nt id="_ref_180"><a href="#prod-ParenthesizedExpression">ParenthesizedExpression</a></emu-nt></emu-rhs>
-    <emu-rhs a="d007fnkw"><emu-nt id="_ref_181"><a href="#prod-ModelExpression">ModelExpression</a></emu-nt></emu-rhs>
-    <emu-rhs a="rmcinm4a"><emu-nt id="_ref_182"><a href="#prod-TupleExpression">TupleExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-PrimaryExpression">PrimaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="kul-a19e">
+        <emu-nt id="_ref_178"><a href="#prod-Literal">Literal</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="mpejatd_">
+        <emu-nt id="_ref_179"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="k5j7cutc">
+        <emu-nt id="_ref_180"><a href="#prod-ParenthesizedExpression">ParenthesizedExpression</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="d007fnkw">
+        <emu-nt id="_ref_181"><a href="#prod-ModelExpression">ModelExpression</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="rmcinm4a">
+        <emu-nt id="_ref_182"><a href="#prod-TupleExpression">TupleExpression</a></emu-nt>
+    </emu-rhs>
 </emu-production>
 <emu-production name="Literal" id="prod-Literal">
-    <emu-nt><a href="#prod-Literal">Literal</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="xhtltz00"><emu-nt id="_ref_183"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt></emu-rhs>
-    <emu-rhs a="nqjh_sxl"><emu-nt id="_ref_184"><a href="#prod-BooleanLiteral">BooleanLiteral</a></emu-nt></emu-rhs>
-    <emu-rhs a="pui0b1rt"><emu-nt id="_ref_185"><a href="#prod-NumericLiteral">NumericLiteral</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-Literal">Literal</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="xhtltz00">
+        <emu-nt id="_ref_183"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="nqjh_sxl">
+        <emu-nt id="_ref_184"><a href="#prod-BooleanLiteral">BooleanLiteral</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="pui0b1rt">
+        <emu-nt id="_ref_185"><a href="#prod-NumericLiteral">NumericLiteral</a></emu-nt>
+    </emu-rhs>
 </emu-production>
 <emu-production name="ReferenceExpression" id="prod-ReferenceExpression">
     <emu-nt><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="mzr2yu9j">
@@ -3045,7 +3335,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ReferenceExpressionList" id="prod-ReferenceExpressionList">
-    <emu-nt><a href="#prod-ReferenceExpressionList">ReferenceExpressionList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="mpejatd_"><emu-nt id="_ref_188"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ReferenceExpressionList">ReferenceExpressionList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="mpejatd_">
+        <emu-nt id="_ref_188"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="ry70nwgl">
         <emu-nt id="_ref_189"><a href="#prod-ReferenceExpressionList">ReferenceExpressionList</a></emu-nt>
         <emu-t>,</emu-t>
@@ -3053,7 +3345,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="IdentifierOrMemberExpression" id="prod-IdentifierOrMemberExpression">
-    <emu-nt><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bras6mo_"><emu-nt id="_ref_191"><a href="#prod-Identifier">Identifier</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bras6mo_">
+        <emu-nt id="_ref_191"><a href="#prod-Identifier">Identifier</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="fagplbkz">
         <emu-nt id="_ref_192"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
         <emu-t>.</emu-t>
@@ -3096,7 +3390,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ExpressionList" id="prod-ExpressionList">
-    <emu-nt><a href="#prod-ExpressionList">ExpressionList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="l7avubnp"><emu-nt id="_ref_199"><a href="#prod-Expression">Expression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ExpressionList">ExpressionList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="l7avubnp">
+        <emu-nt id="_ref_199"><a href="#prod-Expression">Expression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="8cbmyyhk">
         <emu-nt id="_ref_200"><a href="#prod-ExpressionList">ExpressionList</a></emu-nt>
         <emu-t>,</emu-t>
@@ -3136,15 +3432,29 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionSelector" id="prod-ProjectionSelector">
-    <emu-nt><a href="#prod-ProjectionSelector">ProjectionSelector</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="-mdwbm0b"><emu-t>model</emu-t></emu-rhs>
-    <emu-rhs a="71rsbeuh"><emu-t>interface</emu-t></emu-rhs>
-    <emu-rhs a="ytodrzn0"><emu-t>op</emu-t></emu-rhs>
-    <emu-rhs a="hgzzvb8j"><emu-t>union</emu-t></emu-rhs>
-    <emu-rhs a="mpejatd_"><emu-nt id="_ref_212"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionSelector">ProjectionSelector</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="-mdwbm0b">
+        <emu-t>model</emu-t>
+    </emu-rhs>
+    <emu-rhs a="71rsbeuh">
+        <emu-t>interface</emu-t>
+    </emu-rhs>
+    <emu-rhs a="ytodrzn0">
+        <emu-t>op</emu-t>
+    </emu-rhs>
+    <emu-rhs a="hgzzvb8j">
+        <emu-t>union</emu-t>
+    </emu-rhs>
+    <emu-rhs a="mpejatd_">
+        <emu-nt id="_ref_212"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
+    </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionDirection" id="prod-ProjectionDirection">
-    <emu-nt><a href="#prod-ProjectionDirection">ProjectionDirection</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="cys308sz"><emu-t>to</emu-t></emu-rhs>
-    <emu-rhs a="gbwtlciv"><emu-t>from</emu-t></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionDirection">ProjectionDirection</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="cys308sz">
+        <emu-t>to</emu-t>
+    </emu-rhs>
+    <emu-rhs a="gbwtlciv">
+        <emu-t>from</emu-t>
+    </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionTag" id="prod-ProjectionTag">
     <emu-nt><a href="#prod-ProjectionTag">ProjectionTag</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="pkshwqzc">
@@ -3160,10 +3470,14 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionBody" id="prod-ProjectionBody">
-    <emu-nt><a href="#prod-ProjectionBody">ProjectionBody</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bxmgst2s"><emu-nt id="_ref_215"><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionBody">ProjectionBody</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bxmgst2s">
+        <emu-nt id="_ref_215"><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt>
+    </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionStatementList" id="prod-ProjectionStatementList">
-    <emu-nt><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="8jls0kgx"><emu-nt id="_ref_216"><a href="#prod-ProjectionStatementItem">ProjectionStatementItem</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="8jls0kgx">
+        <emu-nt id="_ref_216"><a href="#prod-ProjectionStatementItem">ProjectionStatementItem</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="123mhtoq">
         <emu-nt id="_ref_217"><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt>
         <emu-t>;</emu-t>
@@ -3171,20 +3485,28 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionStatementItem" id="prod-ProjectionStatementItem">
-    <emu-nt><a href="#prod-ProjectionStatementItem">ProjectionStatementItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ygil0lya"><emu-nt>ProjectionExpressionStatement</emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionStatementItem">ProjectionStatementItem</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ygil0lya">
+        <emu-nt>ProjectionExpressionStatement</emu-nt>
+    </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionExpression" id="prod-ProjectionExpression">
-    <emu-nt><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="vzsiuzn4"><emu-nt id="_ref_219"><a href="#prod-ProjectionReturnExpression">ProjectionReturnExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="vzsiuzn4">
+        <emu-nt id="_ref_219"><a href="#prod-ProjectionReturnExpression">ProjectionReturnExpression</a></emu-nt>
+    </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionReturnExpression" id="prod-ProjectionReturnExpression">
-    <emu-nt><a href="#prod-ProjectionReturnExpression">ProjectionReturnExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="24gnoobj"><emu-nt id="_ref_220"><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionReturnExpression">ProjectionReturnExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="24gnoobj">
+        <emu-nt id="_ref_220"><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="mxa7it1a">
         <emu-t>return</emu-t>
         <emu-nt id="_ref_221"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionLogicalOrExpression" id="prod-ProjectionLogicalOrExpression">
-    <emu-nt><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="aawamjyo"><emu-nt id="_ref_222"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="aawamjyo">
+        <emu-nt id="_ref_222"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="k589waww">
         <emu-nt id="_ref_223"><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt>
         <emu-t>||</emu-t>
@@ -3192,7 +3514,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionLogicalAndExpression" id="prod-ProjectionLogicalAndExpression">
-    <emu-nt><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="nttyzhj4"><emu-nt id="_ref_225"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="nttyzhj4">
+        <emu-nt id="_ref_225"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="evmo1uol">
         <emu-nt id="_ref_226"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt>
         <emu-t>&amp;&amp;</emu-t>
@@ -3200,7 +3524,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionEqualityExpression" id="prod-ProjectionEqualityExpression">
-    <emu-nt><a href="#prod-ProjectionEqualityExpression">ProjectionEqualityExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="nttyzhj4"><emu-nt id="_ref_228"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionEqualityExpression">ProjectionEqualityExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="nttyzhj4">
+        <emu-nt id="_ref_228"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="lackn1tw">
         <emu-nt id="_ref_229"><a href="#prod-ProjectionEqualityExpression">ProjectionEqualityExpression</a></emu-nt>
         <emu-t>==</emu-t>
@@ -3213,7 +3539,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionRelationalExpression" id="prod-ProjectionRelationalExpression">
-    <emu-nt><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="flky6l5a"><emu-nt id="_ref_233"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="flky6l5a">
+        <emu-nt id="_ref_233"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="7lkhh7co">
         <emu-nt id="_ref_234"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
         <emu-t>&lt;</emu-t>
@@ -3236,7 +3564,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionAdditiveExpression" id="prod-ProjectionAdditiveExpression">
-    <emu-nt><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="eked4n7k"><emu-nt id="_ref_242"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="eked4n7k">
+        <emu-nt id="_ref_242"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="iiox3k7e">
         <emu-nt id="_ref_243"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
         <emu-t>+</emu-t>
@@ -3249,7 +3579,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionMultiplicativeExpression" id="prod-ProjectionMultiplicativeExpression">
-    <emu-nt><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="eosbpz0i"><emu-nt id="_ref_247"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="eosbpz0i">
+        <emu-nt id="_ref_247"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="oklvxhw2">
         <emu-nt id="_ref_248"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
         <emu-t>*</emu-t>
@@ -3262,14 +3594,18 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionUnaryExpression" id="prod-ProjectionUnaryExpression">
-    <emu-nt><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="y0pnlb1i"><emu-nt id="_ref_252"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="y0pnlb1i">
+        <emu-nt id="_ref_252"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="xbyln6wd">
         <emu-t>!</emu-t>
         <emu-nt id="_ref_253"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionCallExpression" id="prod-ProjectionCallExpression">
-    <emu-nt><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bovlf96p"><emu-nt id="_ref_254"><a href="#prod-ProjectionDecoratorReferenceExpression">ProjectionDecoratorReferenceExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bovlf96p">
+        <emu-nt id="_ref_254"><a href="#prod-ProjectionDecoratorReferenceExpression">ProjectionDecoratorReferenceExpression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="dskpubvk">
         <emu-nt id="_ref_255"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
         <emu-nt id="_ref_256"><a href="#prod-ProjectionCallArguments">ProjectionCallArguments</a></emu-nt>
@@ -3293,14 +3629,18 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionDecoratorReferenceExpression" id="prod-ProjectionDecoratorReferenceExpression">
-    <emu-nt><a href="#prod-ProjectionDecoratorReferenceExpression">ProjectionDecoratorReferenceExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="upl3vrmk"><emu-nt id="_ref_262"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionDecoratorReferenceExpression">ProjectionDecoratorReferenceExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="upl3vrmk">
+        <emu-nt id="_ref_262"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="ifcyd-aq">
         <emu-t>@</emu-t>
         <emu-nt id="_ref_263"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionMemberExpression" id="prod-ProjectionMemberExpression">
-    <emu-nt><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="0yuqksdg"><emu-nt id="_ref_264"><a href="#prod-ProjectionPrimaryExpression">ProjectionPrimaryExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="0yuqksdg">
+        <emu-nt id="_ref_264"><a href="#prod-ProjectionPrimaryExpression">ProjectionPrimaryExpression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="jew6aiq_">
         <emu-nt id="_ref_265"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt>
         <emu-t>.</emu-t>
@@ -3313,14 +3653,30 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionPrimaryExpression" id="prod-ProjectionPrimaryExpression">
-    <emu-nt><a href="#prod-ProjectionPrimaryExpression">ProjectionPrimaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="gb-biqvs"><emu-t>self</emu-t></emu-rhs>
-    <emu-rhs a="bras6mo_"><emu-nt id="_ref_269"><a href="#prod-Identifier">Identifier</a></emu-nt></emu-rhs>
-    <emu-rhs a="cjpglqhg"><emu-nt id="_ref_270"><a href="#prod-ProjectionIfExpression">ProjectionIfExpression</a></emu-nt></emu-rhs>
-    <emu-rhs a="kwuqjwk9"><emu-nt id="_ref_271"><a href="#prod-ProjectionLambdaExpression">ProjectionLambdaExpression</a></emu-nt></emu-rhs>
-    <emu-rhs a="kul-a19e"><emu-nt id="_ref_272"><a href="#prod-Literal">Literal</a></emu-nt></emu-rhs>
-    <emu-rhs a="pmeanrkf"><emu-nt id="_ref_273"><a href="#prod-ProjectionModelExpression">ProjectionModelExpression</a></emu-nt></emu-rhs>
-    <emu-rhs a="0ehfrlsm"><emu-nt id="_ref_274"><a href="#prod-ProjectionTupleExpression">ProjectionTupleExpression</a></emu-nt></emu-rhs>
-    <emu-rhs a="ult0-wp7"><emu-nt id="_ref_275"><a href="#prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">CoverProjectionParenthesizedExpressionAndLambdaParameterList</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionPrimaryExpression">ProjectionPrimaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="gb-biqvs">
+        <emu-t>self</emu-t>
+    </emu-rhs>
+    <emu-rhs a="bras6mo_">
+        <emu-nt id="_ref_269"><a href="#prod-Identifier">Identifier</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="cjpglqhg">
+        <emu-nt id="_ref_270"><a href="#prod-ProjectionIfExpression">ProjectionIfExpression</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="kwuqjwk9">
+        <emu-nt id="_ref_271"><a href="#prod-ProjectionLambdaExpression">ProjectionLambdaExpression</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="kul-a19e">
+        <emu-nt id="_ref_272"><a href="#prod-Literal">Literal</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="pmeanrkf">
+        <emu-nt id="_ref_273"><a href="#prod-ProjectionModelExpression">ProjectionModelExpression</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="0ehfrlsm">
+        <emu-nt id="_ref_274"><a href="#prod-ProjectionTupleExpression">ProjectionTupleExpression</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="ult0-wp7">
+        <emu-nt id="_ref_275"><a href="#prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">CoverProjectionParenthesizedExpressionAndLambdaParameterList</a></emu-nt>
+    </emu-rhs>
 </emu-production>
 <emu-production name="CoverProjectionParenthesizedExpressionAndLambdaParameterList" id="prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">
     <emu-nt><a href="#prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">CoverProjectionParenthesizedExpressionAndLambdaParameterList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="b22wugnz">
@@ -3330,7 +3686,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionExpressionList" id="prod-ProjectionExpressionList">
-    <emu-nt><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="emksbnr7"><emu-nt id="_ref_277"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="emksbnr7">
+        <emu-nt id="_ref_277"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="if8za0tg">
         <emu-nt id="_ref_278"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt>
         <emu-t>,</emu-t>
@@ -3376,7 +3734,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionModelPropertyList" id="prod-ProjectionModelPropertyList">
-    <emu-nt><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="qnv19o8r"><emu-nt id="_ref_288"><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="qnv19o8r">
+        <emu-nt id="_ref_288"><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="k06km7_w">
         <emu-nt id="_ref_289"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
         <emu-t>,</emu-t>
@@ -3389,7 +3749,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionModelProperty" id="prod-ProjectionModelProperty">
-    <emu-nt><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="noc7fhyz"><emu-nt id="_ref_293"><a href="#prod-ProjectionModelSpreadProperty">ProjectionModelSpreadProperty</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="noc7fhyz">
+        <emu-nt id="_ref_293"><a href="#prod-ProjectionModelSpreadProperty">ProjectionModelSpreadProperty</a></emu-nt>
+    </emu-rhs>
     <emu-rhs a="6zpn0h3k">
         <emu-nt optional="" id="_ref_294"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-nt id="_ref_295"><a href="#prod-Identifier">Identifier</a></emu-nt>

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/mkdirp": "~1.0.1",
     "@types/node": "~16.0.3",
-    "ecmarkup": "~9.8.1",
+    "ecmarkup": "~12.0.3",
     "@cadl-lang/internal-build-utils": "~0.1.0"
   }
 }


### PR DESCRIPTION
Version 9.x of ecmmarkup was dependent on a few deprecated packages
![image](https://user-images.githubusercontent.com/1031227/165644581-87bbd349-bd67-4df7-819b-e44a1fce09bf.png)
