### PR TITLE
Add/improve doc for @summary and @doc

### DIFF
--- a/common/changes/@cadl-lang/compiler/doc-improvements_2022-05-02-19-24.json
+++ b/common/changes/@cadl-lang/compiler/doc-improvements_2022-05-02-19-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Improve tests for doc decorator",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -194,6 +194,8 @@ alias DogPage = Page<Dog>;
 
 Unlike `model`, `alias` does not create a new entity, and as such will not change generated code in any way. An alias merely describes a source code shorthand to avoid repeating the right-hand side in multiple places.
 
+Because alias does not create a new entity, you cannot specify decorators on an alias.
+
 ### Type Literals
 
 API authors often need to describe API shapes in terms of specific literal values. For example, this operation returns this specific integer status code, or this model member can be one of a few specific string values. It is also often useful to pass specific literal values to decorators. Cadl supports string, number, and boolean literal values to support these cases:
@@ -470,12 +472,44 @@ Dog type: Model
 
 Cadl comes built-in with a number of decorators that are useful for defining service APIs regardless of what protocol or language you're targeting.
 
+- @summary - attach a documentation string, typically a short, single-line description.
 - @doc - attach a documentation string. Works great with multi-line string literals.
 - @tag - attach a simple tag to a declaration
 - @secret - mark a string as a secret value that should be treated carefully to avoid exposure
 - @minValue/@maxValue - set the min and max values of number types
 - @minLength/@maxLength - set the min and max lengths for strings
 - @pattern - set the pattern for a string using regular expression syntax
+
+##### @summary
+
+Syntax:
+
+```
+@summary(text [, object])
+```
+
+`@summary` attaches a documentation string. It is typically used to give a short, single-line
+description, and can be used in combination with or instead of `@doc`.
+
+The first argument to `@summary` is a string, which may contain template parameters, enclosed in braces,
+which are replaced with an attribute for the type (commonly "name") passed as the second (optional) argument.
+
+`@summary` can be specified on any language element -- a model, an operation, a namespace, etc.
+
+##### @doc
+
+Syntax:
+
+```
+@doc(text [, object])
+```
+
+`@doc` attaches a documentation string. Works great with multi-line string literals.
+
+The first argument to `@doc` is a string, which may contain template parameters, enclosed in braces,
+which are replaced with an attribute for the type (commonly "name") passed as the second (optional) argument.
+
+`@doc` can be specified on any language element -- a model, an operation, a namespace, etc.
 
 ##### Visibility decorators
 

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -55,6 +55,15 @@ function setTemplatedStringProperty(
 }
 
 const summaryKey = Symbol("summary");
+/**
+ * @summary attaches a documentation string. It is typically used to give a short, single-line
+ * description, and can be used in combination with or instead of @doc.
+ *
+ * The first argument to @summary is a string, which may contain template parameters, enclosed in braces,
+ * which are replaced with an attribute for the type (commonly "name") passed as the second (optional) argument.
+ *
+ * @summary can be specified on any language element -- a model, an operation, a namespace, etc.
+ */
 export function $summary(
   { program }: DecoratorContext,
   target: Type,
@@ -69,6 +78,14 @@ export function getSummary(program: Program, type: Type): string | undefined {
 }
 
 const docsKey = Symbol("docs");
+/**
+ * @doc attaches a documentation string. Works great with multi-line string literals.
+ *
+ * The first argument to @doc is a string, which may contain template parameters, enclosed in braces,
+ * which are replaced with an attribute for the type (commonly "name") passed as the second (optional) argument.
+ *
+ * @doc can be specified on any language element -- a model, an operation, a namespace, etc.
+ */
 export function $doc(
   { program }: DecoratorContext,
   target: Type,

--- a/packages/compiler/test/decorators/decorators.ts
+++ b/packages/compiler/test/decorators/decorators.ts
@@ -49,6 +49,80 @@ describe("compiler: built-in decorators", () => {
       strictEqual(getDoc(runner.program, B), "Templated B");
     });
 
+    it("applies @doc on namespace", async () => {
+      const { TestDoc } = await runner.compile(
+        `
+        @test
+        @doc("doc for namespace")
+        namespace TestDoc {
+        }
+        `
+      );
+
+      strictEqual(getDoc(runner.program, TestDoc), "doc for namespace");
+    });
+
+    it("applies @doc on enum", async () => {
+      const { Color, Red } = await runner.compile(
+        `
+        @test
+        @doc("doc for enum")
+        enum Color {
+          @test
+          @doc("doc for enum element")
+          Red: "red",
+        }
+        `
+      );
+
+      strictEqual(getDoc(runner.program, Color), "doc for enum");
+      strictEqual(getDoc(runner.program, Red), "doc for enum element");
+    });
+
+    it("applies @doc on union", async () => {
+      const { AB } = await runner.compile(
+        `
+        model A { }
+        model B { }
+
+        @test
+        @doc("doc for union")
+        union AB { a: A, b: B }
+        `
+      );
+
+      strictEqual(getDoc(runner.program, AB), "doc for union");
+    });
+
+    it("applies @doc on interfaces", async () => {
+      const { TestDoc, a } = await runner.compile(
+        `
+        @test
+        @doc("doc for interface")
+        interface TestDoc {
+          @test
+          @doc("doc for interface operation")
+          a(): string;
+        }
+        `
+      );
+
+      strictEqual(getDoc(runner.program, TestDoc), "doc for interface");
+      strictEqual(getDoc(runner.program, a), "doc for interface operation");
+    });
+
+    it("applies @doc on operations", async () => {
+      const { b } = await runner.compile(
+        `
+        @test
+        @doc("doc for an operation")
+        op b(): string;
+        `
+      );
+
+      strictEqual(getDoc(runner.program, b), "doc for an operation");
+    });
+
     it("emit diagnostic if doc is not a string", async () => {
       const diagnostics = await runner.diagnose(`
         @doc("foo" | "bar")
@@ -63,7 +137,7 @@ describe("compiler: built-in decorators", () => {
   });
 
   describe("@friendlyName", () => {
-    it("applies @doc on model", async () => {
+    it("applies @friendlyName on model", async () => {
       const { A, B, C } = await runner.compile(`
         @test
         @friendlyName("MyNameIsA")


### PR DESCRIPTION
This is a tiny PR to add/improve documentation for the core decorators `@summary` and `@doc`.

I've added this documentation in two places:
1. As a block comment in `decorators.ts`, in the expectation that this or something very close to this can be the source for intellisense help on decorators when it is implemented, and
2. In docs/tutorial.md.  The documentation added there is more "reference" than "tutorial" but I could not find a better place for it, so I put it there.

I also added a test for `@doc` to verify that it works on all language elements.