### PR TITLE
Add documentation for key decorators in `compiler` and `rest` libs

### DIFF
--- a/common/changes/@cadl-lang/compiler/decorator-docs_2022-05-04-12-43.json
+++ b/common/changes/@cadl-lang/compiler/decorator-docs_2022-05-04-12-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/rest/decorator-docs_2022-05-04-12-43.json
+++ b/common/changes/@cadl-lang/rest/decorator-docs_2022-05-04-12-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -711,6 +711,46 @@ namespace Pets {
 
 ```
 
+##### Automatic route generation
+
+Instead of manually specifying routes using the `@route` decorator, you automatically generate
+routes from operation parameters by applying the `@autoRoute` decorator to an operation or a namespace
+or interface containing operations.
+
+For this to work, an operation's path parameters (those marked with `@path`) must also be marked with
+the `@segment` decorator to specify what the preceding path segment should be.
+
+This is especially useful when reusing common parameter sets defined as model types.
+
+For example:
+
+```
+model CommonParameters {
+  @path
+  @segment("tenants")
+  tenantId: string;
+
+  @path
+  @segment("users")
+  userName: string;
+}
+
+@autoRoute
+interface UserOperations {
+  @get
+  getUser(...CommonParameters): User | Error;
+
+  @put
+  updateUser(...CommonParameters, user: User): User | Error;
+}
+```
+
+This will result in the following route for both operations
+
+```
+/tenants/{tenantId}/users/{userName}
+```
+
 #### Path and query parameters
 
 Model properties and parameters which should be passed as path and query parameters use the `@path` and `@query` parameters respectively. Let's modify our list operation to support pagination, and add a read operation to our Pets resource:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -474,11 +474,14 @@ Cadl comes built-in with a number of decorators that are useful for defining ser
 
 - @summary - attach a documentation string, typically a short, single-line description.
 - @doc - attach a documentation string. Works great with multi-line string literals.
+- @key - mark a model property as the key to identify instances of that type
 - @tag - attach a simple tag to a declaration
 - @secret - mark a string as a secret value that should be treated carefully to avoid exposure
 - @minValue/@maxValue - set the min and max values of number types
 - @minLength/@maxLength - set the min and max lengths for strings
+- @knownValues - mark a string type with an enum that contains all known values
 - @pattern - set the pattern for a string using regular expression syntax
+- @format - specify the data format hint for a string type
 
 ##### @summary
 
@@ -510,6 +513,70 @@ The first argument to `@doc` is a string, which may contain template parameters,
 which are replaced with an attribute for the type (commonly "name") passed as the second (optional) argument.
 
 `@doc` can be specified on any language element -- a model, an operation, a namespace, etc.
+
+##### @knownValues
+
+Syntax:
+
+```
+@knownValues(enumTypeReference)
+```
+
+`@knownValues` marks a string type with an enum that contains all known values
+
+The first parameter is a reference to an enum type that enumerates all possible values that the
+type accepts.
+
+`@knownValues` can only be applied to model types that extend `string`.
+
+Example:
+
+```
+enum OperationStateValues {
+  Running,
+  Completed,
+  Failed
+}
+
+@knownValues(OperationStateValues)
+model OperationState extends string {
+}
+```
+
+##### @key
+
+Syntax:
+
+```
+@key([keyName])
+```
+
+`@key` - mark a model property as the key to identify instances of that type
+
+The optional first argument accepts an alternate key name which may be used by emitters.
+Otherwise, the name of the target property will be used.
+
+`@key` can only be applied to model properties.
+
+##### @format
+
+Syntax:
+
+```
+@format(formatName)
+```
+
+`@format` - specify the data format hint for a string type
+
+The first argument is a string that identifies the format that the string type expects. Any string
+can be entered here, but a Cadl emitter must know how to interpret
+
+For Cadl specs that will be used with an OpenAPI emitter, the OpenAPI specification describes possible
+valid values for a string type's format:
+
+https://swagger.io/specification/#data-types
+
+`@format` can be applied to a type that extends from `string` or a `string`-typed model property.
 
 ##### Visibility decorators
 

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -205,6 +205,19 @@ export function isErrorModel(program: Program, target: Type): boolean {
 
 const formatValuesKey = Symbol("formatValues");
 
+/**
+ * `@format` - specify the data format hint for a string type
+ *
+ * The first argument is a string that identifies the format that the string type expects.  Any string
+ * can be entered here, but a Cadl emitter must know how to interpret
+ *
+ * For Cadl specs that will be used with an OpenAPI emitter, the OpenAPI specification describes possible
+ * valid values for a string type's format:
+ *
+ * https://swagger.io/specification/#data-types
+ *
+ * `@format` can be specified on a type that extends from `string` or a `string`-typed model property.
+ */
 export function $format({ program }: DecoratorContext, target: Type, format: string) {
   if (
     !validateDecoratorTarget(program, target, "@format", ["Model", "ModelProperty"]) ||
@@ -585,7 +598,13 @@ export function getFriendlyName(program: Program, target: Type): string {
 
 const knownValuesKey = Symbol("knownValues");
 /**
- * Specify the known values for a string type.
+ * `@knownValues` marks a string type with an enum that contains all known values
+ *
+ * The first parameter is a reference to an enum type that describes all possible values that the
+ * type accepts.
+ *
+ * `@knownValues` can only be applied to model types that extend `string`.
+ *
  * @param target Decorator target. Must be a string. (model Foo extends string)
  * @param knownValues Must be an enum.
  */
@@ -654,6 +673,14 @@ export function getKnownValues(
 
 const keyKey = Symbol("key");
 
+/**
+ * `@key` - mark a model property as the key to identify instances of that type
+ *
+ * The optional first argument accepts an alternate key name which may be used by emitters.
+ * Otherwise, the name of the target property will be used.
+ *
+ * `@key` can only be applied to model properties.
+ */
 export function $key({ program }: DecoratorContext, entity: Type, altName?: string): void {
   if (!validateDecoratorTarget(program, entity, "@key", "ModelProperty")) {
     return;

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -14,6 +14,81 @@ npm install @cadl-lang/rest
 
 See [Rest section in the tutorial](../../docs/tutorial.md#rest-apis)
 
+## Decorators
+
+The `@cadl-lang/rest` library defines the following decorators:
+
+### `@parentResource`
+
+Syntax:
+
+```
+@parentResource(parentModelTypeReference)
+```
+
+`@parentResource` marks a model property with a reference to its parent resource type
+
+The first argument should be a reference to a model type which will be treated as the parent
+type of the target model type. This will cause the `@key` properties of all parent types of
+the target type to show up in operations of the `Resource*<T>` interfaces defined in this library.
+
+`@parentResource` can only be applied to models.
+
+### `@segment`
+
+Syntax:
+
+```
+@segment(segmentString)
+```
+
+`@segment` defines the preceding path segment for a `@path` parameter in auto-generated routes
+
+The first argument should be a string that will be inserted into the operation route before the
+path parameter's name field. For example:
+
+```
+op getUser(
+  @path
+  @segment("users")
+  userId: string
+): User
+```
+
+Would produce the route `/users/{userId}`.
+
+`@segment` can only be applied to model properties or operation parameters.
+
+### `@route`
+
+Syntax:
+
+```
+@route(routeString)
+```
+
+`@route` defines the relative route URI for the target operation
+
+The first argument should be a URI fragment that may contain one or more path parameter fields.
+If the namespace or interface that contains the operation is also marked with a `@route` decorator,
+it will be used as a prefix to the route URI of the operation.
+
+`@route` can only be applied to operations, namespaces, and interfaces.
+
+### `@autoRoute`
+
+Syntax:
+
+```
+@autoRoute()
+```
+
+`@autoRoute` enables automatic route generation for an operation, namespace, or interface.
+
+When applied to an operation, it automatically generates the operation's route based on path parameter
+metadata. When applied to a namespace or interface, it causes all operations under that scope to have
+auto-generated routes.
+
 ## See also
 
 - [Cadl Getting Started](https://github.com/microsoft/cadl#getting-started)

--- a/packages/rest/src/resource.ts
+++ b/packages/rest/src/resource.ts
@@ -163,6 +163,15 @@ export function getParentResource(
   return program.stateMap(parentResourceTypesKey).get(resourceType);
 }
 
+/**
+ * `@parentResource` marks a model property with a reference to its parent resource type
+ *
+ * The first argument should be a reference to a model type which will be treated as the parent
+ * type of the target model type.  This will cause the `@key` properties of all parent types of
+ * the target type to show up in operations of the `Resource*<T>` interfaces defined in this library.
+ *
+ * `@parentResource` can only be applied to models.
+ */
 export function $parentResource({ program }: DecoratorContext, entity: Type, parentType: Type) {
   if (!validateDecoratorTarget(program, parentType, "@parentResource", "Model")) {
     return;

--- a/packages/rest/src/rest.ts
+++ b/packages/rest/src/rest.ts
@@ -62,6 +62,15 @@ export function getDiscriminator(program: Program, entity: Type): Discriminator 
 }
 
 const segmentsKey = Symbol("segments");
+
+/**
+ * `@segment` defines the preceding path segment for a `@path` parameter in auto-generated routes
+ *
+ * The first argument should be a string that will be inserted into the operation route before the
+ * path parameter's name field.
+ *
+ * `@segment` can only be applied to model properties or operation parameters.
+ */
 export function $segment({ program }: DecoratorContext, entity: Type, name: string) {
   if (
     !validateDecoratorTarget(program, entity, "@segment", ["Model", "ModelProperty", "Operation"])

--- a/packages/rest/src/route.ts
+++ b/packages/rest/src/route.ts
@@ -67,6 +67,15 @@ export interface RoutePath {
   isReset: boolean;
 }
 
+/**
+ * `@route` defines the relative route URI for the target operation
+ *
+ * The first argument should be a URI fragment that may contain one or more path parameter fields.
+ * If the namespace or interface that contains the operation is also marked with a `@route` decorator,
+ * it will be used as a prefix to the route URI of the operation.
+ *
+ * `@route` can only be applied to operations, namespaces, and interfaces.
+ */
 export function $route({ program }: DecoratorContext, entity: Type, path: string) {
   setRoute(program, entity, {
     path,
@@ -529,6 +538,14 @@ const resourceOperationToVerb: any = {
 };
 
 const autoRouteKey = Symbol("autoRoute");
+
+/**
+ * `@autoRoute` enables automatic route generation for an operation, namespace, or interface.
+ *
+ * When applied to an operation, it automatically generates the operation's route based on path parameter
+ * metadata.  When applied to a namespace or interface, it causes all operations under that scope to have
+ * auto-generated routes.
+ */
 export function $autoRoute({ program }: DecoratorContext, entity: Type) {
   if (
     !validateDecoratorTarget(program, entity, "@autoRoute", ["Namespace", "Interface", "Operation"])


### PR DESCRIPTION
This change fixes #1419 by adding documentation for a few key decorators in the `@cadl-lang/compiler` and `@cadl-lang/rest` libraries.  It also adds some explanation of how `@autoRoute` generates routes from operation parameter metadata.