### PR TITLE
Make Program.checker required

### DIFF
--- a/common/changes/@cadl-lang/compiler/make-checker-required_2022-05-04-19-37.json
+++ b/common/changes/@cadl-lang/compiler/make-checker-required_2022-05-04-19-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Make Program.checker required",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi/make-checker-required_2022-05-04-19-37.json
+++ b/common/changes/@cadl-lang/openapi/make-checker-required_2022-05-04-19-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/openapi3/make-checker-required_2022-05-04-19-37.json
+++ b/common/changes/@cadl-lang/openapi3/make-checker-required_2022-05-04-19-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/make-checker-required_2022-05-04-19-37.json
+++ b/common/changes/@cadl-lang/rest/make-checker-required_2022-05-04-19-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/versioning/make-checker-required_2022-05-04-19-37.json
+++ b/common/changes/@cadl-lang/versioning/make-checker-required_2022-05-04-19-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/packages/compiler/core/decorator-utils.ts
+++ b/packages/compiler/core/decorator-utils.ts
@@ -166,7 +166,7 @@ export function validateDecoratorParamType<K extends Type["kind"]>(
 
 function prettyValue(program: Program, value: any) {
   if (typeof value === "object" && value !== null && "kind" in value) {
-    return program.checker!.getTypeName(value);
+    return program.checker.getTypeName(value);
   }
   return value;
 }

--- a/packages/compiler/core/program.ts
+++ b/packages/compiler/core/program.ts
@@ -49,7 +49,7 @@ export interface Program {
   literalTypes: Map<string | number | boolean, LiteralType>;
   host: CompilerHost;
   logger: Logger;
-  checker?: Checker;
+  checker: Checker;
   emitters: EmitterRef[];
   readonly diagnostics: readonly Diagnostic[];
   loadCadlScript(cadlScript: SourceFile): Promise<CadlScriptNode>;
@@ -211,6 +211,7 @@ export async function createProgram(
   const logger = createLogger({ sink: host.logSink, level: options.diagnosticLevel });
 
   const program: Program = {
+    checker: undefined!,
     compilerOptions: options,
     sourceFiles: new Map(),
     jsSourceFiles: new Map(),

--- a/packages/compiler/core/projector.ts
+++ b/packages/compiler/core/projector.ts
@@ -51,7 +51,7 @@ export function createProjector(
   startNode?: Type
 ): Projector {
   const projectedTypes = new Map<Type, Type>();
-  const checker = program.checker!;
+  const checker = program.checker;
   const neverType = checker.neverType;
   const scope: Type[] = [];
   const projector: Projector = {
@@ -66,8 +66,8 @@ export function createProjector(
   const targetGlobalNs = startNode
     ? startNode.projector
       ? startNode.projector.projectedGlobalNamespace!
-      : program.checker!.getGlobalNamespaceType()
-    : program.checker!.getGlobalNamespaceType();
+      : program.checker.getGlobalNamespaceType()
+    : program.checker.getGlobalNamespaceType();
 
   // project all the namespaces first
   projector.projectedGlobalNamespace = projectNamespace(targetGlobalNs) as NamespaceType;

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -110,7 +110,7 @@ export function $inspectTypeName(program: Program, target: Type, text: string) {
   // eslint-disable-next-line no-console
   if (text) console.log(text);
   // eslint-disable-next-line no-console
-  console.log(program.checker!.getTypeName(target));
+  console.log(program.checker.getTypeName(target));
 }
 
 const intrinsicsKey = Symbol("intrinsics");

--- a/packages/compiler/lib/service.ts
+++ b/packages/compiler/lib/service.ts
@@ -139,13 +139,13 @@ export function getServiceVersion(program: Program): string {
 
 export function getServiceNamespace(program: Program): NamespaceType | undefined {
   const serviceDetails = getServiceDetails(program);
-  return serviceDetails.namespace ?? program.checker!.getGlobalNamespaceType();
+  return serviceDetails.namespace ?? program.checker.getGlobalNamespaceType();
 }
 
 export function getServiceNamespaceString(program: Program): string | undefined {
   const serviceDetails = getServiceDetails(program);
   return (
-    (serviceDetails.namespace && program.checker!.getNamespaceString(serviceDetails.namespace)) ||
+    (serviceDetails.namespace && program.checker.getNamespaceString(serviceDetails.namespace)) ||
     undefined
   );
 }

--- a/packages/compiler/server/serverlib.ts
+++ b/packages/compiler/server/serverlib.ts
@@ -404,7 +404,7 @@ export function createServer(host: ServerHost): Server {
   async function gotoDefinition(params: DefinitionParams): Promise<Location[]> {
     const sym = await compile(params.textDocument, (program, document, file) => {
       const id = getNodeAtPosition(file, document.offsetAt(params.position));
-      return id?.kind == SyntaxKind.Identifier ? program.checker?.resolveIdentifier(id) : undefined;
+      return id?.kind == SyntaxKind.Identifier ? program.checker.resolveIdentifier(id) : undefined;
     });
     return getLocations(sym?.declarations);
   }
@@ -482,7 +482,7 @@ export function createServer(host: ServerHost): Server {
       return [];
     }
 
-    const sym = program.checker?.resolveIdentifier(id);
+    const sym = program.checker.resolveIdentifier(id);
     if (!sym) {
       return [id];
     }
@@ -492,7 +492,7 @@ export function createServer(host: ServerHost): Server {
       visitChildren(script, function visit(node) {
         if (
           node.kind === SyntaxKind.Identifier &&
-          program.checker?.resolveIdentifier(node) === sym
+          program.checker.resolveIdentifier(node) === sym
         ) {
           references.push(node);
         }
@@ -521,7 +521,7 @@ export function createServer(host: ServerHost): Server {
     node: IdentifierNode,
     completions: CompletionList
   ) {
-    const result = program.checker!.resolveCompletions(node);
+    const result = program.checker.resolveCompletions(node);
     if (result.size === 0) {
       return;
     }
@@ -536,7 +536,7 @@ export function createServer(host: ServerHost): Server {
       ) {
         kind = CompletionItemKind.Module;
       } else {
-        const type = program.checker!.getTypeForNode(sym.declarations[0]);
+        const type = program.checker.getTypeForNode(sym.declarations[0]);
         documentation = getDoc(program, type);
         kind = getCompletionItemKind(program, type);
       }

--- a/packages/compiler/test/checker/cloneType.ts
+++ b/packages/compiler/test/checker/cloneType.ts
@@ -36,7 +36,7 @@ describe("compiler: type cloning", () => {
       const { test } = (await testHost.compile("./test.cadl")) as {
         test: Type;
       };
-      const clone = testHost.program.checker!.cloneType(test);
+      const clone = testHost.program.checker.cloneType(test);
       ok(blues.has(clone!), "the clone is blue");
       deepStrictEqual(test, clone!);
     });

--- a/packages/compiler/test/checker/global-namespace.ts
+++ b/packages/compiler/test/checker/global-namespace.ts
@@ -16,7 +16,7 @@ describe("compiler: global namespace", () => {
 
       await testHost.compile("./");
 
-      const globalNamespaceType = testHost.program.checker?.getGlobalNamespaceType();
+      const globalNamespaceType = testHost.program.checker.getGlobalNamespaceType();
       assert(
         globalNamespaceType?.namespaces.get("Foo"),
         "Namespace Foo was added to global namespace type"
@@ -28,7 +28,7 @@ describe("compiler: global namespace", () => {
 
       await testHost.compile("./");
 
-      const globalNamespaceType = testHost.program.checker?.getGlobalNamespaceType();
+      const globalNamespaceType = testHost.program.checker.getGlobalNamespaceType();
       assert(
         globalNamespaceType?.models.get("MyModel"),
         "model MyModel was added to global namespace type"
@@ -40,7 +40,7 @@ describe("compiler: global namespace", () => {
 
       await testHost.compile("./");
 
-      const globalNamespaceType = testHost.program.checker?.getGlobalNamespaceType();
+      const globalNamespaceType = testHost.program.checker.getGlobalNamespaceType();
       assert(
         globalNamespaceType?.operations.get("myOperation"),
         "operation myOperation was added to global namespace type"
@@ -65,7 +65,7 @@ describe("compiler: global namespace", () => {
 
       await testHost.compile("./");
 
-      const globalNamespaceType = testHost.program.checker?.getGlobalNamespaceType();
+      const globalNamespaceType = testHost.program.checker.getGlobalNamespaceType();
       assert(
         globalNamespaceType?.namespaces.get("Foo"),
         "Namespace Foo was added to global namespace type"
@@ -81,7 +81,7 @@ describe("compiler: global namespace", () => {
 
       await testHost.compile("./");
 
-      const globalNamespaceType = testHost.program.checker?.getGlobalNamespaceType();
+      const globalNamespaceType = testHost.program.checker.getGlobalNamespaceType();
       assert(
         globalNamespaceType?.models.get("MyModel"),
         "model MyModel was added to global namespace type"
@@ -93,7 +93,7 @@ describe("compiler: global namespace", () => {
 
       await testHost.compile("./");
 
-      const globalNamespaceType = testHost.program.checker?.getGlobalNamespaceType();
+      const globalNamespaceType = testHost.program.checker.getGlobalNamespaceType();
       assert(
         globalNamespaceType?.operations.get("myOperation"),
         "operation myOperation was added to global namespace type"

--- a/packages/compiler/test/checker/interface.ts
+++ b/packages/compiler/test/checker/interface.ts
@@ -30,7 +30,7 @@ describe("compiler: interfaces", () => {
       Foo: InterfaceType;
     };
 
-    strictEqual(Foo.namespace, testHost.program.checker!.getGlobalNamespaceType());
+    strictEqual(Foo.namespace, testHost.program.checker.getGlobalNamespaceType());
     strictEqual(Foo.name, "Foo");
     strictEqual(Foo.operations.size, 1);
     const bar = Foo.operations.get("bar");

--- a/packages/compiler/test/checker/namespaces.ts
+++ b/packages/compiler/test/checker/namespaces.ts
@@ -614,8 +614,8 @@ describe("compiler: namespace type name", () => {
     );
 
     const { Model1, Model2 } = await testHost.compile("./a.cadl");
-    strictEqual(testHost.program.checker?.getTypeName(Model1), "Foo.Model1");
-    strictEqual(testHost.program.checker?.getTypeName(Model2), "Foo.Other.Bar.Model2");
+    strictEqual(testHost.program.checker.getTypeName(Model1), "Foo.Model1");
+    strictEqual(testHost.program.checker.getTypeName(Model2), "Foo.Other.Bar.Model2");
   });
 
   it("gets full name in edge case with decorators", async () => {
@@ -643,7 +643,7 @@ describe("compiler: namespace type name", () => {
     );
 
     const { SomeModel, AnotherModel } = await testHost.compile("./main.cadl");
-    const checker = testHost.program.checker!;
+    const checker = testHost.program.checker;
     strictEqual(checker.getTypeName(SomeModel), "SomeNamespace.SomeModel");
     strictEqual(checker.getTypeName(AnotherModel), "AnotherNamespace.AnotherModel");
   });

--- a/packages/compiler/test/checker/projection.ts
+++ b/packages/compiler/test/checker/projection.ts
@@ -474,7 +474,7 @@ describe("cadl: projections", () => {
         `
       );
       const { Foo } = (await testHost.compile("main.cadl")) as { Foo: OperationType };
-      const result = testHost.program.checker!.project(Foo, Foo.projections[0].to!) as ModelType;
+      const result = testHost.program.checker.project(Foo, Foo.projections[0].to!) as ModelType;
       strictEqual(result.properties.get("x")!.type.kind, "Model");
       strictEqual(result.properties.get("y")!.type.kind, "Intrinsic");
     });

--- a/packages/compiler/test/test-semantic-walker.ts
+++ b/packages/compiler/test/test-semantic-walker.ts
@@ -91,7 +91,7 @@ describe("compiler: semantic walker", () => {
     `);
 
     assert.deepStrictEqual(
-      result.namespaces.map((x) => host.program.checker!.getNamespaceString(x)),
+      result.namespaces.map((x) => host.program.checker.getNamespaceString(x)),
       ["", "Global", "Global.My", "Global.My.Simple", "Global.My.Parent", "Global.My.Parent.Child"]
     );
   });

--- a/packages/openapi/src/helpers.ts
+++ b/packages/openapi/src/helpers.ts
@@ -52,7 +52,7 @@ export function getTypeName(
   existing?: Record<string, any>
 ): string {
   const name =
-    getFriendlyName(program, type, options) ?? program.checker!.getTypeName(type, options);
+    getFriendlyName(program, type, options) ?? program.checker.getTypeName(type, options);
 
   if (existing && existing[name]) {
     reportDiagnostic(program, {
@@ -139,7 +139,7 @@ function getDefaultFriendlyName(
   if (!hasDefaultFriendlyName(program, type)) {
     return undefined;
   }
-  const ns = program.checker!.getNamespaceString(type.namespace, options);
+  const ns = program.checker.getNamespaceString(type.namespace, options);
   const model = (ns ? ns + "." : "") + type.name;
   const args = type.templateArguments.map((arg) => getTypeName(program, arg, options));
   return `${model}_${args.join("_")}`;

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -181,7 +181,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
   const typeNameOptions: TypeNameOptions = {
     // shorten type names by removing Cadl and service namespace
     namespaceFilter(ns) {
-      const name = program.checker!.getNamespaceString(ns);
+      const name = program.checker.getNamespaceString(ns);
       return name !== "Cadl" && name !== serviceNamespace;
     },
   };

--- a/packages/rest/src/resource.ts
+++ b/packages/rest/src/resource.ts
@@ -97,7 +97,7 @@ function cloneKeyProperties(context: DecoratorContext, target: ModelType, resour
     const { keyProperty } = resourceKey;
     const keyName = getKeyName(program, keyProperty);
 
-    const newProp = program.checker!.cloneType(keyProperty);
+    const newProp = program.checker.cloneType(keyProperty);
     newProp.name = keyName;
     newProp.decorators.push(
       {

--- a/packages/versioning/src/versioning.ts
+++ b/packages/versioning/src/versioning.ts
@@ -249,7 +249,7 @@ export function $onValidate(program: Program) {
           if (!(value instanceof Map)) {
             reportDiagnostic(program, {
               code: "versioned-dependency-record-not-model",
-              format: { dependency: program.checker!.getNamespaceString(dependencyNs) },
+              format: { dependency: program.checker.getNamespaceString(dependencyNs) },
               target: namespace,
             });
           }
@@ -257,7 +257,7 @@ export function $onValidate(program: Program) {
           if (typeof value !== "string") {
             reportDiagnostic(program, {
               code: "versioned-dependency-not-string",
-              format: { dependency: program.checker!.getNamespaceString(dependencyNs) },
+              format: { dependency: program.checker.getNamespaceString(dependencyNs) },
               target: namespace,
             });
           }
@@ -281,8 +281,8 @@ function validateVersionedNamespaceUsage(
         reportDiagnostic(program, {
           code: "using-versioned-library",
           format: {
-            sourceNs: program.checker!.getNamespaceString(source),
-            targetNs: program.checker!.getNamespaceString(target),
+            sourceNs: program.checker.getNamespaceString(source),
+            targetNs: program.checker.getNamespaceString(target),
           },
           target: source ?? NoTarget,
         });
@@ -318,8 +318,8 @@ export function resolveVersions(program: Program, rootNs: NamespaceType): Versio
       const map = new Map();
       for (const [dependencyNs, version] of dependencies) {
         if (typeof version !== "string") {
-          const rootNsName = program.checker!.getNamespaceString(rootNs);
-          const dependencyNsName = program.checker!.getNamespaceString(dependencyNs);
+          const rootNsName = program.checker.getNamespaceString(rootNs);
+          const dependencyNsName = program.checker.getNamespaceString(dependencyNs);
           throw new Error(
             `Unexpected error: Namespace ${rootNsName} version dependency to ${dependencyNsName} should be a string.`
           );
@@ -338,8 +338,8 @@ export function resolveVersions(program: Program, rootNs: NamespaceType): Versio
 
       for (const [dependencyNs, versionMap] of dependencies) {
         if (!(versionMap instanceof Map)) {
-          const rootNsName = program.checker!.getNamespaceString(rootNs);
-          const dependencyNsName = program.checker!.getNamespaceString(dependencyNs);
+          const rootNsName = program.checker.getNamespaceString(rootNs);
+          const dependencyNsName = program.checker.getNamespaceString(dependencyNs);
           throw new Error(
             `Unexpected error: Namespace ${rootNsName} version dependency to ${dependencyNsName} should be a mapping of version.`
           );


### PR DESCRIPTION
I did this during another change in progress out of frustration, but then realized it's going to make the diff noisy, so sending this out first.

It's an implementation detail that the checker is undefined when we're only part-way through initializing the program. Don't pass this on to consumers.