### PR TITLE
Update shared script to allow enforcing dotnet & bump min to 6

### DIFF
--- a/common/changes/@cadl-lang/internal-build-utils/net-6_2022-05-13-15-29.json
+++ b/common/changes/@cadl-lang/internal-build-utils/net-6_2022-05-13-15-29.json
@@ -1,0 +1,15 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/internal-build-utils",
+      "comment": "Dotnet tools allow enforcing dotnet as a requirement and make skipping optional",
+      "type": "minor"
+    },
+    {
+      "packageName": "@cadl-lang/internal-build-utils",
+      "comment": "Bump minimum dotnet version to dotnet6.0",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/internal-build-utils"
+}

--- a/common/changes/cadl-vs/net-6_2022-05-13-15-29.json
+++ b/common/changes/cadl-vs/net-6_2022-05-13-15-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vs",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "cadl-vs"
+}

--- a/eng/scripts/check-format.js
+++ b/eng/scripts/check-format.js
@@ -1,5 +1,8 @@
 // @ts-check
-import { runDotnetFormat } from "../../packages/internal-build-utils/dist/src/index.js";
+import {
+  ensureDotnetVersion,
+  runDotnetFormat,
+} from "../../packages/internal-build-utils/dist/src/index.js";
 import { CommandFailedError, runPrettier } from "./helpers.js";
 
 try {

--- a/eng/scripts/check-format.js
+++ b/eng/scripts/check-format.js
@@ -4,6 +4,7 @@ import { CommandFailedError, runPrettier } from "./helpers.js";
 
 try {
   runPrettier("--list-different");
+  ensureDotnetVersion({ exitIfError: true });
   runDotnetFormat("--verify-no-changes");
 } catch (err) {
   if (err instanceof CommandFailedError) {

--- a/eng/scripts/format.js
+++ b/eng/scripts/format.js
@@ -1,5 +1,10 @@
 // @ts-check
-import { runDotnetFormat } from "../../packages/internal-build-utils/dist/src/index.js";
+import {
+  ensureDotnetVersion,
+  runDotnetFormat,
+} from "../../packages/internal-build-utils/dist/src/index.js";
 import { runPrettier } from "./helpers.js";
 runPrettier("--write");
+
+await ensureDotnetVersion({ exitIfError: true });
 await runDotnetFormat();

--- a/packages/cadl-vs/scripts/build.js
+++ b/packages/cadl-vs/scripts/build.js
@@ -1,5 +1,10 @@
 // @ts-check
-import { getVisualStudioMsBuildPath, run, runDotnetOrExit } from "@cadl-lang/internal-build-utils";
+import {
+  ensureDotnetVersion,
+  getVisualStudioMsBuildPath,
+  run,
+  runDotnet,
+} from "@cadl-lang/internal-build-utils";
 import { readFile } from "fs/promises";
 import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
@@ -21,7 +26,8 @@ async function main() {
 
   const result = await getBuildTool();
   if (result.type === "dotnet") {
-    await runDotnetOrExit(["build", "--configuration", "Release", `-p:Version=${version}`], {
+    await ensureDotnetVersion({ exitIfError: true });
+    await runDotnet(["build", "--configuration", "Release", `-p:Version=${version}`], {
       cwd: pkgRoot,
     });
   } else {

--- a/packages/cadl-vs/scripts/restore.js
+++ b/packages/cadl-vs/scripts/restore.js
@@ -1,8 +1,9 @@
 // @ts-check
-import { runDotnetOrExit } from "@cadl-lang/internal-build-utils";
+import { ensureDotnetVersion, runDotnet } from "@cadl-lang/internal-build-utils";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 
 const pkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
-await runDotnetOrExit(["restore", "Microsoft.Cadl.VS.sln"], { cwd: pkgRoot });
+await ensureDotnetVersion({ exitIfError: true });
+await runDotnet(["restore", "Microsoft.Cadl.VS.sln"], { cwd: pkgRoot });

--- a/packages/internal-build-utils/src/constants.ts
+++ b/packages/internal-build-utils/src/constants.ts
@@ -1,7 +1,7 @@
 export const vsMinimumVersion = "16.9";
 
-export const minimumDotnetVersion = {
-  major: 5,
+export const MinimumDotnetVersion = {
+  major: 6,
   minor: 0,
 };
 

--- a/packages/internal-build-utils/src/dotnet.ts
+++ b/packages/internal-build-utils/src/dotnet.ts
@@ -1,8 +1,8 @@
 import { execAsync, run, RunOptions } from "./common.js";
-import { minimumDotnetVersion } from "./constants.js";
+import { MinimumDotnetVersion } from "./constants.js";
 
-export async function runDotnetOrExit(args: string[], options: RunOptions = {}) {
-  await ensureDotnetVersionOrExit();
+export async function runDotnet(args: string[], options: RunOptions = {}) {
+  await ensureDotnetVersion();
   return run("dotnet", args, options);
 }
 
@@ -19,11 +19,11 @@ export async function validateDotnetVersion(): Promise<{ error?: string }> {
     const [major, minor, _patch] = version.split(".").map((x) => parseInt(x, 10));
 
     if (
-      major < minimumDotnetVersion.major ||
-      (major === minimumDotnetVersion.major && minor < minimumDotnetVersion.minor)
+      major < MinimumDotnetVersion.major ||
+      (major === MinimumDotnetVersion.major && minor < MinimumDotnetVersion.minor)
     ) {
       return {
-        error: `dotnet command version "${version}" is not maching minimum requirement of ${minimumDotnetVersion.major}.${minimumDotnetVersion.minor}.x`,
+        error: `dotnet command version "${version}" is not maching minimum requirement of ${MinimumDotnetVersion.major}.${MinimumDotnetVersion.minor}.x`,
       };
     }
     return {};
@@ -37,7 +37,7 @@ export async function validateDotnetVersion(): Promise<{ error?: string }> {
 }
 
 let validatedDotnet = false;
-export async function ensureDotnetVersionOrExit() {
+export async function ensureDotnetVersion(options: { exitIfError?: boolean } = {}) {
   if (validatedDotnet) {
     return;
   }
@@ -45,7 +45,7 @@ export async function ensureDotnetVersionOrExit() {
   const { error } = await validateDotnetVersion();
   if (error) {
     // If running in CI/AzureDevOps fail if dotnet is invalid.
-    if (process.env.CI || process.env.TF_BUILD) {
+    if (process.env.CI || process.env.TF_BUILD || !options.exitIfError) {
       // eslint-disable-next-line no-console
       console.error(`error: ${error}`);
       process.exit(1);
@@ -63,7 +63,7 @@ export async function ensureDotnetVersionOrExit() {
  * Runs the dotnet formatter.
  */
 export async function runDotnetFormat(...args: string[]) {
-  return runDotnetOrExit([
+  return runDotnet([
     "format",
     "whitespace",
     ".",


### PR DESCRIPTION
- Update the dotnet build utils to allow enforcing dotnet as a requirement. 
**Dotnet remains optional in this repo.**
- Bump minimum dotnet to net6