### PR TITLE
Add @readOnly decorator for OpenAPI

### DIFF
--- a/common/changes/@cadl-lang/openapi/read-only-decorator_2022-05-13-14-46.json
+++ b/common/changes/@cadl-lang/openapi/read-only-decorator_2022-05-13-14-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "Add @readOnly decorator for OpenAPI",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/openapi3/read-only-decorator_2022-05-13-14-46.json
+++ b/common/changes/@cadl-lang/openapi3/read-only-decorator_2022-05-13-14-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Add @readOnly decorator for OpenAPI",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/docs/cadl-for-openapi-dev.md
+++ b/docs/cadl-for-openapi-dev.md
@@ -50,6 +50,12 @@ For `type: string` data types:
 | `maxLength: value`          | `@maxLength(value)` decorator |       |
 | `pattern: regex`            | `@pattern(regex)` decorator   |       |
 
+Use the `@readOnly` decorator to specify that a property of any type should be marked `readOnly: true`:
+
+| OpenAPI/JSON Schema keyword | Cadl construct        | Notes |
+| --------------------------- | --------------------- | ----- |
+| `readOnly: true`            | `@readOnly` decorator |       |
+
 There are two ways to define an `enum` data type. One is with the [Cadl `enum` statement](https://github.com/microsoft/cadl/blob/main/docs/tutorial.md#enums), e.g.:
 
 ```cadl

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -91,6 +91,25 @@ export function isDefaultResponse(program: Program, entity: Type): boolean {
   return program.stateSet(defaultResponseKey).has(entity);
 }
 
+const readOnlyKey = Symbol("readOnly");
+/**
+ * @readOnly marks a property to set as "readOnly: true" in an OpenAPI schema.
+ *
+ * @readOnly accepts no arguments.
+ *
+ * @readOnly can be specified on model property. It throws an error when applied to any other language element.
+ */
+export function $readOnly({ program }: DecoratorContext, entity: Type) {
+  if (!validateDecoratorTarget(program, entity, "@readOnly", "ModelProperty")) {
+    return;
+  }
+  program.stateSet(readOnlyKey).add(entity);
+}
+
+export function getReadOnly(program: Program, entity: Type): boolean {
+  return program.stateSet(readOnlyKey).has(entity);
+}
+
 export interface ExternalDocs {
   url: string;
   description?: string;

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -22,7 +22,6 @@ import {
   getServiceTitle,
   getServiceVersion,
   getSummary,
-  getVisibility,
   isErrorType,
   isIntrinsic,
   isNumericType,
@@ -45,6 +44,7 @@ import {
   getExternalDocs,
   getOperationId,
   getParameterKey,
+  getReadOnly,
   getTypeName,
   shouldInline,
 } from "@cadl-lang/openapi";
@@ -866,8 +866,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       }
 
       // Should the property be marked as readOnly?
-      const vis = getVisibility(program, prop);
-      if (vis && vis.includes("read") && vis.length == 1) {
+      if (getReadOnly(program, prop)) {
         modelSchema.properties[name].readOnly = true;
       }
 

--- a/packages/openapi3/test/test-openapi-output.ts
+++ b/packages/openapi3/test/test-openapi-output.ts
@@ -443,6 +443,29 @@ describe("openapi3: definitions", () => {
     });
   });
 
+  it("defines readOnly properties", async () => {
+    const res = await oapiForModel(
+      "Pet",
+      `
+      model Pet {
+        @readOnly
+        name: string;
+      };
+      `
+    );
+    ok(res.isRef);
+    deepStrictEqual(res.schemas.Pet, {
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          readOnly: true,
+        },
+      },
+      required: ["name"],
+    });
+  });
+
   it("defines nullable properties", async () => {
     const res = await oapiForModel(
       "Pet",

--- a/packages/samples/test/output/visibility/openapi.json
+++ b/packages/samples/test/output/visibility/openapi.json
@@ -103,8 +103,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string",
-            "readOnly": true
+            "type": "string"
           },
           "name": {
             "type": "string"

--- a/packages/samples/testserver/body-complex/body-complex.cadl
+++ b/packages/samples/testserver/body-complex/body-complex.cadl
@@ -88,8 +88,8 @@ model DictionaryWrapper {
 }
 
 model ReadonlyObj {
-  @visibility("read") id: int32;
-  @visibility("read") size: int32;
+  @readOnly id: int32;
+  @readOnly size: int32;
 }
 
 @doc("AutoRest Complex Body Test Service")


### PR DESCRIPTION
This PR adds the @readOnly decorator to OpenAPI and changes the openapi3 emitter to use this rather than @visibility("read") to set `readOnly: true` on schema properties.

Fixes #453 