### PR TITLE
Fix prerelease publishing for packages with no change

### DIFF
--- a/common/changes/@cadl-lang/internal-build-utils/fix-prerelease-publish_2022-05-17-04-23.json
+++ b/common/changes/@cadl-lang/internal-build-utils/fix-prerelease-publish_2022-05-17-04-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/internal-build-utils",
+      "comment": "Fix prerelease publishing for packages with no changes.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/internal-build-utils"
+}

--- a/packages/internal-build-utils/src/prerelease.ts
+++ b/packages/internal-build-utils/src/prerelease.ts
@@ -107,10 +107,10 @@ function updateDependencyVersions(packageManifest: PackageJson, updatedPackages:
 
 async function addPrereleaseNumber(
   changeCounts: Record<string, number>,
-  packagePaths: Record<string, { path: string; version: string }>
+  packages: Record<string, { path: string; version: string }>
 ) {
   const updatedManifests: Record<string, BumpManifest> = {};
-  for (const [packageName, packageInfo] of Object.entries(packagePaths)) {
+  for (const [packageName, packageInfo] of Object.entries(packages)) {
     const changeCount = changeCounts[packageName] ?? 0;
     const packageJsonPath = join(packageInfo.path, "package.json");
     const packageJsonContent = await readJsonFile<PackageJson>(packageJsonPath);
@@ -139,14 +139,14 @@ async function addPrereleaseNumber(
 
 export async function bumpVersionsForPrerelease(workspaceRoots: string[]) {
   let changeCounts = {};
-  let packagePaths: Record<string, { path: string; version: string }> = {};
+  let packages: Record<string, { path: string; version: string }> = {};
   for (const workspaceRoot of workspaceRoots) {
     changeCounts = { ...changeCounts, ...(await getChangeCountPerPackage(workspaceRoot)) };
 
-    packagePaths = { ...packagePaths, ...(await getPackages(workspaceRoot)) };
+    packages = { ...packages, ...(await getPackages(workspaceRoot)) };
   }
   console.log("Change counts: ", changeCounts);
-  console.log("Package paths", packagePaths);
+  console.log("Packages", packages);
 
   // Bumping with rush publish so rush computes from the changes what will be the next non prerelease version.
   console.log("Bumping versions with rush publish");
@@ -160,7 +160,7 @@ export async function bumpVersionsForPrerelease(workspaceRoots: string[]) {
   }
 
   console.log("Adding prerelease number");
-  await addPrereleaseNumber(changeCounts, packagePaths);
+  await addPrereleaseNumber(changeCounts, packages);
 }
 
 async function findAllFiles(dir: string): Promise<string[]> {

--- a/packages/internal-build-utils/src/prerelease.ts
+++ b/packages/internal-build-utils/src/prerelease.ts
@@ -119,15 +119,6 @@ async function addPrereleaseNumber(
         ? packageInfo.version // Use existing version. Bug in rush --partial-prerelease not working
         : `${packageJsonContent.version}.${changeCount}`;
 
-    // if (!packageJsonContent.version.endsWith(`-${PRERELEASE_TYPE}`)) {
-    //   throw new Error(
-    //     [
-    //       `Couldn't add change count to package '${packageName}'. Version ${packageJsonContent.version} should be ending with '-${PRERELEASE_TYPE}'`,
-    //       `This means that the rush publish --apply --publish didn't bump this package version but this script found 1 change. Appending the change count would result in an invalid version.`,
-    //     ].join("\n")
-    //   );
-    // }
-
     console.log(`Setting version for ${packageName} to '${newVersion}'`);
     updatedManifests[packageName] = {
       packageJsonPath,


### PR DESCRIPTION
Issue with rush publish with `--partial-prerelease` not actually working at all and still adding `-dev` to all packages even if there is no changes causing an invalid version