### PR TITLE
Provide a better diagnostic when the main file of a library is not found

### DIFF
--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -375,6 +375,12 @@ const diagnostics = {
       default: paramMessage`Couldn't find library "${"path"}"`,
     },
   },
+  "library-invalid": {
+    severity: "error",
+    messages: {
+      default: paramMessage`Library "${"path"}" has an invalid cadlMain configuration.`,
+    },
+  },
   "compiler-version-mismatch": {
     severity: "error",
     messages: {

--- a/packages/compiler/core/program.ts
+++ b/packages/compiler/core/program.ts
@@ -468,6 +468,11 @@ export async function createProgram(
               createDiagnostic({ code: "library-not-found", format: { path }, target })
             );
             continue;
+          } else if (e.code === "INVALID_MAIN") {
+            program.reportDiagnostic(
+              createDiagnostic({ code: "library-invalid", format: { path }, target })
+            );
+            continue;
           } else {
             throw e;
           }


### PR DESCRIPTION
When loading library with invalid `cadlMain` file
![image](https://user-images.githubusercontent.com/1031227/169925755-a81e042c-7b04-484c-8285-445b8b15e474.png)

When loading an emitter with invalid `main` file
![image](https://user-images.githubusercontent.com/1031227/169925712-7f46d7f3-9624-49a7-bef4-6cb74c4cc631.png)
