### PR TITLE
Add support for operation templates and operation signature reuse

### DIFF
--- a/common/changes/@cadl-lang/compiler/operation-templates_2022-05-25-12-20.json
+++ b/common/changes/@cadl-lang/compiler/operation-templates_2022-05-25-12-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add support for operation templates and operation signature reuse",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/rest/operation-templates_2022-05-25-13-10.json
+++ b/common/changes/@cadl-lang/rest/operation-templates_2022-05-25-13-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Skip templated operations when scanning for operation routes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/cadl-vscode/operation-templates_2022-06-02-16-12.json
+++ b/common/changes/cadl-vscode/operation-templates_2022-06-02-16-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vscode",
+      "comment": "Update tmLanguage grammar for operation signature support",
+      "type": "minor"
+    }
+  ],
+  "packageName": "cadl-vscode"
+}

--- a/docs/spec.html
+++ b/docs/spec.html
@@ -3256,8 +3256,8 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="OperationSignatureReference" id="prod-OperationSignatureReference">
-    <emu-nt><a href="#prod-OperationSignatureReference">OperationSignatureReference</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="_vfnudru">
-        <emu-t>:</emu-t>
+    <emu-nt><a href="#prod-OperationSignatureReference">OperationSignatureReference</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="jm_bzxxi">
+        <emu-t>is</emu-t>
         <emu-nt id="_ref_166"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>

--- a/docs/spec.html
+++ b/docs/spec.html
@@ -1255,7 +1255,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 let sdoMap = JSON.parse(`{}`);
-let biblio = JSON.parse(`{"refsByClause":{"lexical-grammar":["_ref_0","_ref_1","_ref_2","_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_9","_ref_10","_ref_11","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23","_ref_24","_ref_25","_ref_26","_ref_27","_ref_28","_ref_29","_ref_30","_ref_31","_ref_32","_ref_33","_ref_34","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45","_ref_46","_ref_47","_ref_48","_ref_49","_ref_50","_ref_51","_ref_52","_ref_53","_ref_54","_ref_55","_ref_56","_ref_57","_ref_58","_ref_59","_ref_60","_ref_61","_ref_62","_ref_63","_ref_64","_ref_65","_ref_66","_ref_67","_ref_68","_ref_69"],"syntactic-grammar":["_ref_70","_ref_71","_ref_72","_ref_73","_ref_74","_ref_75","_ref_76","_ref_77","_ref_78","_ref_79","_ref_80","_ref_81","_ref_82","_ref_83","_ref_84","_ref_85","_ref_86","_ref_87","_ref_88","_ref_89","_ref_90","_ref_91","_ref_92","_ref_93","_ref_94","_ref_95","_ref_96","_ref_97","_ref_98","_ref_99","_ref_100","_ref_101","_ref_102","_ref_103","_ref_104","_ref_105","_ref_106","_ref_107","_ref_108","_ref_109","_ref_110","_ref_111","_ref_112","_ref_113","_ref_114","_ref_115","_ref_116","_ref_117","_ref_118","_ref_119","_ref_120","_ref_121","_ref_122","_ref_123","_ref_124","_ref_125","_ref_126","_ref_127","_ref_128","_ref_129","_ref_130","_ref_131","_ref_132","_ref_133","_ref_134","_ref_135","_ref_136","_ref_137","_ref_138","_ref_139","_ref_140","_ref_141","_ref_142","_ref_143","_ref_144","_ref_145","_ref_146","_ref_147","_ref_148","_ref_149","_ref_150","_ref_151","_ref_152","_ref_153","_ref_154","_ref_155","_ref_156","_ref_157","_ref_158","_ref_159","_ref_160","_ref_161","_ref_162","_ref_163","_ref_164","_ref_165","_ref_166","_ref_167","_ref_168","_ref_169","_ref_170","_ref_171","_ref_172","_ref_173","_ref_174","_ref_175","_ref_176","_ref_177","_ref_178","_ref_179","_ref_180","_ref_181","_ref_182","_ref_183","_ref_184","_ref_185","_ref_186","_ref_187","_ref_188","_ref_189","_ref_190","_ref_191","_ref_192","_ref_193","_ref_194","_ref_195","_ref_196","_ref_197","_ref_198","_ref_199","_ref_200","_ref_201","_ref_202","_ref_203","_ref_204","_ref_205","_ref_206","_ref_207","_ref_208","_ref_209","_ref_210","_ref_211","_ref_212","_ref_213","_ref_214","_ref_215","_ref_216","_ref_217","_ref_218","_ref_219","_ref_220","_ref_221","_ref_222","_ref_223","_ref_224","_ref_225","_ref_226","_ref_227","_ref_228","_ref_229","_ref_230","_ref_231","_ref_232","_ref_233","_ref_234","_ref_235","_ref_236","_ref_237","_ref_238","_ref_239","_ref_240","_ref_241","_ref_242","_ref_243","_ref_244","_ref_245","_ref_246","_ref_247","_ref_248","_ref_249","_ref_250","_ref_251","_ref_252","_ref_253","_ref_254","_ref_255","_ref_256","_ref_257","_ref_258","_ref_259","_ref_260","_ref_261","_ref_262","_ref_263","_ref_264","_ref_265","_ref_266","_ref_267","_ref_268","_ref_269","_ref_270","_ref_271","_ref_272","_ref_273","_ref_274","_ref_275","_ref_276","_ref_277","_ref_278","_ref_279","_ref_280","_ref_281","_ref_282","_ref_283","_ref_284","_ref_285","_ref_286","_ref_287","_ref_288","_ref_289","_ref_290","_ref_291","_ref_292","_ref_293","_ref_294","_ref_295","_ref_296","_ref_297","_ref_298","_ref_299","_ref_300","_ref_301","_ref_302","_ref_303","_ref_304","_ref_305"]},"entries":[{"type":"clause","id":"intro","titleHTML":"Introduction","number":""},{"type":"production","id":"prod-SourceCharacter","name":"SourceCharacter","referencingIds":["_ref_49","_ref_53","_ref_64","_ref_65","_ref_69"]},{"type":"production","id":"prod-InputElement","name":"InputElement"},{"type":"production","id":"prod-Token","name":"Token","referencingIds":["_ref_0"]},{"type":"production","id":"prod-Trivia","name":"Trivia","referencingIds":["_ref_1"]},{"type":"production","id":"prod-Keyword","name":"Keyword","referencingIds":["_ref_2","_ref_11"]},{"type":"production","id":"prod-Identifier","name":"Identifier","referencingIds":["_ref_3","_ref_89","_ref_103","_ref_109","_ref_116","_ref_120","_ref_127","_ref_133","_ref_143","_ref_150","_ref_156","_ref_159","_ref_161","_ref_166","_ref_191","_ref_193","_ref_213","_ref_258","_ref_260","_ref_266","_ref_268","_ref_269","_ref_295"]},{"type":"production","id":"prod-IdentifierName","name":"IdentifierName","referencingIds":["_ref_10","_ref_13"]},{"type":"production","id":"prod-IdentifierStart","name":"IdentifierStart","referencingIds":["_ref_12"]},{"type":"production","id":"prod-IdentifierContinue","name":"IdentifierContinue","referencingIds":["_ref_14","_ref_15"]},{"type":"production","id":"prod-AsciiLetter","name":"AsciiLetter","referencingIds":["_ref_17"]},{"type":"production","id":"prod-BooleanLiteral","name":"BooleanLiteral","referencingIds":["_ref_9","_ref_184"]},{"type":"production","id":"prod-NumericLiteral","name":"NumericLiteral","referencingIds":["_ref_4","_ref_149","_ref_185"]},{"type":"production","id":"prod-DecimalLiteral","name":"DecimalLiteral","referencingIds":["_ref_19"]},{"type":"production","id":"prod-DecimalIntegerLiteral","name":"DecimalIntegerLiteral","referencingIds":["_ref_22","_ref_25","_ref_33"]},{"type":"production","id":"prod-DecimalDigits","name":"DecimalDigits","referencingIds":["_ref_23","_ref_27","_ref_28","_ref_29","_ref_31","_ref_34","_ref_35","_ref_36"]},{"type":"production","id":"prod-DecimalDigit","name":"DecimalDigit","referencingIds":["_ref_16","_ref_18","_ref_30","_ref_32"]},{"type":"production","id":"prod-ExponentPart","name":"ExponentPart","referencingIds":["_ref_24","_ref_26"]},{"type":"production","id":"prod-DecimalIntegerInteger","name":"DecimalIntegerInteger"},{"type":"production","id":"prod-HexIntegerLiteral","name":"HexIntegerLiteral","referencingIds":["_ref_20"]},{"type":"production","id":"prod-HexDigits","name":"HexDigits","referencingIds":["_ref_37","_ref_39"]},{"type":"production","id":"prod-HexDigit","name":"HexDigit","referencingIds":["_ref_38","_ref_40"]},{"type":"production","id":"prod-BinaryIntegerLiteral","name":"BinaryIntegerLiteral","referencingIds":["_ref_21"]},{"type":"production","id":"prod-BinaryDigits","name":"BinaryDigits","referencingIds":["_ref_41","_ref_43"]},{"type":"production","id":"prod-BinaryDigit","name":"BinaryDigit","referencingIds":["_ref_42","_ref_44"]},{"type":"production","id":"prod-StringLiteral","name":"StringLiteral","referencingIds":["_ref_5","_ref_77","_ref_106","_ref_130","_ref_146","_ref_148","_ref_183","_ref_298"]},{"type":"production","id":"prod-StringCharacters","name":"StringCharacters","referencingIds":["_ref_45","_ref_48"]},{"type":"production","id":"prod-StringCharacter","name":"StringCharacter","referencingIds":["_ref_47"]},{"type":"production","id":"prod-TripleQuotedStringCharacters","name":"TripleQuotedStringCharacters","referencingIds":["_ref_46","_ref_52"]},{"type":"production","id":"prod-TripleQuotedStringCharacter","name":"TripleQuotedStringCharacter","referencingIds":["_ref_51"]},{"type":"production","id":"prod-EscapeCharacter","name":"EscapeCharacter","referencingIds":["_ref_50","_ref_54"]},{"type":"production","id":"prod-Punctuator","name":"Punctuator","referencingIds":["_ref_6"]},{"type":"production","id":"prod-WhiteSpace","name":"WhiteSpace","referencingIds":["_ref_8"]},{"type":"production","id":"prod-Comment","name":"Comment","referencingIds":["_ref_7"]},{"type":"production","id":"prod-MultiLineComment","name":"MultiLineComment","referencingIds":["_ref_55"]},{"type":"production","id":"prod-MultiLineCommentChars","name":"MultiLineCommentChars","referencingIds":["_ref_57","_ref_59","_ref_62"]},{"type":"production","id":"prod-PostAsteriskCommentChars","name":"PostAsteriskCommentChars","referencingIds":["_ref_60","_ref_63"]},{"type":"production","id":"prod-MultiLineNotAsteriskChar","name":"MultiLineNotAsteriskChar","referencingIds":["_ref_58"]},{"type":"production","id":"prod-MultiLineNotForwardSlashOrAsteriskChar","name":"MultiLineNotForwardSlashOrAsteriskChar","referencingIds":["_ref_61"]},{"type":"production","id":"prod-SingleLineComment","name":"SingleLineComment","referencingIds":["_ref_56"]},{"type":"production","id":"prod-SingleLineCommentChars","name":"SingleLineCommentChars","referencingIds":["_ref_66","_ref_68"]},{"type":"production","id":"prod-SingleLineCommentChar","name":"SingleLineCommentChar","referencingIds":["_ref_67"]},{"type":"clause","id":"lexical-grammar","titleHTML":"Lexical Grammar","number":"1"},{"type":"production","id":"prod-CadlScriptItemList","name":"CadlScriptItemList","referencingIds":["_ref_70"]},{"type":"production","id":"prod-CadlScriptItem","name":"CadlScriptItem","referencingIds":["_ref_71"]},{"type":"production","id":"prod-BlocklessNamespaceStatement","name":"BlocklessNamespaceStatement","referencingIds":["_ref_72"]},{"type":"production","id":"prod-ImportStatement","name":"ImportStatement","referencingIds":["_ref_73"]},{"type":"production","id":"prod-StatementList","name":"StatementList","referencingIds":["_ref_78","_ref_164"]},{"type":"production","id":"prod-Statement","name":"Statement","referencingIds":["_ref_74","_ref_79"]},{"type":"production","id":"prod-UsingStatement","name":"UsingStatement","referencingIds":["_ref_84"]},{"type":"production","id":"prod-ModelStatement","name":"ModelStatement","referencingIds":["_ref_80"]},{"type":"production","id":"prod-ModelHeritage","name":"ModelHeritage","referencingIds":["_ref_90"]},{"type":"production","id":"prod-ModelBody","name":"ModelBody","referencingIds":["_ref_91","_ref_197"]},{"type":"production","id":"prod-ModelPropertyList","name":"ModelPropertyList","referencingIds":["_ref_94","_ref_95","_ref_97","_ref_99","_ref_117","_ref_167"]},{"type":"production","id":"prod-ModelProperty","name":"ModelProperty","referencingIds":["_ref_96","_ref_98","_ref_100"]},{"type":"production","id":"prod-ModelSpreadProperty","name":"ModelSpreadProperty","referencingIds":["_ref_101"]},{"type":"production","id":"prod-InterfaceStatement","name":"InterfaceStatement","referencingIds":["_ref_81"]},{"type":"production","id":"prod-InterfaceHeritage","name":"InterfaceHeritage","referencingIds":["_ref_110"]},{"type":"production","id":"prod-InterfaceMemberList","name":"InterfaceMemberList","referencingIds":["_ref_112","_ref_114"]},{"type":"production","id":"prod-InterfaceMember","name":"InterfaceMember","referencingIds":["_ref_113","_ref_115"]},{"type":"production","id":"prod-UnionStatement","name":"UnionStatement"},{"type":"production","id":"prod-UnionBody","name":"UnionBody","referencingIds":["_ref_121"]},{"type":"production","id":"prod-UnionVariantList","name":"UnionVariantList","referencingIds":["_ref_122","_ref_124"]},{"type":"production","id":"prod-UnionVariant","name":"UnionVariant","referencingIds":["_ref_123","_ref_125"]},{"type":"production","id":"prod-EnumStatement","name":"EnumStatement","referencingIds":["_ref_85"]},{"type":"production","id":"prod-EnumBody","name":"EnumBody","referencingIds":["_ref_134"]},{"type":"production","id":"prod-EnumMemberList","name":"EnumMemberList","referencingIds":["_ref_135","_ref_136","_ref_138","_ref_140"]},{"type":"production","id":"prod-EnumMember","name":"EnumMember","referencingIds":["_ref_137","_ref_139","_ref_141"]},{"type":"production","id":"prod-EnumMemberValue","name":"EnumMemberValue","referencingIds":["_ref_144","_ref_147"]},{"type":"production","id":"prod-AliasStatement","name":"AliasStatement","referencingIds":["_ref_86"]},{"type":"production","id":"prod-TemplateParameterList","name":"TemplateParameterList","referencingIds":["_ref_152","_ref_154"]},{"type":"production","id":"prod-TemplateParameter","name":"TemplateParameter","referencingIds":["_ref_153","_ref_155"]},{"type":"production","id":"prod-TemplateParameterDefault","name":"TemplateParameterDefault","referencingIds":["_ref_157"]},{"type":"production","id":"prod-IdentifierList","name":"IdentifierList","referencingIds":["_ref_160","_ref_214","_ref_305"]},{"type":"production","id":"prod-NamespaceStatement","name":"NamespaceStatement","referencingIds":["_ref_82"]},{"type":"production","id":"prod-OperationStatement","name":"OperationStatement","referencingIds":["_ref_83"]},{"type":"production","id":"prod-Expression","name":"Expression","referencingIds":["_ref_104","_ref_107","_ref_118","_ref_128","_ref_131","_ref_151","_ref_158","_ref_168","_ref_196","_ref_199","_ref_201"]},{"type":"production","id":"prod-UnionExpressionOrHigher","name":"UnionExpressionOrHigher","referencingIds":["_ref_169","_ref_171"]},{"type":"production","id":"prod-IntersectionExpressionOrHigher","name":"IntersectionExpressionOrHigher","referencingIds":["_ref_170","_ref_172","_ref_174"]},{"type":"production","id":"prod-ArrayExpressionOrHigher","name":"ArrayExpressionOrHigher","referencingIds":["_ref_173","_ref_175","_ref_177"]},{"type":"production","id":"prod-PrimaryExpression","name":"PrimaryExpression","referencingIds":["_ref_176"]},{"type":"production","id":"prod-Literal","name":"Literal","referencingIds":["_ref_178","_ref_272"]},{"type":"production","id":"prod-ReferenceExpression","name":"ReferenceExpression","referencingIds":["_ref_92","_ref_93","_ref_108","_ref_179","_ref_188","_ref_190","_ref_212"]},{"type":"production","id":"prod-ReferenceExpressionList","name":"ReferenceExpressionList","referencingIds":["_ref_111","_ref_189"]},{"type":"production","id":"prod-IdentifierOrMemberExpression","name":"IdentifierOrMemberExpression","referencingIds":["_ref_76","_ref_87","_ref_163","_ref_186","_ref_192","_ref_204","_ref_263"]},{"type":"production","id":"prod-TemplateArguments","name":"TemplateArguments","referencingIds":["_ref_187"]},{"type":"production","id":"prod-ProjectionArguments","name":"ProjectionArguments"},{"type":"production","id":"prod-ParenthesizedExpression","name":"ParenthesizedExpression","referencingIds":["_ref_180"]},{"type":"production","id":"prod-ModelExpression","name":"ModelExpression","referencingIds":["_ref_181"]},{"type":"production","id":"prod-TupleExpression","name":"TupleExpression","referencingIds":["_ref_182"]},{"type":"production","id":"prod-ExpressionList","name":"ExpressionList","referencingIds":["_ref_194","_ref_195","_ref_198","_ref_200","_ref_206"]},{"type":"production","id":"prod-DecoratorList","name":"DecoratorList","referencingIds":["_ref_75","_ref_88","_ref_102","_ref_105","_ref_119","_ref_126","_ref_129","_ref_132","_ref_142","_ref_145","_ref_162","_ref_165","_ref_202","_ref_294","_ref_297"]},{"type":"production","id":"prod-Decorator","name":"Decorator","referencingIds":["_ref_203"]},{"type":"production","id":"prod-DecoratorArguments","name":"DecoratorArguments","referencingIds":["_ref_205"]},{"type":"production","id":"prod-ProjectionStatement","name":"ProjectionStatement"},{"type":"production","id":"prod-ProjectionSelector","name":"ProjectionSelector","referencingIds":["_ref_207"]},{"type":"production","id":"prod-ProjectionDirection","name":"ProjectionDirection","referencingIds":["_ref_208"]},{"type":"production","id":"prod-ProjectionTag","name":"ProjectionTag","referencingIds":["_ref_209"]},{"type":"production","id":"prod-ProjectionParameters","name":"ProjectionParameters","referencingIds":["_ref_210"]},{"type":"production","id":"prod-ProjectionBody","name":"ProjectionBody","referencingIds":["_ref_211"]},{"type":"production","id":"prod-ProjectionStatementList","name":"ProjectionStatementList","referencingIds":["_ref_215","_ref_217"]},{"type":"production","id":"prod-ProjectionStatementItem","name":"ProjectionStatementItem","referencingIds":["_ref_216","_ref_218"]},{"type":"production","id":"prod-ProjectionExpression","name":"ProjectionExpression","referencingIds":["_ref_221","_ref_277","_ref_279","_ref_280","_ref_281","_ref_283","_ref_296","_ref_299","_ref_300"]},{"type":"production","id":"prod-ProjectionReturnExpression","name":"ProjectionReturnExpression","referencingIds":["_ref_219"]},{"type":"production","id":"prod-ProjectionLogicalOrExpression","name":"ProjectionLogicalOrExpression","referencingIds":["_ref_220","_ref_223"]},{"type":"production","id":"prod-ProjectionLogicalAndExpression","name":"ProjectionLogicalAndExpression","referencingIds":["_ref_222","_ref_224","_ref_226"]},{"type":"production","id":"prod-ProjectionEqualityExpression","name":"ProjectionEqualityExpression","referencingIds":["_ref_229","_ref_231"]},{"type":"production","id":"prod-ProjectionRelationalExpression","name":"ProjectionRelationalExpression","referencingIds":["_ref_225","_ref_227","_ref_228","_ref_230","_ref_232","_ref_234","_ref_236","_ref_238","_ref_240"]},{"type":"production","id":"prod-ProjectionAdditiveExpression","name":"ProjectionAdditiveExpression","referencingIds":["_ref_233","_ref_235","_ref_237","_ref_239","_ref_241","_ref_243","_ref_245"]},{"type":"production","id":"prod-ProjectionMultiplicativeExpression","name":"ProjectionMultiplicativeExpression","referencingIds":["_ref_242","_ref_244","_ref_246","_ref_248","_ref_250"]},{"type":"production","id":"prod-ProjectionUnaryExpression","name":"ProjectionUnaryExpression","referencingIds":["_ref_247","_ref_249","_ref_251","_ref_253"]},{"type":"production","id":"prod-ProjectionCallExpression","name":"ProjectionCallExpression","referencingIds":["_ref_252","_ref_255","_ref_257","_ref_259"]},{"type":"production","id":"prod-ProjectionCallArguments","name":"ProjectionCallArguments","referencingIds":["_ref_256"]},{"type":"production","id":"prod-ProjectionDecoratorReferenceExpression","name":"ProjectionDecoratorReferenceExpression","referencingIds":["_ref_254"]},{"type":"production","id":"prod-ProjectionMemberExpression","name":"ProjectionMemberExpression","referencingIds":["_ref_262","_ref_265","_ref_267"]},{"type":"production","id":"prod-ProjectionPrimaryExpression","name":"ProjectionPrimaryExpression","referencingIds":["_ref_264"]},{"type":"production","id":"prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList","name":"CoverProjectionParenthesizedExpressionAndLambdaParameterList","referencingIds":["_ref_275","_ref_302"]},{"type":"production","id":"prod-ProjectionExpressionList","name":"ProjectionExpressionList","referencingIds":["_ref_261","_ref_276","_ref_278","_ref_301","_ref_304"]},{"type":"production","id":"prod-ProjectionIfExpression","name":"ProjectionIfExpression","referencingIds":["_ref_270","_ref_284"]},{"type":"production","id":"prod-ProjectionModelExpression","name":"ProjectionModelExpression","referencingIds":["_ref_273"]},{"type":"production","id":"prod-ProjectionModelBody","name":"ProjectionModelBody","referencingIds":["_ref_285"]},{"type":"production","id":"prod-ProjectionModelPropertyList","name":"ProjectionModelPropertyList","referencingIds":["_ref_286","_ref_287","_ref_289","_ref_291"]},{"type":"production","id":"prod-ProjectionModelProperty","name":"ProjectionModelProperty","referencingIds":["_ref_288","_ref_290","_ref_292"]},{"type":"production","id":"prod-ProjectionModelSpreadProperty","name":"ProjectionModelSpreadProperty","referencingIds":["_ref_293"]},{"type":"production","id":"prod-ProjectionTupleExpression","name":"ProjectionTupleExpression","referencingIds":["_ref_274"]},{"type":"production","id":"prod-ProjectionLambdaExpression","name":"ProjectionLambdaExpression","referencingIds":["_ref_271"]},{"type":"production","id":"prod-ProjectionBlockExpression","name":"ProjectionBlockExpression","referencingIds":["_ref_282","_ref_303"]},{"type":"production","id":"prod-LambdaParameters","name":"LambdaParameters"},{"type":"clause","id":"syntactic-grammar","titleHTML":"Syntactic Grammar","number":"2"}]}`);
+let biblio = JSON.parse(`{"refsByClause":{"lexical-grammar":["_ref_0","_ref_1","_ref_2","_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_9","_ref_10","_ref_11","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23","_ref_24","_ref_25","_ref_26","_ref_27","_ref_28","_ref_29","_ref_30","_ref_31","_ref_32","_ref_33","_ref_34","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45","_ref_46","_ref_47","_ref_48","_ref_49","_ref_50","_ref_51","_ref_52","_ref_53","_ref_54","_ref_55","_ref_56","_ref_57","_ref_58","_ref_59","_ref_60","_ref_61","_ref_62","_ref_63","_ref_64","_ref_65","_ref_66","_ref_67","_ref_68","_ref_69"],"syntactic-grammar":["_ref_70","_ref_71","_ref_72","_ref_73","_ref_74","_ref_75","_ref_76","_ref_77","_ref_78","_ref_79","_ref_80","_ref_81","_ref_82","_ref_83","_ref_84","_ref_85","_ref_86","_ref_87","_ref_88","_ref_89","_ref_90","_ref_91","_ref_92","_ref_93","_ref_94","_ref_95","_ref_96","_ref_97","_ref_98","_ref_99","_ref_100","_ref_101","_ref_102","_ref_103","_ref_104","_ref_105","_ref_106","_ref_107","_ref_108","_ref_109","_ref_110","_ref_111","_ref_112","_ref_113","_ref_114","_ref_115","_ref_116","_ref_117","_ref_118","_ref_119","_ref_120","_ref_121","_ref_122","_ref_123","_ref_124","_ref_125","_ref_126","_ref_127","_ref_128","_ref_129","_ref_130","_ref_131","_ref_132","_ref_133","_ref_134","_ref_135","_ref_136","_ref_137","_ref_138","_ref_139","_ref_140","_ref_141","_ref_142","_ref_143","_ref_144","_ref_145","_ref_146","_ref_147","_ref_148","_ref_149","_ref_150","_ref_151","_ref_152","_ref_153","_ref_154","_ref_155","_ref_156","_ref_157","_ref_158","_ref_159","_ref_160","_ref_161","_ref_162","_ref_163","_ref_164","_ref_165","_ref_166","_ref_167","_ref_168","_ref_169","_ref_170","_ref_171","_ref_172","_ref_173","_ref_174","_ref_175","_ref_176","_ref_177","_ref_178","_ref_179","_ref_180","_ref_181","_ref_182","_ref_183","_ref_184","_ref_185","_ref_186","_ref_187","_ref_188","_ref_189","_ref_190","_ref_191","_ref_192","_ref_193","_ref_194","_ref_195","_ref_196","_ref_197","_ref_198","_ref_199","_ref_200","_ref_201","_ref_202","_ref_203","_ref_204","_ref_205","_ref_206","_ref_207","_ref_208","_ref_209","_ref_210","_ref_211","_ref_212","_ref_213","_ref_214","_ref_215","_ref_216","_ref_217","_ref_218","_ref_219","_ref_220","_ref_221","_ref_222","_ref_223","_ref_224","_ref_225","_ref_226","_ref_227","_ref_228","_ref_229","_ref_230","_ref_231","_ref_232","_ref_233","_ref_234","_ref_235","_ref_236","_ref_237","_ref_238","_ref_239","_ref_240","_ref_241","_ref_242","_ref_243","_ref_244","_ref_245","_ref_246","_ref_247","_ref_248","_ref_249","_ref_250","_ref_251","_ref_252","_ref_253","_ref_254","_ref_255","_ref_256","_ref_257","_ref_258","_ref_259","_ref_260","_ref_261","_ref_262","_ref_263","_ref_264","_ref_265","_ref_266","_ref_267","_ref_268","_ref_269","_ref_270","_ref_271","_ref_272","_ref_273","_ref_274","_ref_275","_ref_276","_ref_277","_ref_278","_ref_279","_ref_280","_ref_281","_ref_282","_ref_283","_ref_284","_ref_285","_ref_286","_ref_287","_ref_288","_ref_289","_ref_290","_ref_291","_ref_292","_ref_293","_ref_294","_ref_295","_ref_296","_ref_297","_ref_298","_ref_299","_ref_300","_ref_301","_ref_302","_ref_303","_ref_304","_ref_305","_ref_306","_ref_307","_ref_308","_ref_309","_ref_310"]},"entries":[{"type":"clause","id":"intro","titleHTML":"Introduction","number":""},{"type":"production","id":"prod-SourceCharacter","name":"SourceCharacter","referencingIds":["_ref_49","_ref_53","_ref_64","_ref_65","_ref_69"]},{"type":"production","id":"prod-InputElement","name":"InputElement"},{"type":"production","id":"prod-Token","name":"Token","referencingIds":["_ref_0"]},{"type":"production","id":"prod-Trivia","name":"Trivia","referencingIds":["_ref_1"]},{"type":"production","id":"prod-Keyword","name":"Keyword","referencingIds":["_ref_2","_ref_11"]},{"type":"production","id":"prod-Identifier","name":"Identifier","referencingIds":["_ref_3","_ref_89","_ref_103","_ref_109","_ref_116","_ref_120","_ref_127","_ref_133","_ref_143","_ref_150","_ref_156","_ref_159","_ref_161","_ref_171","_ref_196","_ref_198","_ref_218","_ref_263","_ref_265","_ref_271","_ref_273","_ref_274","_ref_300"]},{"type":"production","id":"prod-IdentifierName","name":"IdentifierName","referencingIds":["_ref_10","_ref_13"]},{"type":"production","id":"prod-IdentifierStart","name":"IdentifierStart","referencingIds":["_ref_12"]},{"type":"production","id":"prod-IdentifierContinue","name":"IdentifierContinue","referencingIds":["_ref_14","_ref_15"]},{"type":"production","id":"prod-AsciiLetter","name":"AsciiLetter","referencingIds":["_ref_17"]},{"type":"production","id":"prod-BooleanLiteral","name":"BooleanLiteral","referencingIds":["_ref_9","_ref_189"]},{"type":"production","id":"prod-NumericLiteral","name":"NumericLiteral","referencingIds":["_ref_4","_ref_149","_ref_190"]},{"type":"production","id":"prod-DecimalLiteral","name":"DecimalLiteral","referencingIds":["_ref_19"]},{"type":"production","id":"prod-DecimalIntegerLiteral","name":"DecimalIntegerLiteral","referencingIds":["_ref_22","_ref_25","_ref_33"]},{"type":"production","id":"prod-DecimalDigits","name":"DecimalDigits","referencingIds":["_ref_23","_ref_27","_ref_28","_ref_29","_ref_31","_ref_34","_ref_35","_ref_36"]},{"type":"production","id":"prod-DecimalDigit","name":"DecimalDigit","referencingIds":["_ref_16","_ref_18","_ref_30","_ref_32"]},{"type":"production","id":"prod-ExponentPart","name":"ExponentPart","referencingIds":["_ref_24","_ref_26"]},{"type":"production","id":"prod-DecimalIntegerInteger","name":"DecimalIntegerInteger"},{"type":"production","id":"prod-HexIntegerLiteral","name":"HexIntegerLiteral","referencingIds":["_ref_20"]},{"type":"production","id":"prod-HexDigits","name":"HexDigits","referencingIds":["_ref_37","_ref_39"]},{"type":"production","id":"prod-HexDigit","name":"HexDigit","referencingIds":["_ref_38","_ref_40"]},{"type":"production","id":"prod-BinaryIntegerLiteral","name":"BinaryIntegerLiteral","referencingIds":["_ref_21"]},{"type":"production","id":"prod-BinaryDigits","name":"BinaryDigits","referencingIds":["_ref_41","_ref_43"]},{"type":"production","id":"prod-BinaryDigit","name":"BinaryDigit","referencingIds":["_ref_42","_ref_44"]},{"type":"production","id":"prod-StringLiteral","name":"StringLiteral","referencingIds":["_ref_5","_ref_77","_ref_106","_ref_130","_ref_146","_ref_148","_ref_188","_ref_303"]},{"type":"production","id":"prod-StringCharacters","name":"StringCharacters","referencingIds":["_ref_45","_ref_48"]},{"type":"production","id":"prod-StringCharacter","name":"StringCharacter","referencingIds":["_ref_47"]},{"type":"production","id":"prod-TripleQuotedStringCharacters","name":"TripleQuotedStringCharacters","referencingIds":["_ref_46","_ref_52"]},{"type":"production","id":"prod-TripleQuotedStringCharacter","name":"TripleQuotedStringCharacter","referencingIds":["_ref_51"]},{"type":"production","id":"prod-EscapeCharacter","name":"EscapeCharacter","referencingIds":["_ref_50","_ref_54"]},{"type":"production","id":"prod-Punctuator","name":"Punctuator","referencingIds":["_ref_6"]},{"type":"production","id":"prod-WhiteSpace","name":"WhiteSpace","referencingIds":["_ref_8"]},{"type":"production","id":"prod-Comment","name":"Comment","referencingIds":["_ref_7"]},{"type":"production","id":"prod-MultiLineComment","name":"MultiLineComment","referencingIds":["_ref_55"]},{"type":"production","id":"prod-MultiLineCommentChars","name":"MultiLineCommentChars","referencingIds":["_ref_57","_ref_59","_ref_62"]},{"type":"production","id":"prod-PostAsteriskCommentChars","name":"PostAsteriskCommentChars","referencingIds":["_ref_60","_ref_63"]},{"type":"production","id":"prod-MultiLineNotAsteriskChar","name":"MultiLineNotAsteriskChar","referencingIds":["_ref_58"]},{"type":"production","id":"prod-MultiLineNotForwardSlashOrAsteriskChar","name":"MultiLineNotForwardSlashOrAsteriskChar","referencingIds":["_ref_61"]},{"type":"production","id":"prod-SingleLineComment","name":"SingleLineComment","referencingIds":["_ref_56"]},{"type":"production","id":"prod-SingleLineCommentChars","name":"SingleLineCommentChars","referencingIds":["_ref_66","_ref_68"]},{"type":"production","id":"prod-SingleLineCommentChar","name":"SingleLineCommentChar","referencingIds":["_ref_67"]},{"type":"clause","id":"lexical-grammar","titleHTML":"Lexical Grammar","number":"1"},{"type":"production","id":"prod-CadlScriptItemList","name":"CadlScriptItemList","referencingIds":["_ref_70"]},{"type":"production","id":"prod-CadlScriptItem","name":"CadlScriptItem","referencingIds":["_ref_71"]},{"type":"production","id":"prod-BlocklessNamespaceStatement","name":"BlocklessNamespaceStatement","referencingIds":["_ref_72"]},{"type":"production","id":"prod-ImportStatement","name":"ImportStatement","referencingIds":["_ref_73"]},{"type":"production","id":"prod-StatementList","name":"StatementList","referencingIds":["_ref_78","_ref_164"]},{"type":"production","id":"prod-Statement","name":"Statement","referencingIds":["_ref_74","_ref_79"]},{"type":"production","id":"prod-UsingStatement","name":"UsingStatement","referencingIds":["_ref_84"]},{"type":"production","id":"prod-ModelStatement","name":"ModelStatement","referencingIds":["_ref_80"]},{"type":"production","id":"prod-ModelHeritage","name":"ModelHeritage","referencingIds":["_ref_90"]},{"type":"production","id":"prod-ModelBody","name":"ModelBody","referencingIds":["_ref_91","_ref_202"]},{"type":"production","id":"prod-ModelPropertyList","name":"ModelPropertyList","referencingIds":["_ref_94","_ref_95","_ref_97","_ref_99","_ref_117","_ref_165"]},{"type":"production","id":"prod-ModelProperty","name":"ModelProperty","referencingIds":["_ref_96","_ref_98","_ref_100"]},{"type":"production","id":"prod-ModelSpreadProperty","name":"ModelSpreadProperty","referencingIds":["_ref_101"]},{"type":"production","id":"prod-InterfaceStatement","name":"InterfaceStatement","referencingIds":["_ref_81"]},{"type":"production","id":"prod-InterfaceHeritage","name":"InterfaceHeritage","referencingIds":["_ref_110"]},{"type":"production","id":"prod-InterfaceMemberList","name":"InterfaceMemberList","referencingIds":["_ref_112","_ref_114"]},{"type":"production","id":"prod-InterfaceMember","name":"InterfaceMember","referencingIds":["_ref_113","_ref_115"]},{"type":"production","id":"prod-UnionStatement","name":"UnionStatement"},{"type":"production","id":"prod-UnionBody","name":"UnionBody","referencingIds":["_ref_121"]},{"type":"production","id":"prod-UnionVariantList","name":"UnionVariantList","referencingIds":["_ref_122","_ref_124"]},{"type":"production","id":"prod-UnionVariant","name":"UnionVariant","referencingIds":["_ref_123","_ref_125"]},{"type":"production","id":"prod-EnumStatement","name":"EnumStatement","referencingIds":["_ref_85"]},{"type":"production","id":"prod-EnumBody","name":"EnumBody","referencingIds":["_ref_134"]},{"type":"production","id":"prod-EnumMemberList","name":"EnumMemberList","referencingIds":["_ref_135","_ref_136","_ref_138","_ref_140"]},{"type":"production","id":"prod-EnumMember","name":"EnumMember","referencingIds":["_ref_137","_ref_139","_ref_141"]},{"type":"production","id":"prod-EnumMemberValue","name":"EnumMemberValue","referencingIds":["_ref_144","_ref_147"]},{"type":"production","id":"prod-AliasStatement","name":"AliasStatement","referencingIds":["_ref_86"]},{"type":"production","id":"prod-TemplateParameterList","name":"TemplateParameterList","referencingIds":["_ref_152","_ref_154"]},{"type":"production","id":"prod-TemplateParameter","name":"TemplateParameter","referencingIds":["_ref_153","_ref_155"]},{"type":"production","id":"prod-TemplateParameterDefault","name":"TemplateParameterDefault","referencingIds":["_ref_157"]},{"type":"production","id":"prod-IdentifierList","name":"IdentifierList","referencingIds":["_ref_160","_ref_219","_ref_310"]},{"type":"production","id":"prod-NamespaceStatement","name":"NamespaceStatement","referencingIds":["_ref_82"]},{"type":"production","id":"prod-OperationSignatureDeclaration","name":"OperationSignatureDeclaration","referencingIds":["_ref_168"]},{"type":"production","id":"prod-OperationSignatureReference","name":"OperationSignatureReference","referencingIds":["_ref_169"]},{"type":"production","id":"prod-OperationSignature","name":"OperationSignature","referencingIds":["_ref_173"]},{"type":"production","id":"prod-OperationStatement","name":"OperationStatement","referencingIds":["_ref_83"]},{"type":"production","id":"prod-Expression","name":"Expression","referencingIds":["_ref_104","_ref_107","_ref_118","_ref_128","_ref_131","_ref_151","_ref_158","_ref_166","_ref_201","_ref_204","_ref_206"]},{"type":"production","id":"prod-UnionExpressionOrHigher","name":"UnionExpressionOrHigher","referencingIds":["_ref_174","_ref_176"]},{"type":"production","id":"prod-IntersectionExpressionOrHigher","name":"IntersectionExpressionOrHigher","referencingIds":["_ref_175","_ref_177","_ref_179"]},{"type":"production","id":"prod-ArrayExpressionOrHigher","name":"ArrayExpressionOrHigher","referencingIds":["_ref_178","_ref_180","_ref_182"]},{"type":"production","id":"prod-PrimaryExpression","name":"PrimaryExpression","referencingIds":["_ref_181"]},{"type":"production","id":"prod-Literal","name":"Literal","referencingIds":["_ref_183","_ref_277"]},{"type":"production","id":"prod-ReferenceExpression","name":"ReferenceExpression","referencingIds":["_ref_92","_ref_93","_ref_108","_ref_167","_ref_184","_ref_193","_ref_195","_ref_217"]},{"type":"production","id":"prod-ReferenceExpressionList","name":"ReferenceExpressionList","referencingIds":["_ref_111","_ref_194"]},{"type":"production","id":"prod-IdentifierOrMemberExpression","name":"IdentifierOrMemberExpression","referencingIds":["_ref_76","_ref_87","_ref_163","_ref_191","_ref_197","_ref_209","_ref_268"]},{"type":"production","id":"prod-TemplateArguments","name":"TemplateArguments","referencingIds":["_ref_172","_ref_192"]},{"type":"production","id":"prod-ProjectionArguments","name":"ProjectionArguments"},{"type":"production","id":"prod-ParenthesizedExpression","name":"ParenthesizedExpression","referencingIds":["_ref_185"]},{"type":"production","id":"prod-ModelExpression","name":"ModelExpression","referencingIds":["_ref_186"]},{"type":"production","id":"prod-TupleExpression","name":"TupleExpression","referencingIds":["_ref_187"]},{"type":"production","id":"prod-ExpressionList","name":"ExpressionList","referencingIds":["_ref_199","_ref_200","_ref_203","_ref_205","_ref_211"]},{"type":"production","id":"prod-DecoratorList","name":"DecoratorList","referencingIds":["_ref_75","_ref_88","_ref_102","_ref_105","_ref_119","_ref_126","_ref_129","_ref_132","_ref_142","_ref_145","_ref_162","_ref_170","_ref_207","_ref_299","_ref_302"]},{"type":"production","id":"prod-Decorator","name":"Decorator","referencingIds":["_ref_208"]},{"type":"production","id":"prod-DecoratorArguments","name":"DecoratorArguments","referencingIds":["_ref_210"]},{"type":"production","id":"prod-ProjectionStatement","name":"ProjectionStatement"},{"type":"production","id":"prod-ProjectionSelector","name":"ProjectionSelector","referencingIds":["_ref_212"]},{"type":"production","id":"prod-ProjectionDirection","name":"ProjectionDirection","referencingIds":["_ref_213"]},{"type":"production","id":"prod-ProjectionTag","name":"ProjectionTag","referencingIds":["_ref_214"]},{"type":"production","id":"prod-ProjectionParameters","name":"ProjectionParameters","referencingIds":["_ref_215"]},{"type":"production","id":"prod-ProjectionBody","name":"ProjectionBody","referencingIds":["_ref_216"]},{"type":"production","id":"prod-ProjectionStatementList","name":"ProjectionStatementList","referencingIds":["_ref_220","_ref_222"]},{"type":"production","id":"prod-ProjectionStatementItem","name":"ProjectionStatementItem","referencingIds":["_ref_221","_ref_223"]},{"type":"production","id":"prod-ProjectionExpression","name":"ProjectionExpression","referencingIds":["_ref_226","_ref_282","_ref_284","_ref_285","_ref_286","_ref_288","_ref_301","_ref_304","_ref_305"]},{"type":"production","id":"prod-ProjectionReturnExpression","name":"ProjectionReturnExpression","referencingIds":["_ref_224"]},{"type":"production","id":"prod-ProjectionLogicalOrExpression","name":"ProjectionLogicalOrExpression","referencingIds":["_ref_225","_ref_228"]},{"type":"production","id":"prod-ProjectionLogicalAndExpression","name":"ProjectionLogicalAndExpression","referencingIds":["_ref_227","_ref_229","_ref_231"]},{"type":"production","id":"prod-ProjectionEqualityExpression","name":"ProjectionEqualityExpression","referencingIds":["_ref_234","_ref_236"]},{"type":"production","id":"prod-ProjectionRelationalExpression","name":"ProjectionRelationalExpression","referencingIds":["_ref_230","_ref_232","_ref_233","_ref_235","_ref_237","_ref_239","_ref_241","_ref_243","_ref_245"]},{"type":"production","id":"prod-ProjectionAdditiveExpression","name":"ProjectionAdditiveExpression","referencingIds":["_ref_238","_ref_240","_ref_242","_ref_244","_ref_246","_ref_248","_ref_250"]},{"type":"production","id":"prod-ProjectionMultiplicativeExpression","name":"ProjectionMultiplicativeExpression","referencingIds":["_ref_247","_ref_249","_ref_251","_ref_253","_ref_255"]},{"type":"production","id":"prod-ProjectionUnaryExpression","name":"ProjectionUnaryExpression","referencingIds":["_ref_252","_ref_254","_ref_256","_ref_258"]},{"type":"production","id":"prod-ProjectionCallExpression","name":"ProjectionCallExpression","referencingIds":["_ref_257","_ref_260","_ref_262","_ref_264"]},{"type":"production","id":"prod-ProjectionCallArguments","name":"ProjectionCallArguments","referencingIds":["_ref_261"]},{"type":"production","id":"prod-ProjectionDecoratorReferenceExpression","name":"ProjectionDecoratorReferenceExpression","referencingIds":["_ref_259"]},{"type":"production","id":"prod-ProjectionMemberExpression","name":"ProjectionMemberExpression","referencingIds":["_ref_267","_ref_270","_ref_272"]},{"type":"production","id":"prod-ProjectionPrimaryExpression","name":"ProjectionPrimaryExpression","referencingIds":["_ref_269"]},{"type":"production","id":"prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList","name":"CoverProjectionParenthesizedExpressionAndLambdaParameterList","referencingIds":["_ref_280","_ref_307"]},{"type":"production","id":"prod-ProjectionExpressionList","name":"ProjectionExpressionList","referencingIds":["_ref_266","_ref_281","_ref_283","_ref_306","_ref_309"]},{"type":"production","id":"prod-ProjectionIfExpression","name":"ProjectionIfExpression","referencingIds":["_ref_275","_ref_289"]},{"type":"production","id":"prod-ProjectionModelExpression","name":"ProjectionModelExpression","referencingIds":["_ref_278"]},{"type":"production","id":"prod-ProjectionModelBody","name":"ProjectionModelBody","referencingIds":["_ref_290"]},{"type":"production","id":"prod-ProjectionModelPropertyList","name":"ProjectionModelPropertyList","referencingIds":["_ref_291","_ref_292","_ref_294","_ref_296"]},{"type":"production","id":"prod-ProjectionModelProperty","name":"ProjectionModelProperty","referencingIds":["_ref_293","_ref_295","_ref_297"]},{"type":"production","id":"prod-ProjectionModelSpreadProperty","name":"ProjectionModelSpreadProperty","referencingIds":["_ref_298"]},{"type":"production","id":"prod-ProjectionTupleExpression","name":"ProjectionTupleExpression","referencingIds":["_ref_279"]},{"type":"production","id":"prod-ProjectionLambdaExpression","name":"ProjectionLambdaExpression","referencingIds":["_ref_276"]},{"type":"production","id":"prod-ProjectionBlockExpression","name":"ProjectionBlockExpression","referencingIds":["_ref_287","_ref_308"]},{"type":"production","id":"prod-LambdaParameters","name":"LambdaParameters"},{"type":"clause","id":"syntactic-grammar","titleHTML":"Syntactic Grammar","number":"2"}]}`);
 ;let usesMultipage = false</script><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><style>body {
   display: flex;
   font-size: 18px;
@@ -3250,184 +3250,204 @@ li.menu-search-result-term:before {
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
-<emu-production name="OperationStatement" id="prod-OperationStatement">
-    <emu-nt><a href="#prod-OperationStatement">OperationStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="fic4qgph">
-        <emu-nt optional="" id="_ref_165"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-t>op</emu-t>
-        <emu-nt id="_ref_166"><a href="#prod-Identifier">Identifier</a></emu-nt>
+<emu-production name="OperationSignatureDeclaration" id="prod-OperationSignatureDeclaration">
+    <emu-nt><a href="#prod-OperationSignatureDeclaration">OperationSignatureDeclaration</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="fv6fbcct">
         <emu-t>(</emu-t>
-        <emu-nt optional="" id="_ref_167"><a href="#prod-ModelPropertyList">ModelPropertyList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_165"><a href="#prod-ModelPropertyList">ModelPropertyList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>)</emu-t>
         <emu-t>:</emu-t>
-        <emu-nt id="_ref_168"><a href="#prod-Expression">Expression</a></emu-nt>
+        <emu-nt id="_ref_166"><a href="#prod-Expression">Expression</a></emu-nt>
+    </emu-rhs>
+</emu-production>
+<emu-production name="OperationSignatureReference" id="prod-OperationSignatureReference">
+    <emu-nt><a href="#prod-OperationSignatureReference">OperationSignatureReference</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="_vfnudru">
+        <emu-t>:</emu-t>
+        <emu-nt id="_ref_167"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
+    </emu-rhs>
+</emu-production>
+<emu-production name="OperationSignature" id="prod-OperationSignature">
+    <emu-nt><a href="#prod-OperationSignature">OperationSignature</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="auwsgpwa">
+        <emu-nt id="_ref_168"><a href="#prod-OperationSignatureDeclaration">OperationSignatureDeclaration</a></emu-nt>
+    </emu-rhs>
+    <emu-rhs a="pffyodoe">
+        <emu-nt id="_ref_169"><a href="#prod-OperationSignatureReference">OperationSignatureReference</a></emu-nt>
+    </emu-rhs>
+</emu-production>
+<emu-production name="OperationStatement" id="prod-OperationStatement">
+    <emu-nt><a href="#prod-OperationStatement">OperationStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="actcwu87">
+        <emu-nt optional="" id="_ref_170"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-t>op</emu-t>
+        <emu-nt id="_ref_171"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt optional="" id="_ref_172"><a href="#prod-TemplateArguments">TemplateArguments</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_173"><a href="#prod-OperationSignature">OperationSignature</a></emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="Expression" id="prod-Expression">
     <emu-nt><a href="#prod-Expression">Expression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="otzlm2nv">
-        <emu-nt id="_ref_169"><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_174"><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="UnionExpressionOrHigher" id="prod-UnionExpressionOrHigher">
     <emu-nt><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="l4bpz882">
-        <emu-nt id="_ref_170"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_175"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="oiwllrbb">
         <emu-t optional="">|<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
-        <emu-nt id="_ref_171"><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_176"><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt>
         <emu-t>|</emu-t>
-        <emu-nt id="_ref_172"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_177"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="IntersectionExpressionOrHigher" id="prod-IntersectionExpressionOrHigher">
     <emu-nt><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="fxst_igc">
-        <emu-nt id="_ref_173"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_178"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="cgkcj8yb">
         <emu-t optional="">&amp;<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
-        <emu-nt id="_ref_174"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_179"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt>
         <emu-t>&amp;</emu-t>
-        <emu-nt id="_ref_175"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_180"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ArrayExpressionOrHigher" id="prod-ArrayExpressionOrHigher">
     <emu-nt><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="jvcvemtw">
-        <emu-nt id="_ref_176"><a href="#prod-PrimaryExpression">PrimaryExpression</a></emu-nt>
+        <emu-nt id="_ref_181"><a href="#prod-PrimaryExpression">PrimaryExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="8k-eixnj">
-        <emu-nt id="_ref_177"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_182"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt>
         <emu-t>[</emu-t>
         <emu-t>]</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="PrimaryExpression" id="prod-PrimaryExpression">
     <emu-nt><a href="#prod-PrimaryExpression">PrimaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="kul-a19e">
-        <emu-nt id="_ref_178"><a href="#prod-Literal">Literal</a></emu-nt>
+        <emu-nt id="_ref_183"><a href="#prod-Literal">Literal</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="mpejatd_">
-        <emu-nt id="_ref_179"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
+        <emu-nt id="_ref_184"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="k5j7cutc">
-        <emu-nt id="_ref_180"><a href="#prod-ParenthesizedExpression">ParenthesizedExpression</a></emu-nt>
+        <emu-nt id="_ref_185"><a href="#prod-ParenthesizedExpression">ParenthesizedExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="d007fnkw">
-        <emu-nt id="_ref_181"><a href="#prod-ModelExpression">ModelExpression</a></emu-nt>
+        <emu-nt id="_ref_186"><a href="#prod-ModelExpression">ModelExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="rmcinm4a">
-        <emu-nt id="_ref_182"><a href="#prod-TupleExpression">TupleExpression</a></emu-nt>
+        <emu-nt id="_ref_187"><a href="#prod-TupleExpression">TupleExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="Literal" id="prod-Literal">
     <emu-nt><a href="#prod-Literal">Literal</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="xhtltz00">
-        <emu-nt id="_ref_183"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
+        <emu-nt id="_ref_188"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="nqjh_sxl">
-        <emu-nt id="_ref_184"><a href="#prod-BooleanLiteral">BooleanLiteral</a></emu-nt>
+        <emu-nt id="_ref_189"><a href="#prod-BooleanLiteral">BooleanLiteral</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="pui0b1rt">
-        <emu-nt id="_ref_185"><a href="#prod-NumericLiteral">NumericLiteral</a></emu-nt>
+        <emu-nt id="_ref_190"><a href="#prod-NumericLiteral">NumericLiteral</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ReferenceExpression" id="prod-ReferenceExpression">
     <emu-nt><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="mzr2yu9j">
-        <emu-nt id="_ref_186"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
-        <emu-nt optional="" id="_ref_187"><a href="#prod-TemplateArguments">TemplateArguments</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_191"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
+        <emu-nt optional="" id="_ref_192"><a href="#prod-TemplateArguments">TemplateArguments</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ReferenceExpressionList" id="prod-ReferenceExpressionList">
     <emu-nt><a href="#prod-ReferenceExpressionList">ReferenceExpressionList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="mpejatd_">
-        <emu-nt id="_ref_188"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
+        <emu-nt id="_ref_193"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="ry70nwgl">
-        <emu-nt id="_ref_189"><a href="#prod-ReferenceExpressionList">ReferenceExpressionList</a></emu-nt>
+        <emu-nt id="_ref_194"><a href="#prod-ReferenceExpressionList">ReferenceExpressionList</a></emu-nt>
         <emu-t>,</emu-t>
-        <emu-nt id="_ref_190"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
+        <emu-nt id="_ref_195"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="IdentifierOrMemberExpression" id="prod-IdentifierOrMemberExpression">
     <emu-nt><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bras6mo_">
-        <emu-nt id="_ref_191"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_196"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="fagplbkz">
-        <emu-nt id="_ref_192"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
+        <emu-nt id="_ref_197"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
         <emu-t>.</emu-t>
-        <emu-nt id="_ref_193"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_198"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="TemplateArguments" id="prod-TemplateArguments">
     <emu-nt><a href="#prod-TemplateArguments">TemplateArguments</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="erulm7dq">
         <emu-t>&lt;</emu-t>
-        <emu-nt id="_ref_194"><a href="#prod-ExpressionList">ExpressionList</a></emu-nt>
+        <emu-nt id="_ref_199"><a href="#prod-ExpressionList">ExpressionList</a></emu-nt>
         <emu-t>&gt;</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionArguments" id="prod-ProjectionArguments">
     <emu-nt><a href="#prod-ProjectionArguments">ProjectionArguments</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="gq6jlu5e">
         <emu-t>(</emu-t>
-        <emu-nt optional="" id="_ref_195"><a href="#prod-ExpressionList">ExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_200"><a href="#prod-ExpressionList">ExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ParenthesizedExpression" id="prod-ParenthesizedExpression">
     <emu-nt><a href="#prod-ParenthesizedExpression">ParenthesizedExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="s6bvnd5v">
         <emu-t>(</emu-t>
-        <emu-nt id="_ref_196"><a href="#prod-Expression">Expression</a></emu-nt>
+        <emu-nt id="_ref_201"><a href="#prod-Expression">Expression</a></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ModelExpression" id="prod-ModelExpression">
     <emu-nt><a href="#prod-ModelExpression">ModelExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="p9stvizw">
         <emu-t>{</emu-t>
-        <emu-nt optional="" id="_ref_197"><a href="#prod-ModelBody">ModelBody</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_202"><a href="#prod-ModelBody">ModelBody</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="TupleExpression" id="prod-TupleExpression">
     <emu-nt><a href="#prod-TupleExpression">TupleExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="lfcd3ro5">
         <emu-t>[</emu-t>
-        <emu-nt optional="" id="_ref_198"><a href="#prod-ExpressionList">ExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_203"><a href="#prod-ExpressionList">ExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>]</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ExpressionList" id="prod-ExpressionList">
     <emu-nt><a href="#prod-ExpressionList">ExpressionList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="l7avubnp">
-        <emu-nt id="_ref_199"><a href="#prod-Expression">Expression</a></emu-nt>
+        <emu-nt id="_ref_204"><a href="#prod-Expression">Expression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="8cbmyyhk">
-        <emu-nt id="_ref_200"><a href="#prod-ExpressionList">ExpressionList</a></emu-nt>
+        <emu-nt id="_ref_205"><a href="#prod-ExpressionList">ExpressionList</a></emu-nt>
         <emu-t>,</emu-t>
-        <emu-nt id="_ref_201"><a href="#prod-Expression">Expression</a></emu-nt>
+        <emu-nt id="_ref_206"><a href="#prod-Expression">Expression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="DecoratorList" id="prod-DecoratorList">
     <emu-nt><a href="#prod-DecoratorList">DecoratorList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="a6fvhq_2">
-        <emu-nt optional="" id="_ref_202"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_203"><a href="#prod-Decorator">Decorator</a></emu-nt>
+        <emu-nt optional="" id="_ref_207"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_208"><a href="#prod-Decorator">Decorator</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="Decorator" id="prod-Decorator">
     <emu-nt><a href="#prod-Decorator">Decorator</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="p1dbtqtg">
         <emu-t>@</emu-t>
-        <emu-nt id="_ref_204"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
-        <emu-nt optional="" id="_ref_205"><a href="#prod-DecoratorArguments">DecoratorArguments</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_209"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
+        <emu-nt optional="" id="_ref_210"><a href="#prod-DecoratorArguments">DecoratorArguments</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="DecoratorArguments" id="prod-DecoratorArguments">
     <emu-nt><a href="#prod-DecoratorArguments">DecoratorArguments</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="gq6jlu5e">
         <emu-t>(</emu-t>
-        <emu-nt optional="" id="_ref_206"><a href="#prod-ExpressionList">ExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_211"><a href="#prod-ExpressionList">ExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionStatement" id="prod-ProjectionStatement">
     <emu-nt><a href="#prod-ProjectionStatement">ProjectionStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="_13j6y1k">
         <emu-t>projection</emu-t>
-        <emu-nt id="_ref_207"><a href="#prod-ProjectionSelector">ProjectionSelector</a></emu-nt>
-        <emu-nt id="_ref_208"><a href="#prod-ProjectionDirection">ProjectionDirection</a></emu-nt>
-        <emu-nt id="_ref_209"><a href="#prod-ProjectionTag">ProjectionTag</a></emu-nt>
-        <emu-nt optional="" id="_ref_210"><a href="#prod-ProjectionParameters">ProjectionParameters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_212"><a href="#prod-ProjectionSelector">ProjectionSelector</a></emu-nt>
+        <emu-nt id="_ref_213"><a href="#prod-ProjectionDirection">ProjectionDirection</a></emu-nt>
+        <emu-nt id="_ref_214"><a href="#prod-ProjectionTag">ProjectionTag</a></emu-nt>
+        <emu-nt optional="" id="_ref_215"><a href="#prod-ProjectionParameters">ProjectionParameters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>{</emu-t>
-        <emu-nt id="_ref_211"><a href="#prod-ProjectionBody">ProjectionBody</a></emu-nt>
+        <emu-nt id="_ref_216"><a href="#prod-ProjectionBody">ProjectionBody</a></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
@@ -3445,7 +3465,7 @@ li.menu-search-result-term:before {
         <emu-t>union</emu-t>
     </emu-rhs>
     <emu-rhs a="mpejatd_">
-        <emu-nt id="_ref_212"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
+        <emu-nt id="_ref_217"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionDirection" id="prod-ProjectionDirection">
@@ -3459,29 +3479,29 @@ li.menu-search-result-term:before {
 <emu-production name="ProjectionTag" id="prod-ProjectionTag">
     <emu-nt><a href="#prod-ProjectionTag">ProjectionTag</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="pkshwqzc">
         <emu-t>#</emu-t>
-        <emu-nt id="_ref_213"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_218"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionParameters" id="prod-ProjectionParameters">
     <emu-nt><a href="#prod-ProjectionParameters">ProjectionParameters</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="yyjrc85a">
         <emu-t>(</emu-t>
-        <emu-nt optional="" id="_ref_214"><a href="#prod-IdentifierList">IdentifierList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_219"><a href="#prod-IdentifierList">IdentifierList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionBody" id="prod-ProjectionBody">
     <emu-nt><a href="#prod-ProjectionBody">ProjectionBody</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bxmgst2s">
-        <emu-nt id="_ref_215"><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt>
+        <emu-nt id="_ref_220"><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionStatementList" id="prod-ProjectionStatementList">
     <emu-nt><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="8jls0kgx">
-        <emu-nt id="_ref_216"><a href="#prod-ProjectionStatementItem">ProjectionStatementItem</a></emu-nt>
+        <emu-nt id="_ref_221"><a href="#prod-ProjectionStatementItem">ProjectionStatementItem</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="123mhtoq">
-        <emu-nt id="_ref_217"><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt>
+        <emu-nt id="_ref_222"><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt>
         <emu-t>;</emu-t>
-        <emu-nt id="_ref_218"><a href="#prod-ProjectionStatementItem">ProjectionStatementItem</a></emu-nt>
+        <emu-nt id="_ref_223"><a href="#prod-ProjectionStatementItem">ProjectionStatementItem</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionStatementItem" id="prod-ProjectionStatementItem">
@@ -3491,165 +3511,165 @@ li.menu-search-result-term:before {
 </emu-production>
 <emu-production name="ProjectionExpression" id="prod-ProjectionExpression">
     <emu-nt><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="vzsiuzn4">
-        <emu-nt id="_ref_219"><a href="#prod-ProjectionReturnExpression">ProjectionReturnExpression</a></emu-nt>
+        <emu-nt id="_ref_224"><a href="#prod-ProjectionReturnExpression">ProjectionReturnExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionReturnExpression" id="prod-ProjectionReturnExpression">
     <emu-nt><a href="#prod-ProjectionReturnExpression">ProjectionReturnExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="24gnoobj">
-        <emu-nt id="_ref_220"><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt>
+        <emu-nt id="_ref_225"><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="mxa7it1a">
         <emu-t>return</emu-t>
-        <emu-nt id="_ref_221"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_226"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionLogicalOrExpression" id="prod-ProjectionLogicalOrExpression">
     <emu-nt><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="aawamjyo">
-        <emu-nt id="_ref_222"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt>
+        <emu-nt id="_ref_227"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="k589waww">
-        <emu-nt id="_ref_223"><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt>
+        <emu-nt id="_ref_228"><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt>
         <emu-t>||</emu-t>
-        <emu-nt id="_ref_224"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt>
+        <emu-nt id="_ref_229"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionLogicalAndExpression" id="prod-ProjectionLogicalAndExpression">
     <emu-nt><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="nttyzhj4">
-        <emu-nt id="_ref_225"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_230"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="evmo1uol">
-        <emu-nt id="_ref_226"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt>
+        <emu-nt id="_ref_231"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt>
         <emu-t>&amp;&amp;</emu-t>
-        <emu-nt id="_ref_227"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_232"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionEqualityExpression" id="prod-ProjectionEqualityExpression">
     <emu-nt><a href="#prod-ProjectionEqualityExpression">ProjectionEqualityExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="nttyzhj4">
-        <emu-nt id="_ref_228"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_233"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="lackn1tw">
-        <emu-nt id="_ref_229"><a href="#prod-ProjectionEqualityExpression">ProjectionEqualityExpression</a></emu-nt>
+        <emu-nt id="_ref_234"><a href="#prod-ProjectionEqualityExpression">ProjectionEqualityExpression</a></emu-nt>
         <emu-t>==</emu-t>
-        <emu-nt id="_ref_230"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_235"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="mlrnlbcv">
-        <emu-nt id="_ref_231"><a href="#prod-ProjectionEqualityExpression">ProjectionEqualityExpression</a></emu-nt>
+        <emu-nt id="_ref_236"><a href="#prod-ProjectionEqualityExpression">ProjectionEqualityExpression</a></emu-nt>
         <emu-t>!=</emu-t>
-        <emu-nt id="_ref_232"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_237"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionRelationalExpression" id="prod-ProjectionRelationalExpression">
     <emu-nt><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="flky6l5a">
-        <emu-nt id="_ref_233"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+        <emu-nt id="_ref_238"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="7lkhh7co">
-        <emu-nt id="_ref_234"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_239"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
         <emu-t>&lt;</emu-t>
-        <emu-nt id="_ref_235"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+        <emu-nt id="_ref_240"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="jwbqdqyk">
-        <emu-nt id="_ref_236"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_241"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
         <emu-t>&gt;</emu-t>
-        <emu-nt id="_ref_237"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+        <emu-nt id="_ref_242"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="rg5xsl8u">
-        <emu-nt id="_ref_238"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_243"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
         <emu-t>&lt;=</emu-t>
-        <emu-nt id="_ref_239"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+        <emu-nt id="_ref_244"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="y-qu2tqb">
-        <emu-nt id="_ref_240"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_245"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
         <emu-t>&gt;=</emu-t>
-        <emu-nt id="_ref_241"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+        <emu-nt id="_ref_246"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionAdditiveExpression" id="prod-ProjectionAdditiveExpression">
     <emu-nt><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="eked4n7k">
-        <emu-nt id="_ref_242"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
+        <emu-nt id="_ref_247"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="iiox3k7e">
-        <emu-nt id="_ref_243"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+        <emu-nt id="_ref_248"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
         <emu-t>+</emu-t>
-        <emu-nt id="_ref_244"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
+        <emu-nt id="_ref_249"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="xy3v8nqo">
-        <emu-nt id="_ref_245"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+        <emu-nt id="_ref_250"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
         <emu-t>-</emu-t>
-        <emu-nt id="_ref_246"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
+        <emu-nt id="_ref_251"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionMultiplicativeExpression" id="prod-ProjectionMultiplicativeExpression">
     <emu-nt><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="eosbpz0i">
-        <emu-nt id="_ref_247"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
+        <emu-nt id="_ref_252"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="oklvxhw2">
-        <emu-nt id="_ref_248"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
+        <emu-nt id="_ref_253"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
         <emu-t>*</emu-t>
-        <emu-nt id="_ref_249"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
+        <emu-nt id="_ref_254"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="vmdvvwy0">
-        <emu-nt id="_ref_250"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
+        <emu-nt id="_ref_255"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
         <emu-t>/</emu-t>
-        <emu-nt id="_ref_251"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
+        <emu-nt id="_ref_256"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionUnaryExpression" id="prod-ProjectionUnaryExpression">
     <emu-nt><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="y0pnlb1i">
-        <emu-nt id="_ref_252"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
+        <emu-nt id="_ref_257"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="xbyln6wd">
         <emu-t>!</emu-t>
-        <emu-nt id="_ref_253"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
+        <emu-nt id="_ref_258"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionCallExpression" id="prod-ProjectionCallExpression">
     <emu-nt><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bovlf96p">
-        <emu-nt id="_ref_254"><a href="#prod-ProjectionDecoratorReferenceExpression">ProjectionDecoratorReferenceExpression</a></emu-nt>
+        <emu-nt id="_ref_259"><a href="#prod-ProjectionDecoratorReferenceExpression">ProjectionDecoratorReferenceExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="dskpubvk">
-        <emu-nt id="_ref_255"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
-        <emu-nt id="_ref_256"><a href="#prod-ProjectionCallArguments">ProjectionCallArguments</a></emu-nt>
+        <emu-nt id="_ref_260"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
+        <emu-nt id="_ref_261"><a href="#prod-ProjectionCallArguments">ProjectionCallArguments</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="mlqh18ki">
-        <emu-nt id="_ref_257"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
+        <emu-nt id="_ref_262"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
         <emu-t>.</emu-t>
-        <emu-nt id="_ref_258"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_263"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="o5cqmytw">
-        <emu-nt id="_ref_259"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
+        <emu-nt id="_ref_264"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
         <emu-t>::</emu-t>
-        <emu-nt id="_ref_260"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_265"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionCallArguments" id="prod-ProjectionCallArguments">
     <emu-nt><a href="#prod-ProjectionCallArguments">ProjectionCallArguments</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="j4chh_gn">
         <emu-t>(</emu-t>
-        <emu-nt optional="" id="_ref_261"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_266"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionDecoratorReferenceExpression" id="prod-ProjectionDecoratorReferenceExpression">
     <emu-nt><a href="#prod-ProjectionDecoratorReferenceExpression">ProjectionDecoratorReferenceExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="upl3vrmk">
-        <emu-nt id="_ref_262"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt>
+        <emu-nt id="_ref_267"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="ifcyd-aq">
         <emu-t>@</emu-t>
-        <emu-nt id="_ref_263"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
+        <emu-nt id="_ref_268"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionMemberExpression" id="prod-ProjectionMemberExpression">
     <emu-nt><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="0yuqksdg">
-        <emu-nt id="_ref_264"><a href="#prod-ProjectionPrimaryExpression">ProjectionPrimaryExpression</a></emu-nt>
+        <emu-nt id="_ref_269"><a href="#prod-ProjectionPrimaryExpression">ProjectionPrimaryExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="jew6aiq_">
-        <emu-nt id="_ref_265"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt>
+        <emu-nt id="_ref_270"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt>
         <emu-t>.</emu-t>
-        <emu-nt id="_ref_266"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_271"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="rdfgqhl2">
-        <emu-nt id="_ref_267"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt>
+        <emu-nt id="_ref_272"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt>
         <emu-t>::</emu-t>
-        <emu-nt id="_ref_268"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_273"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionPrimaryExpression" id="prod-ProjectionPrimaryExpression">
@@ -3657,147 +3677,147 @@ li.menu-search-result-term:before {
         <emu-t>self</emu-t>
     </emu-rhs>
     <emu-rhs a="bras6mo_">
-        <emu-nt id="_ref_269"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_274"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="cjpglqhg">
-        <emu-nt id="_ref_270"><a href="#prod-ProjectionIfExpression">ProjectionIfExpression</a></emu-nt>
+        <emu-nt id="_ref_275"><a href="#prod-ProjectionIfExpression">ProjectionIfExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="kwuqjwk9">
-        <emu-nt id="_ref_271"><a href="#prod-ProjectionLambdaExpression">ProjectionLambdaExpression</a></emu-nt>
+        <emu-nt id="_ref_276"><a href="#prod-ProjectionLambdaExpression">ProjectionLambdaExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="kul-a19e">
-        <emu-nt id="_ref_272"><a href="#prod-Literal">Literal</a></emu-nt>
+        <emu-nt id="_ref_277"><a href="#prod-Literal">Literal</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="pmeanrkf">
-        <emu-nt id="_ref_273"><a href="#prod-ProjectionModelExpression">ProjectionModelExpression</a></emu-nt>
+        <emu-nt id="_ref_278"><a href="#prod-ProjectionModelExpression">ProjectionModelExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="0ehfrlsm">
-        <emu-nt id="_ref_274"><a href="#prod-ProjectionTupleExpression">ProjectionTupleExpression</a></emu-nt>
+        <emu-nt id="_ref_279"><a href="#prod-ProjectionTupleExpression">ProjectionTupleExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="ult0-wp7">
-        <emu-nt id="_ref_275"><a href="#prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">CoverProjectionParenthesizedExpressionAndLambdaParameterList</a></emu-nt>
+        <emu-nt id="_ref_280"><a href="#prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">CoverProjectionParenthesizedExpressionAndLambdaParameterList</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="CoverProjectionParenthesizedExpressionAndLambdaParameterList" id="prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">
     <emu-nt><a href="#prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">CoverProjectionParenthesizedExpressionAndLambdaParameterList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="b22wugnz">
         <emu-t>(</emu-t>
-        <emu-nt id="_ref_276"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt>
+        <emu-nt id="_ref_281"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionExpressionList" id="prod-ProjectionExpressionList">
     <emu-nt><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="emksbnr7">
-        <emu-nt id="_ref_277"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_282"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="if8za0tg">
-        <emu-nt id="_ref_278"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt>
+        <emu-nt id="_ref_283"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt>
         <emu-t>,</emu-t>
-        <emu-nt id="_ref_279"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_284"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionIfExpression" id="prod-ProjectionIfExpression">
     <emu-nt><a href="#prod-ProjectionIfExpression">ProjectionIfExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="4wt0s7kz">
         <emu-t>if</emu-t>
-        <emu-nt id="_ref_280"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_285"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
         <emu-nt>BlockExpression</emu-nt>
     </emu-rhs>
     <emu-rhs a="uh-blucs">
         <emu-t>if</emu-t>
-        <emu-nt id="_ref_281"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_286"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
         <emu-nt>BlockExpression</emu-nt>
         <emu-t>else</emu-t>
-        <emu-nt id="_ref_282"><a href="#prod-ProjectionBlockExpression">ProjectionBlockExpression</a></emu-nt>
+        <emu-nt id="_ref_287"><a href="#prod-ProjectionBlockExpression">ProjectionBlockExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="o_gymffi">
         <emu-t>if</emu-t>
-        <emu-nt id="_ref_283"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_288"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
         <emu-nt>BlockExpression</emu-nt>
         <emu-t>else</emu-t>
-        <emu-nt id="_ref_284"><a href="#prod-ProjectionIfExpression">ProjectionIfExpression</a></emu-nt>
+        <emu-nt id="_ref_289"><a href="#prod-ProjectionIfExpression">ProjectionIfExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionModelExpression" id="prod-ProjectionModelExpression">
     <emu-nt><a href="#prod-ProjectionModelExpression">ProjectionModelExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="uni6ofws">
         <emu-t>{</emu-t>
-        <emu-nt optional="" id="_ref_285"><a href="#prod-ProjectionModelBody">ProjectionModelBody</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_290"><a href="#prod-ProjectionModelBody">ProjectionModelBody</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionModelBody" id="prod-ProjectionModelBody">
     <emu-nt><a href="#prod-ProjectionModelBody">ProjectionModelBody</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="rtfwbkzz">
-        <emu-nt id="_ref_286"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
+        <emu-nt id="_ref_291"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
         <emu-t optional="">,<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
     </emu-rhs>
     <emu-rhs a="foktbtgh">
-        <emu-nt id="_ref_287"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
+        <emu-nt id="_ref_292"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
         <emu-t optional="">;<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionModelPropertyList" id="prod-ProjectionModelPropertyList">
     <emu-nt><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="qnv19o8r">
-        <emu-nt id="_ref_288"><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt>
+        <emu-nt id="_ref_293"><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="k06km7_w">
-        <emu-nt id="_ref_289"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
+        <emu-nt id="_ref_294"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
         <emu-t>,</emu-t>
-        <emu-nt id="_ref_290"><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt>
+        <emu-nt id="_ref_295"><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="xtycdbqj">
-        <emu-nt id="_ref_291"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
+        <emu-nt id="_ref_296"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
         <emu-t>;</emu-t>
-        <emu-nt id="_ref_292"><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt>
+        <emu-nt id="_ref_297"><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionModelProperty" id="prod-ProjectionModelProperty">
     <emu-nt><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="noc7fhyz">
-        <emu-nt id="_ref_293"><a href="#prod-ProjectionModelSpreadProperty">ProjectionModelSpreadProperty</a></emu-nt>
+        <emu-nt id="_ref_298"><a href="#prod-ProjectionModelSpreadProperty">ProjectionModelSpreadProperty</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="6zpn0h3k">
-        <emu-nt optional="" id="_ref_294"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_295"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt optional="" id="_ref_299"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_300"><a href="#prod-Identifier">Identifier</a></emu-nt>
         <emu-t optional="">?<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
         <emu-t>:</emu-t>
-        <emu-nt id="_ref_296"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_301"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="oncm7e4f">
-        <emu-nt optional="" id="_ref_297"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_298"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
+        <emu-nt optional="" id="_ref_302"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_303"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
         <emu-t optional="">?<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
         <emu-t>:</emu-t>
-        <emu-nt id="_ref_299"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_304"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionModelSpreadProperty" id="prod-ProjectionModelSpreadProperty">
     <emu-nt><a href="#prod-ProjectionModelSpreadProperty">ProjectionModelSpreadProperty</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="npvsjwgu">
         <emu-t>...</emu-t>
-        <emu-nt id="_ref_300"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_305"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionTupleExpression" id="prod-ProjectionTupleExpression">
     <emu-nt><a href="#prod-ProjectionTupleExpression">ProjectionTupleExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="zhtv_ku5">
         <emu-t>[</emu-t>
-        <emu-nt optional="" id="_ref_301"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_306"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>]</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionLambdaExpression" id="prod-ProjectionLambdaExpression">
     <emu-nt><a href="#prod-ProjectionLambdaExpression">ProjectionLambdaExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="wjv4b-0b">
-        <emu-nt id="_ref_302"><a href="#prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">CoverProjectionParenthesizedExpressionAndLambdaParameterList</a></emu-nt>
+        <emu-nt id="_ref_307"><a href="#prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">CoverProjectionParenthesizedExpressionAndLambdaParameterList</a></emu-nt>
         <emu-t>=&gt;</emu-t>
-        <emu-nt id="_ref_303"><a href="#prod-ProjectionBlockExpression">ProjectionBlockExpression</a></emu-nt>
+        <emu-nt id="_ref_308"><a href="#prod-ProjectionBlockExpression">ProjectionBlockExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionBlockExpression" id="prod-ProjectionBlockExpression">
     <emu-nt><a href="#prod-ProjectionBlockExpression">ProjectionBlockExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="qsr0aizg">
         <emu-t>{</emu-t>
-        <emu-nt id="_ref_304"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt>
+        <emu-nt id="_ref_309"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="LambdaParameters" id="prod-LambdaParameters">
     <emu-nt><a href="#prod-LambdaParameters">LambdaParameters</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="yyjrc85a">
         <emu-t>(</emu-t>
-        <emu-nt optional="" id="_ref_305"><a href="#prod-IdentifierList">IdentifierList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_310"><a href="#prod-IdentifierList">IdentifierList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>

--- a/docs/spec.html
+++ b/docs/spec.html
@@ -1255,7 +1255,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 let sdoMap = JSON.parse(`{}`);
-let biblio = JSON.parse(`{"refsByClause":{"lexical-grammar":["_ref_0","_ref_1","_ref_2","_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_9","_ref_10","_ref_11","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23","_ref_24","_ref_25","_ref_26","_ref_27","_ref_28","_ref_29","_ref_30","_ref_31","_ref_32","_ref_33","_ref_34","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45","_ref_46","_ref_47","_ref_48","_ref_49","_ref_50","_ref_51","_ref_52","_ref_53","_ref_54","_ref_55","_ref_56","_ref_57","_ref_58","_ref_59","_ref_60","_ref_61","_ref_62","_ref_63","_ref_64","_ref_65","_ref_66","_ref_67","_ref_68","_ref_69"],"syntactic-grammar":["_ref_70","_ref_71","_ref_72","_ref_73","_ref_74","_ref_75","_ref_76","_ref_77","_ref_78","_ref_79","_ref_80","_ref_81","_ref_82","_ref_83","_ref_84","_ref_85","_ref_86","_ref_87","_ref_88","_ref_89","_ref_90","_ref_91","_ref_92","_ref_93","_ref_94","_ref_95","_ref_96","_ref_97","_ref_98","_ref_99","_ref_100","_ref_101","_ref_102","_ref_103","_ref_104","_ref_105","_ref_106","_ref_107","_ref_108","_ref_109","_ref_110","_ref_111","_ref_112","_ref_113","_ref_114","_ref_115","_ref_116","_ref_117","_ref_118","_ref_119","_ref_120","_ref_121","_ref_122","_ref_123","_ref_124","_ref_125","_ref_126","_ref_127","_ref_128","_ref_129","_ref_130","_ref_131","_ref_132","_ref_133","_ref_134","_ref_135","_ref_136","_ref_137","_ref_138","_ref_139","_ref_140","_ref_141","_ref_142","_ref_143","_ref_144","_ref_145","_ref_146","_ref_147","_ref_148","_ref_149","_ref_150","_ref_151","_ref_152","_ref_153","_ref_154","_ref_155","_ref_156","_ref_157","_ref_158","_ref_159","_ref_160","_ref_161","_ref_162","_ref_163","_ref_164","_ref_165","_ref_166","_ref_167","_ref_168","_ref_169","_ref_170","_ref_171","_ref_172","_ref_173","_ref_174","_ref_175","_ref_176","_ref_177","_ref_178","_ref_179","_ref_180","_ref_181","_ref_182","_ref_183","_ref_184","_ref_185","_ref_186","_ref_187","_ref_188","_ref_189","_ref_190","_ref_191","_ref_192","_ref_193","_ref_194","_ref_195","_ref_196","_ref_197","_ref_198","_ref_199","_ref_200","_ref_201","_ref_202","_ref_203","_ref_204","_ref_205","_ref_206","_ref_207","_ref_208","_ref_209","_ref_210","_ref_211","_ref_212","_ref_213","_ref_214","_ref_215","_ref_216","_ref_217","_ref_218","_ref_219","_ref_220","_ref_221","_ref_222","_ref_223","_ref_224","_ref_225","_ref_226","_ref_227","_ref_228","_ref_229","_ref_230","_ref_231","_ref_232","_ref_233","_ref_234","_ref_235","_ref_236","_ref_237","_ref_238","_ref_239","_ref_240","_ref_241","_ref_242","_ref_243","_ref_244","_ref_245","_ref_246","_ref_247","_ref_248","_ref_249","_ref_250","_ref_251","_ref_252","_ref_253","_ref_254","_ref_255","_ref_256","_ref_257","_ref_258","_ref_259","_ref_260","_ref_261","_ref_262","_ref_263","_ref_264","_ref_265","_ref_266","_ref_267","_ref_268","_ref_269","_ref_270","_ref_271","_ref_272","_ref_273","_ref_274","_ref_275","_ref_276","_ref_277","_ref_278","_ref_279","_ref_280","_ref_281","_ref_282","_ref_283","_ref_284","_ref_285","_ref_286","_ref_287","_ref_288","_ref_289","_ref_290","_ref_291","_ref_292","_ref_293","_ref_294","_ref_295","_ref_296","_ref_297","_ref_298","_ref_299","_ref_300","_ref_301","_ref_302","_ref_303","_ref_304","_ref_305","_ref_306","_ref_307","_ref_308","_ref_309","_ref_310"]},"entries":[{"type":"clause","id":"intro","titleHTML":"Introduction","number":""},{"type":"production","id":"prod-SourceCharacter","name":"SourceCharacter","referencingIds":["_ref_49","_ref_53","_ref_64","_ref_65","_ref_69"]},{"type":"production","id":"prod-InputElement","name":"InputElement"},{"type":"production","id":"prod-Token","name":"Token","referencingIds":["_ref_0"]},{"type":"production","id":"prod-Trivia","name":"Trivia","referencingIds":["_ref_1"]},{"type":"production","id":"prod-Keyword","name":"Keyword","referencingIds":["_ref_2","_ref_11"]},{"type":"production","id":"prod-Identifier","name":"Identifier","referencingIds":["_ref_3","_ref_89","_ref_103","_ref_109","_ref_116","_ref_120","_ref_127","_ref_133","_ref_143","_ref_150","_ref_156","_ref_159","_ref_161","_ref_171","_ref_196","_ref_198","_ref_218","_ref_263","_ref_265","_ref_271","_ref_273","_ref_274","_ref_300"]},{"type":"production","id":"prod-IdentifierName","name":"IdentifierName","referencingIds":["_ref_10","_ref_13"]},{"type":"production","id":"prod-IdentifierStart","name":"IdentifierStart","referencingIds":["_ref_12"]},{"type":"production","id":"prod-IdentifierContinue","name":"IdentifierContinue","referencingIds":["_ref_14","_ref_15"]},{"type":"production","id":"prod-AsciiLetter","name":"AsciiLetter","referencingIds":["_ref_17"]},{"type":"production","id":"prod-BooleanLiteral","name":"BooleanLiteral","referencingIds":["_ref_9","_ref_189"]},{"type":"production","id":"prod-NumericLiteral","name":"NumericLiteral","referencingIds":["_ref_4","_ref_149","_ref_190"]},{"type":"production","id":"prod-DecimalLiteral","name":"DecimalLiteral","referencingIds":["_ref_19"]},{"type":"production","id":"prod-DecimalIntegerLiteral","name":"DecimalIntegerLiteral","referencingIds":["_ref_22","_ref_25","_ref_33"]},{"type":"production","id":"prod-DecimalDigits","name":"DecimalDigits","referencingIds":["_ref_23","_ref_27","_ref_28","_ref_29","_ref_31","_ref_34","_ref_35","_ref_36"]},{"type":"production","id":"prod-DecimalDigit","name":"DecimalDigit","referencingIds":["_ref_16","_ref_18","_ref_30","_ref_32"]},{"type":"production","id":"prod-ExponentPart","name":"ExponentPart","referencingIds":["_ref_24","_ref_26"]},{"type":"production","id":"prod-DecimalIntegerInteger","name":"DecimalIntegerInteger"},{"type":"production","id":"prod-HexIntegerLiteral","name":"HexIntegerLiteral","referencingIds":["_ref_20"]},{"type":"production","id":"prod-HexDigits","name":"HexDigits","referencingIds":["_ref_37","_ref_39"]},{"type":"production","id":"prod-HexDigit","name":"HexDigit","referencingIds":["_ref_38","_ref_40"]},{"type":"production","id":"prod-BinaryIntegerLiteral","name":"BinaryIntegerLiteral","referencingIds":["_ref_21"]},{"type":"production","id":"prod-BinaryDigits","name":"BinaryDigits","referencingIds":["_ref_41","_ref_43"]},{"type":"production","id":"prod-BinaryDigit","name":"BinaryDigit","referencingIds":["_ref_42","_ref_44"]},{"type":"production","id":"prod-StringLiteral","name":"StringLiteral","referencingIds":["_ref_5","_ref_77","_ref_106","_ref_130","_ref_146","_ref_148","_ref_188","_ref_303"]},{"type":"production","id":"prod-StringCharacters","name":"StringCharacters","referencingIds":["_ref_45","_ref_48"]},{"type":"production","id":"prod-StringCharacter","name":"StringCharacter","referencingIds":["_ref_47"]},{"type":"production","id":"prod-TripleQuotedStringCharacters","name":"TripleQuotedStringCharacters","referencingIds":["_ref_46","_ref_52"]},{"type":"production","id":"prod-TripleQuotedStringCharacter","name":"TripleQuotedStringCharacter","referencingIds":["_ref_51"]},{"type":"production","id":"prod-EscapeCharacter","name":"EscapeCharacter","referencingIds":["_ref_50","_ref_54"]},{"type":"production","id":"prod-Punctuator","name":"Punctuator","referencingIds":["_ref_6"]},{"type":"production","id":"prod-WhiteSpace","name":"WhiteSpace","referencingIds":["_ref_8"]},{"type":"production","id":"prod-Comment","name":"Comment","referencingIds":["_ref_7"]},{"type":"production","id":"prod-MultiLineComment","name":"MultiLineComment","referencingIds":["_ref_55"]},{"type":"production","id":"prod-MultiLineCommentChars","name":"MultiLineCommentChars","referencingIds":["_ref_57","_ref_59","_ref_62"]},{"type":"production","id":"prod-PostAsteriskCommentChars","name":"PostAsteriskCommentChars","referencingIds":["_ref_60","_ref_63"]},{"type":"production","id":"prod-MultiLineNotAsteriskChar","name":"MultiLineNotAsteriskChar","referencingIds":["_ref_58"]},{"type":"production","id":"prod-MultiLineNotForwardSlashOrAsteriskChar","name":"MultiLineNotForwardSlashOrAsteriskChar","referencingIds":["_ref_61"]},{"type":"production","id":"prod-SingleLineComment","name":"SingleLineComment","referencingIds":["_ref_56"]},{"type":"production","id":"prod-SingleLineCommentChars","name":"SingleLineCommentChars","referencingIds":["_ref_66","_ref_68"]},{"type":"production","id":"prod-SingleLineCommentChar","name":"SingleLineCommentChar","referencingIds":["_ref_67"]},{"type":"clause","id":"lexical-grammar","titleHTML":"Lexical Grammar","number":"1"},{"type":"production","id":"prod-CadlScriptItemList","name":"CadlScriptItemList","referencingIds":["_ref_70"]},{"type":"production","id":"prod-CadlScriptItem","name":"CadlScriptItem","referencingIds":["_ref_71"]},{"type":"production","id":"prod-BlocklessNamespaceStatement","name":"BlocklessNamespaceStatement","referencingIds":["_ref_72"]},{"type":"production","id":"prod-ImportStatement","name":"ImportStatement","referencingIds":["_ref_73"]},{"type":"production","id":"prod-StatementList","name":"StatementList","referencingIds":["_ref_78","_ref_164"]},{"type":"production","id":"prod-Statement","name":"Statement","referencingIds":["_ref_74","_ref_79"]},{"type":"production","id":"prod-UsingStatement","name":"UsingStatement","referencingIds":["_ref_84"]},{"type":"production","id":"prod-ModelStatement","name":"ModelStatement","referencingIds":["_ref_80"]},{"type":"production","id":"prod-ModelHeritage","name":"ModelHeritage","referencingIds":["_ref_90"]},{"type":"production","id":"prod-ModelBody","name":"ModelBody","referencingIds":["_ref_91","_ref_202"]},{"type":"production","id":"prod-ModelPropertyList","name":"ModelPropertyList","referencingIds":["_ref_94","_ref_95","_ref_97","_ref_99","_ref_117","_ref_165"]},{"type":"production","id":"prod-ModelProperty","name":"ModelProperty","referencingIds":["_ref_96","_ref_98","_ref_100"]},{"type":"production","id":"prod-ModelSpreadProperty","name":"ModelSpreadProperty","referencingIds":["_ref_101"]},{"type":"production","id":"prod-InterfaceStatement","name":"InterfaceStatement","referencingIds":["_ref_81"]},{"type":"production","id":"prod-InterfaceHeritage","name":"InterfaceHeritage","referencingIds":["_ref_110"]},{"type":"production","id":"prod-InterfaceMemberList","name":"InterfaceMemberList","referencingIds":["_ref_112","_ref_114"]},{"type":"production","id":"prod-InterfaceMember","name":"InterfaceMember","referencingIds":["_ref_113","_ref_115"]},{"type":"production","id":"prod-UnionStatement","name":"UnionStatement"},{"type":"production","id":"prod-UnionBody","name":"UnionBody","referencingIds":["_ref_121"]},{"type":"production","id":"prod-UnionVariantList","name":"UnionVariantList","referencingIds":["_ref_122","_ref_124"]},{"type":"production","id":"prod-UnionVariant","name":"UnionVariant","referencingIds":["_ref_123","_ref_125"]},{"type":"production","id":"prod-EnumStatement","name":"EnumStatement","referencingIds":["_ref_85"]},{"type":"production","id":"prod-EnumBody","name":"EnumBody","referencingIds":["_ref_134"]},{"type":"production","id":"prod-EnumMemberList","name":"EnumMemberList","referencingIds":["_ref_135","_ref_136","_ref_138","_ref_140"]},{"type":"production","id":"prod-EnumMember","name":"EnumMember","referencingIds":["_ref_137","_ref_139","_ref_141"]},{"type":"production","id":"prod-EnumMemberValue","name":"EnumMemberValue","referencingIds":["_ref_144","_ref_147"]},{"type":"production","id":"prod-AliasStatement","name":"AliasStatement","referencingIds":["_ref_86"]},{"type":"production","id":"prod-TemplateParameterList","name":"TemplateParameterList","referencingIds":["_ref_152","_ref_154"]},{"type":"production","id":"prod-TemplateParameter","name":"TemplateParameter","referencingIds":["_ref_153","_ref_155"]},{"type":"production","id":"prod-TemplateParameterDefault","name":"TemplateParameterDefault","referencingIds":["_ref_157"]},{"type":"production","id":"prod-IdentifierList","name":"IdentifierList","referencingIds":["_ref_160","_ref_219","_ref_310"]},{"type":"production","id":"prod-NamespaceStatement","name":"NamespaceStatement","referencingIds":["_ref_82"]},{"type":"production","id":"prod-OperationSignatureDeclaration","name":"OperationSignatureDeclaration","referencingIds":["_ref_168"]},{"type":"production","id":"prod-OperationSignatureReference","name":"OperationSignatureReference","referencingIds":["_ref_169"]},{"type":"production","id":"prod-OperationSignature","name":"OperationSignature","referencingIds":["_ref_173"]},{"type":"production","id":"prod-OperationStatement","name":"OperationStatement","referencingIds":["_ref_83"]},{"type":"production","id":"prod-Expression","name":"Expression","referencingIds":["_ref_104","_ref_107","_ref_118","_ref_128","_ref_131","_ref_151","_ref_158","_ref_166","_ref_201","_ref_204","_ref_206"]},{"type":"production","id":"prod-UnionExpressionOrHigher","name":"UnionExpressionOrHigher","referencingIds":["_ref_174","_ref_176"]},{"type":"production","id":"prod-IntersectionExpressionOrHigher","name":"IntersectionExpressionOrHigher","referencingIds":["_ref_175","_ref_177","_ref_179"]},{"type":"production","id":"prod-ArrayExpressionOrHigher","name":"ArrayExpressionOrHigher","referencingIds":["_ref_178","_ref_180","_ref_182"]},{"type":"production","id":"prod-PrimaryExpression","name":"PrimaryExpression","referencingIds":["_ref_181"]},{"type":"production","id":"prod-Literal","name":"Literal","referencingIds":["_ref_183","_ref_277"]},{"type":"production","id":"prod-ReferenceExpression","name":"ReferenceExpression","referencingIds":["_ref_92","_ref_93","_ref_108","_ref_167","_ref_184","_ref_193","_ref_195","_ref_217"]},{"type":"production","id":"prod-ReferenceExpressionList","name":"ReferenceExpressionList","referencingIds":["_ref_111","_ref_194"]},{"type":"production","id":"prod-IdentifierOrMemberExpression","name":"IdentifierOrMemberExpression","referencingIds":["_ref_76","_ref_87","_ref_163","_ref_191","_ref_197","_ref_209","_ref_268"]},{"type":"production","id":"prod-TemplateArguments","name":"TemplateArguments","referencingIds":["_ref_172","_ref_192"]},{"type":"production","id":"prod-ProjectionArguments","name":"ProjectionArguments"},{"type":"production","id":"prod-ParenthesizedExpression","name":"ParenthesizedExpression","referencingIds":["_ref_185"]},{"type":"production","id":"prod-ModelExpression","name":"ModelExpression","referencingIds":["_ref_186"]},{"type":"production","id":"prod-TupleExpression","name":"TupleExpression","referencingIds":["_ref_187"]},{"type":"production","id":"prod-ExpressionList","name":"ExpressionList","referencingIds":["_ref_199","_ref_200","_ref_203","_ref_205","_ref_211"]},{"type":"production","id":"prod-DecoratorList","name":"DecoratorList","referencingIds":["_ref_75","_ref_88","_ref_102","_ref_105","_ref_119","_ref_126","_ref_129","_ref_132","_ref_142","_ref_145","_ref_162","_ref_170","_ref_207","_ref_299","_ref_302"]},{"type":"production","id":"prod-Decorator","name":"Decorator","referencingIds":["_ref_208"]},{"type":"production","id":"prod-DecoratorArguments","name":"DecoratorArguments","referencingIds":["_ref_210"]},{"type":"production","id":"prod-ProjectionStatement","name":"ProjectionStatement"},{"type":"production","id":"prod-ProjectionSelector","name":"ProjectionSelector","referencingIds":["_ref_212"]},{"type":"production","id":"prod-ProjectionDirection","name":"ProjectionDirection","referencingIds":["_ref_213"]},{"type":"production","id":"prod-ProjectionTag","name":"ProjectionTag","referencingIds":["_ref_214"]},{"type":"production","id":"prod-ProjectionParameters","name":"ProjectionParameters","referencingIds":["_ref_215"]},{"type":"production","id":"prod-ProjectionBody","name":"ProjectionBody","referencingIds":["_ref_216"]},{"type":"production","id":"prod-ProjectionStatementList","name":"ProjectionStatementList","referencingIds":["_ref_220","_ref_222"]},{"type":"production","id":"prod-ProjectionStatementItem","name":"ProjectionStatementItem","referencingIds":["_ref_221","_ref_223"]},{"type":"production","id":"prod-ProjectionExpression","name":"ProjectionExpression","referencingIds":["_ref_226","_ref_282","_ref_284","_ref_285","_ref_286","_ref_288","_ref_301","_ref_304","_ref_305"]},{"type":"production","id":"prod-ProjectionReturnExpression","name":"ProjectionReturnExpression","referencingIds":["_ref_224"]},{"type":"production","id":"prod-ProjectionLogicalOrExpression","name":"ProjectionLogicalOrExpression","referencingIds":["_ref_225","_ref_228"]},{"type":"production","id":"prod-ProjectionLogicalAndExpression","name":"ProjectionLogicalAndExpression","referencingIds":["_ref_227","_ref_229","_ref_231"]},{"type":"production","id":"prod-ProjectionEqualityExpression","name":"ProjectionEqualityExpression","referencingIds":["_ref_234","_ref_236"]},{"type":"production","id":"prod-ProjectionRelationalExpression","name":"ProjectionRelationalExpression","referencingIds":["_ref_230","_ref_232","_ref_233","_ref_235","_ref_237","_ref_239","_ref_241","_ref_243","_ref_245"]},{"type":"production","id":"prod-ProjectionAdditiveExpression","name":"ProjectionAdditiveExpression","referencingIds":["_ref_238","_ref_240","_ref_242","_ref_244","_ref_246","_ref_248","_ref_250"]},{"type":"production","id":"prod-ProjectionMultiplicativeExpression","name":"ProjectionMultiplicativeExpression","referencingIds":["_ref_247","_ref_249","_ref_251","_ref_253","_ref_255"]},{"type":"production","id":"prod-ProjectionUnaryExpression","name":"ProjectionUnaryExpression","referencingIds":["_ref_252","_ref_254","_ref_256","_ref_258"]},{"type":"production","id":"prod-ProjectionCallExpression","name":"ProjectionCallExpression","referencingIds":["_ref_257","_ref_260","_ref_262","_ref_264"]},{"type":"production","id":"prod-ProjectionCallArguments","name":"ProjectionCallArguments","referencingIds":["_ref_261"]},{"type":"production","id":"prod-ProjectionDecoratorReferenceExpression","name":"ProjectionDecoratorReferenceExpression","referencingIds":["_ref_259"]},{"type":"production","id":"prod-ProjectionMemberExpression","name":"ProjectionMemberExpression","referencingIds":["_ref_267","_ref_270","_ref_272"]},{"type":"production","id":"prod-ProjectionPrimaryExpression","name":"ProjectionPrimaryExpression","referencingIds":["_ref_269"]},{"type":"production","id":"prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList","name":"CoverProjectionParenthesizedExpressionAndLambdaParameterList","referencingIds":["_ref_280","_ref_307"]},{"type":"production","id":"prod-ProjectionExpressionList","name":"ProjectionExpressionList","referencingIds":["_ref_266","_ref_281","_ref_283","_ref_306","_ref_309"]},{"type":"production","id":"prod-ProjectionIfExpression","name":"ProjectionIfExpression","referencingIds":["_ref_275","_ref_289"]},{"type":"production","id":"prod-ProjectionModelExpression","name":"ProjectionModelExpression","referencingIds":["_ref_278"]},{"type":"production","id":"prod-ProjectionModelBody","name":"ProjectionModelBody","referencingIds":["_ref_290"]},{"type":"production","id":"prod-ProjectionModelPropertyList","name":"ProjectionModelPropertyList","referencingIds":["_ref_291","_ref_292","_ref_294","_ref_296"]},{"type":"production","id":"prod-ProjectionModelProperty","name":"ProjectionModelProperty","referencingIds":["_ref_293","_ref_295","_ref_297"]},{"type":"production","id":"prod-ProjectionModelSpreadProperty","name":"ProjectionModelSpreadProperty","referencingIds":["_ref_298"]},{"type":"production","id":"prod-ProjectionTupleExpression","name":"ProjectionTupleExpression","referencingIds":["_ref_279"]},{"type":"production","id":"prod-ProjectionLambdaExpression","name":"ProjectionLambdaExpression","referencingIds":["_ref_276"]},{"type":"production","id":"prod-ProjectionBlockExpression","name":"ProjectionBlockExpression","referencingIds":["_ref_287","_ref_308"]},{"type":"production","id":"prod-LambdaParameters","name":"LambdaParameters"},{"type":"clause","id":"syntactic-grammar","titleHTML":"Syntactic Grammar","number":"2"}]}`);
+let biblio = JSON.parse(`{"refsByClause":{"lexical-grammar":["_ref_0","_ref_1","_ref_2","_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_9","_ref_10","_ref_11","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23","_ref_24","_ref_25","_ref_26","_ref_27","_ref_28","_ref_29","_ref_30","_ref_31","_ref_32","_ref_33","_ref_34","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45","_ref_46","_ref_47","_ref_48","_ref_49","_ref_50","_ref_51","_ref_52","_ref_53","_ref_54","_ref_55","_ref_56","_ref_57","_ref_58","_ref_59","_ref_60","_ref_61","_ref_62","_ref_63","_ref_64","_ref_65","_ref_66","_ref_67","_ref_68","_ref_69"],"syntactic-grammar":["_ref_70","_ref_71","_ref_72","_ref_73","_ref_74","_ref_75","_ref_76","_ref_77","_ref_78","_ref_79","_ref_80","_ref_81","_ref_82","_ref_83","_ref_84","_ref_85","_ref_86","_ref_87","_ref_88","_ref_89","_ref_90","_ref_91","_ref_92","_ref_93","_ref_94","_ref_95","_ref_96","_ref_97","_ref_98","_ref_99","_ref_100","_ref_101","_ref_102","_ref_103","_ref_104","_ref_105","_ref_106","_ref_107","_ref_108","_ref_109","_ref_110","_ref_111","_ref_112","_ref_113","_ref_114","_ref_115","_ref_116","_ref_117","_ref_118","_ref_119","_ref_120","_ref_121","_ref_122","_ref_123","_ref_124","_ref_125","_ref_126","_ref_127","_ref_128","_ref_129","_ref_130","_ref_131","_ref_132","_ref_133","_ref_134","_ref_135","_ref_136","_ref_137","_ref_138","_ref_139","_ref_140","_ref_141","_ref_142","_ref_143","_ref_144","_ref_145","_ref_146","_ref_147","_ref_148","_ref_149","_ref_150","_ref_151","_ref_152","_ref_153","_ref_154","_ref_155","_ref_156","_ref_157","_ref_158","_ref_159","_ref_160","_ref_161","_ref_162","_ref_163","_ref_164","_ref_165","_ref_166","_ref_167","_ref_168","_ref_169","_ref_170","_ref_171","_ref_172","_ref_173","_ref_174","_ref_175","_ref_176","_ref_177","_ref_178","_ref_179","_ref_180","_ref_181","_ref_182","_ref_183","_ref_184","_ref_185","_ref_186","_ref_187","_ref_188","_ref_189","_ref_190","_ref_191","_ref_192","_ref_193","_ref_194","_ref_195","_ref_196","_ref_197","_ref_198","_ref_199","_ref_200","_ref_201","_ref_202","_ref_203","_ref_204","_ref_205","_ref_206","_ref_207","_ref_208","_ref_209","_ref_210","_ref_211","_ref_212","_ref_213","_ref_214","_ref_215","_ref_216","_ref_217","_ref_218","_ref_219","_ref_220","_ref_221","_ref_222","_ref_223","_ref_224","_ref_225","_ref_226","_ref_227","_ref_228","_ref_229","_ref_230","_ref_231","_ref_232","_ref_233","_ref_234","_ref_235","_ref_236","_ref_237","_ref_238","_ref_239","_ref_240","_ref_241","_ref_242","_ref_243","_ref_244","_ref_245","_ref_246","_ref_247","_ref_248","_ref_249","_ref_250","_ref_251","_ref_252","_ref_253","_ref_254","_ref_255","_ref_256","_ref_257","_ref_258","_ref_259","_ref_260","_ref_261","_ref_262","_ref_263","_ref_264","_ref_265","_ref_266","_ref_267","_ref_268","_ref_269","_ref_270","_ref_271","_ref_272","_ref_273","_ref_274","_ref_275","_ref_276","_ref_277","_ref_278","_ref_279","_ref_280","_ref_281","_ref_282","_ref_283","_ref_284","_ref_285","_ref_286","_ref_287","_ref_288","_ref_289","_ref_290","_ref_291","_ref_292","_ref_293","_ref_294","_ref_295","_ref_296","_ref_297","_ref_298","_ref_299","_ref_300","_ref_301","_ref_302","_ref_303","_ref_304","_ref_305","_ref_306","_ref_307","_ref_308","_ref_309"]},"entries":[{"type":"clause","id":"intro","titleHTML":"Introduction","number":""},{"type":"production","id":"prod-SourceCharacter","name":"SourceCharacter","referencingIds":["_ref_49","_ref_53","_ref_64","_ref_65","_ref_69"]},{"type":"production","id":"prod-InputElement","name":"InputElement"},{"type":"production","id":"prod-Token","name":"Token","referencingIds":["_ref_0"]},{"type":"production","id":"prod-Trivia","name":"Trivia","referencingIds":["_ref_1"]},{"type":"production","id":"prod-Keyword","name":"Keyword","referencingIds":["_ref_2","_ref_11"]},{"type":"production","id":"prod-Identifier","name":"Identifier","referencingIds":["_ref_3","_ref_89","_ref_103","_ref_109","_ref_116","_ref_119","_ref_126","_ref_132","_ref_142","_ref_149","_ref_155","_ref_158","_ref_160","_ref_170","_ref_195","_ref_197","_ref_217","_ref_262","_ref_264","_ref_270","_ref_272","_ref_273","_ref_299"]},{"type":"production","id":"prod-IdentifierName","name":"IdentifierName","referencingIds":["_ref_10","_ref_13"]},{"type":"production","id":"prod-IdentifierStart","name":"IdentifierStart","referencingIds":["_ref_12"]},{"type":"production","id":"prod-IdentifierContinue","name":"IdentifierContinue","referencingIds":["_ref_14","_ref_15"]},{"type":"production","id":"prod-AsciiLetter","name":"AsciiLetter","referencingIds":["_ref_17"]},{"type":"production","id":"prod-BooleanLiteral","name":"BooleanLiteral","referencingIds":["_ref_9","_ref_188"]},{"type":"production","id":"prod-NumericLiteral","name":"NumericLiteral","referencingIds":["_ref_4","_ref_148","_ref_189"]},{"type":"production","id":"prod-DecimalLiteral","name":"DecimalLiteral","referencingIds":["_ref_19"]},{"type":"production","id":"prod-DecimalIntegerLiteral","name":"DecimalIntegerLiteral","referencingIds":["_ref_22","_ref_25","_ref_33"]},{"type":"production","id":"prod-DecimalDigits","name":"DecimalDigits","referencingIds":["_ref_23","_ref_27","_ref_28","_ref_29","_ref_31","_ref_34","_ref_35","_ref_36"]},{"type":"production","id":"prod-DecimalDigit","name":"DecimalDigit","referencingIds":["_ref_16","_ref_18","_ref_30","_ref_32"]},{"type":"production","id":"prod-ExponentPart","name":"ExponentPart","referencingIds":["_ref_24","_ref_26"]},{"type":"production","id":"prod-DecimalIntegerInteger","name":"DecimalIntegerInteger"},{"type":"production","id":"prod-HexIntegerLiteral","name":"HexIntegerLiteral","referencingIds":["_ref_20"]},{"type":"production","id":"prod-HexDigits","name":"HexDigits","referencingIds":["_ref_37","_ref_39"]},{"type":"production","id":"prod-HexDigit","name":"HexDigit","referencingIds":["_ref_38","_ref_40"]},{"type":"production","id":"prod-BinaryIntegerLiteral","name":"BinaryIntegerLiteral","referencingIds":["_ref_21"]},{"type":"production","id":"prod-BinaryDigits","name":"BinaryDigits","referencingIds":["_ref_41","_ref_43"]},{"type":"production","id":"prod-BinaryDigit","name":"BinaryDigit","referencingIds":["_ref_42","_ref_44"]},{"type":"production","id":"prod-StringLiteral","name":"StringLiteral","referencingIds":["_ref_5","_ref_77","_ref_106","_ref_129","_ref_145","_ref_147","_ref_187","_ref_302"]},{"type":"production","id":"prod-StringCharacters","name":"StringCharacters","referencingIds":["_ref_45","_ref_48"]},{"type":"production","id":"prod-StringCharacter","name":"StringCharacter","referencingIds":["_ref_47"]},{"type":"production","id":"prod-TripleQuotedStringCharacters","name":"TripleQuotedStringCharacters","referencingIds":["_ref_46","_ref_52"]},{"type":"production","id":"prod-TripleQuotedStringCharacter","name":"TripleQuotedStringCharacter","referencingIds":["_ref_51"]},{"type":"production","id":"prod-EscapeCharacter","name":"EscapeCharacter","referencingIds":["_ref_50","_ref_54"]},{"type":"production","id":"prod-Punctuator","name":"Punctuator","referencingIds":["_ref_6"]},{"type":"production","id":"prod-WhiteSpace","name":"WhiteSpace","referencingIds":["_ref_8"]},{"type":"production","id":"prod-Comment","name":"Comment","referencingIds":["_ref_7"]},{"type":"production","id":"prod-MultiLineComment","name":"MultiLineComment","referencingIds":["_ref_55"]},{"type":"production","id":"prod-MultiLineCommentChars","name":"MultiLineCommentChars","referencingIds":["_ref_57","_ref_59","_ref_62"]},{"type":"production","id":"prod-PostAsteriskCommentChars","name":"PostAsteriskCommentChars","referencingIds":["_ref_60","_ref_63"]},{"type":"production","id":"prod-MultiLineNotAsteriskChar","name":"MultiLineNotAsteriskChar","referencingIds":["_ref_58"]},{"type":"production","id":"prod-MultiLineNotForwardSlashOrAsteriskChar","name":"MultiLineNotForwardSlashOrAsteriskChar","referencingIds":["_ref_61"]},{"type":"production","id":"prod-SingleLineComment","name":"SingleLineComment","referencingIds":["_ref_56"]},{"type":"production","id":"prod-SingleLineCommentChars","name":"SingleLineCommentChars","referencingIds":["_ref_66","_ref_68"]},{"type":"production","id":"prod-SingleLineCommentChar","name":"SingleLineCommentChar","referencingIds":["_ref_67"]},{"type":"clause","id":"lexical-grammar","titleHTML":"Lexical Grammar","number":"1"},{"type":"production","id":"prod-CadlScriptItemList","name":"CadlScriptItemList","referencingIds":["_ref_70"]},{"type":"production","id":"prod-CadlScriptItem","name":"CadlScriptItem","referencingIds":["_ref_71"]},{"type":"production","id":"prod-BlocklessNamespaceStatement","name":"BlocklessNamespaceStatement","referencingIds":["_ref_72"]},{"type":"production","id":"prod-ImportStatement","name":"ImportStatement","referencingIds":["_ref_73"]},{"type":"production","id":"prod-StatementList","name":"StatementList","referencingIds":["_ref_78","_ref_163"]},{"type":"production","id":"prod-Statement","name":"Statement","referencingIds":["_ref_74","_ref_79"]},{"type":"production","id":"prod-UsingStatement","name":"UsingStatement","referencingIds":["_ref_84"]},{"type":"production","id":"prod-ModelStatement","name":"ModelStatement","referencingIds":["_ref_80"]},{"type":"production","id":"prod-ModelHeritage","name":"ModelHeritage","referencingIds":["_ref_90"]},{"type":"production","id":"prod-ModelBody","name":"ModelBody","referencingIds":["_ref_91","_ref_201"]},{"type":"production","id":"prod-ModelPropertyList","name":"ModelPropertyList","referencingIds":["_ref_94","_ref_95","_ref_97","_ref_99","_ref_164"]},{"type":"production","id":"prod-ModelProperty","name":"ModelProperty","referencingIds":["_ref_96","_ref_98","_ref_100"]},{"type":"production","id":"prod-ModelSpreadProperty","name":"ModelSpreadProperty","referencingIds":["_ref_101"]},{"type":"production","id":"prod-InterfaceStatement","name":"InterfaceStatement","referencingIds":["_ref_81"]},{"type":"production","id":"prod-InterfaceHeritage","name":"InterfaceHeritage","referencingIds":["_ref_110"]},{"type":"production","id":"prod-InterfaceMemberList","name":"InterfaceMemberList","referencingIds":["_ref_112","_ref_114"]},{"type":"production","id":"prod-InterfaceMember","name":"InterfaceMember","referencingIds":["_ref_113","_ref_115"]},{"type":"production","id":"prod-UnionStatement","name":"UnionStatement"},{"type":"production","id":"prod-UnionBody","name":"UnionBody","referencingIds":["_ref_120"]},{"type":"production","id":"prod-UnionVariantList","name":"UnionVariantList","referencingIds":["_ref_121","_ref_123"]},{"type":"production","id":"prod-UnionVariant","name":"UnionVariant","referencingIds":["_ref_122","_ref_124"]},{"type":"production","id":"prod-EnumStatement","name":"EnumStatement","referencingIds":["_ref_85"]},{"type":"production","id":"prod-EnumBody","name":"EnumBody","referencingIds":["_ref_133"]},{"type":"production","id":"prod-EnumMemberList","name":"EnumMemberList","referencingIds":["_ref_134","_ref_135","_ref_137","_ref_139"]},{"type":"production","id":"prod-EnumMember","name":"EnumMember","referencingIds":["_ref_136","_ref_138","_ref_140"]},{"type":"production","id":"prod-EnumMemberValue","name":"EnumMemberValue","referencingIds":["_ref_143","_ref_146"]},{"type":"production","id":"prod-AliasStatement","name":"AliasStatement","referencingIds":["_ref_86"]},{"type":"production","id":"prod-TemplateParameterList","name":"TemplateParameterList","referencingIds":["_ref_151","_ref_153"]},{"type":"production","id":"prod-TemplateParameter","name":"TemplateParameter","referencingIds":["_ref_152","_ref_154"]},{"type":"production","id":"prod-TemplateParameterDefault","name":"TemplateParameterDefault","referencingIds":["_ref_156"]},{"type":"production","id":"prod-IdentifierList","name":"IdentifierList","referencingIds":["_ref_159","_ref_218","_ref_309"]},{"type":"production","id":"prod-NamespaceStatement","name":"NamespaceStatement","referencingIds":["_ref_82"]},{"type":"production","id":"prod-OperationSignatureDeclaration","name":"OperationSignatureDeclaration","referencingIds":["_ref_167"]},{"type":"production","id":"prod-OperationSignatureReference","name":"OperationSignatureReference","referencingIds":["_ref_168"]},{"type":"production","id":"prod-OperationSignature","name":"OperationSignature","referencingIds":["_ref_117","_ref_172"]},{"type":"production","id":"prod-OperationStatement","name":"OperationStatement","referencingIds":["_ref_83"]},{"type":"production","id":"prod-Expression","name":"Expression","referencingIds":["_ref_104","_ref_107","_ref_127","_ref_130","_ref_150","_ref_157","_ref_165","_ref_200","_ref_203","_ref_205"]},{"type":"production","id":"prod-UnionExpressionOrHigher","name":"UnionExpressionOrHigher","referencingIds":["_ref_173","_ref_175"]},{"type":"production","id":"prod-IntersectionExpressionOrHigher","name":"IntersectionExpressionOrHigher","referencingIds":["_ref_174","_ref_176","_ref_178"]},{"type":"production","id":"prod-ArrayExpressionOrHigher","name":"ArrayExpressionOrHigher","referencingIds":["_ref_177","_ref_179","_ref_181"]},{"type":"production","id":"prod-PrimaryExpression","name":"PrimaryExpression","referencingIds":["_ref_180"]},{"type":"production","id":"prod-Literal","name":"Literal","referencingIds":["_ref_182","_ref_276"]},{"type":"production","id":"prod-ReferenceExpression","name":"ReferenceExpression","referencingIds":["_ref_92","_ref_93","_ref_108","_ref_166","_ref_183","_ref_192","_ref_194","_ref_216"]},{"type":"production","id":"prod-ReferenceExpressionList","name":"ReferenceExpressionList","referencingIds":["_ref_111","_ref_193"]},{"type":"production","id":"prod-IdentifierOrMemberExpression","name":"IdentifierOrMemberExpression","referencingIds":["_ref_76","_ref_87","_ref_162","_ref_190","_ref_196","_ref_208","_ref_267"]},{"type":"production","id":"prod-TemplateArguments","name":"TemplateArguments","referencingIds":["_ref_171","_ref_191"]},{"type":"production","id":"prod-ProjectionArguments","name":"ProjectionArguments"},{"type":"production","id":"prod-ParenthesizedExpression","name":"ParenthesizedExpression","referencingIds":["_ref_184"]},{"type":"production","id":"prod-ModelExpression","name":"ModelExpression","referencingIds":["_ref_185"]},{"type":"production","id":"prod-TupleExpression","name":"TupleExpression","referencingIds":["_ref_186"]},{"type":"production","id":"prod-ExpressionList","name":"ExpressionList","referencingIds":["_ref_198","_ref_199","_ref_202","_ref_204","_ref_210"]},{"type":"production","id":"prod-DecoratorList","name":"DecoratorList","referencingIds":["_ref_75","_ref_88","_ref_102","_ref_105","_ref_118","_ref_125","_ref_128","_ref_131","_ref_141","_ref_144","_ref_161","_ref_169","_ref_206","_ref_298","_ref_301"]},{"type":"production","id":"prod-Decorator","name":"Decorator","referencingIds":["_ref_207"]},{"type":"production","id":"prod-DecoratorArguments","name":"DecoratorArguments","referencingIds":["_ref_209"]},{"type":"production","id":"prod-ProjectionStatement","name":"ProjectionStatement"},{"type":"production","id":"prod-ProjectionSelector","name":"ProjectionSelector","referencingIds":["_ref_211"]},{"type":"production","id":"prod-ProjectionDirection","name":"ProjectionDirection","referencingIds":["_ref_212"]},{"type":"production","id":"prod-ProjectionTag","name":"ProjectionTag","referencingIds":["_ref_213"]},{"type":"production","id":"prod-ProjectionParameters","name":"ProjectionParameters","referencingIds":["_ref_214"]},{"type":"production","id":"prod-ProjectionBody","name":"ProjectionBody","referencingIds":["_ref_215"]},{"type":"production","id":"prod-ProjectionStatementList","name":"ProjectionStatementList","referencingIds":["_ref_219","_ref_221"]},{"type":"production","id":"prod-ProjectionStatementItem","name":"ProjectionStatementItem","referencingIds":["_ref_220","_ref_222"]},{"type":"production","id":"prod-ProjectionExpression","name":"ProjectionExpression","referencingIds":["_ref_225","_ref_281","_ref_283","_ref_284","_ref_285","_ref_287","_ref_300","_ref_303","_ref_304"]},{"type":"production","id":"prod-ProjectionReturnExpression","name":"ProjectionReturnExpression","referencingIds":["_ref_223"]},{"type":"production","id":"prod-ProjectionLogicalOrExpression","name":"ProjectionLogicalOrExpression","referencingIds":["_ref_224","_ref_227"]},{"type":"production","id":"prod-ProjectionLogicalAndExpression","name":"ProjectionLogicalAndExpression","referencingIds":["_ref_226","_ref_228","_ref_230"]},{"type":"production","id":"prod-ProjectionEqualityExpression","name":"ProjectionEqualityExpression","referencingIds":["_ref_233","_ref_235"]},{"type":"production","id":"prod-ProjectionRelationalExpression","name":"ProjectionRelationalExpression","referencingIds":["_ref_229","_ref_231","_ref_232","_ref_234","_ref_236","_ref_238","_ref_240","_ref_242","_ref_244"]},{"type":"production","id":"prod-ProjectionAdditiveExpression","name":"ProjectionAdditiveExpression","referencingIds":["_ref_237","_ref_239","_ref_241","_ref_243","_ref_245","_ref_247","_ref_249"]},{"type":"production","id":"prod-ProjectionMultiplicativeExpression","name":"ProjectionMultiplicativeExpression","referencingIds":["_ref_246","_ref_248","_ref_250","_ref_252","_ref_254"]},{"type":"production","id":"prod-ProjectionUnaryExpression","name":"ProjectionUnaryExpression","referencingIds":["_ref_251","_ref_253","_ref_255","_ref_257"]},{"type":"production","id":"prod-ProjectionCallExpression","name":"ProjectionCallExpression","referencingIds":["_ref_256","_ref_259","_ref_261","_ref_263"]},{"type":"production","id":"prod-ProjectionCallArguments","name":"ProjectionCallArguments","referencingIds":["_ref_260"]},{"type":"production","id":"prod-ProjectionDecoratorReferenceExpression","name":"ProjectionDecoratorReferenceExpression","referencingIds":["_ref_258"]},{"type":"production","id":"prod-ProjectionMemberExpression","name":"ProjectionMemberExpression","referencingIds":["_ref_266","_ref_269","_ref_271"]},{"type":"production","id":"prod-ProjectionPrimaryExpression","name":"ProjectionPrimaryExpression","referencingIds":["_ref_268"]},{"type":"production","id":"prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList","name":"CoverProjectionParenthesizedExpressionAndLambdaParameterList","referencingIds":["_ref_279","_ref_306"]},{"type":"production","id":"prod-ProjectionExpressionList","name":"ProjectionExpressionList","referencingIds":["_ref_265","_ref_280","_ref_282","_ref_305","_ref_308"]},{"type":"production","id":"prod-ProjectionIfExpression","name":"ProjectionIfExpression","referencingIds":["_ref_274","_ref_288"]},{"type":"production","id":"prod-ProjectionModelExpression","name":"ProjectionModelExpression","referencingIds":["_ref_277"]},{"type":"production","id":"prod-ProjectionModelBody","name":"ProjectionModelBody","referencingIds":["_ref_289"]},{"type":"production","id":"prod-ProjectionModelPropertyList","name":"ProjectionModelPropertyList","referencingIds":["_ref_290","_ref_291","_ref_293","_ref_295"]},{"type":"production","id":"prod-ProjectionModelProperty","name":"ProjectionModelProperty","referencingIds":["_ref_292","_ref_294","_ref_296"]},{"type":"production","id":"prod-ProjectionModelSpreadProperty","name":"ProjectionModelSpreadProperty","referencingIds":["_ref_297"]},{"type":"production","id":"prod-ProjectionTupleExpression","name":"ProjectionTupleExpression","referencingIds":["_ref_278"]},{"type":"production","id":"prod-ProjectionLambdaExpression","name":"ProjectionLambdaExpression","referencingIds":["_ref_275"]},{"type":"production","id":"prod-ProjectionBlockExpression","name":"ProjectionBlockExpression","referencingIds":["_ref_286","_ref_307"]},{"type":"production","id":"prod-LambdaParameters","name":"LambdaParameters"},{"type":"clause","id":"syntactic-grammar","titleHTML":"Syntactic Grammar","number":"2"}]}`);
 ;let usesMultipage = false</script><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/styles/base16/solarized-light.min.css"><style>body {
   display: flex;
   font-size: 18px;
@@ -3083,371 +3083,367 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="InterfaceMember" id="prod-InterfaceMember">
-    <emu-nt><a href="#prod-InterfaceMember">InterfaceMember</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="i02ribbk">
+    <emu-nt><a href="#prod-InterfaceMember">InterfaceMember</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="amlwgryq">
         <emu-t optional="">op<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
         <emu-nt id="_ref_116"><a href="#prod-Identifier">Identifier</a></emu-nt>
-        <emu-t>(</emu-t>
-        <emu-nt optional="" id="_ref_117"><a href="#prod-ModelPropertyList">ModelPropertyList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-t>)</emu-t>
-        <emu-t>:</emu-t>
-        <emu-nt id="_ref_118"><a href="#prod-Expression">Expression</a></emu-nt>
+        <emu-nt id="_ref_117"><a href="#prod-OperationSignature">OperationSignature</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="UnionStatement" id="prod-UnionStatement">
     <emu-nt><a href="#prod-UnionStatement">UnionStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="jqsx6v8u">
-        <emu-nt optional="" id="_ref_119"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_118"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>union</emu-t>
-        <emu-nt id="_ref_120"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_119"><a href="#prod-Identifier">Identifier</a></emu-nt>
         <emu-nt optional="">TemplateParameters<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>{</emu-t>
-        <emu-nt optional="" id="_ref_121"><a href="#prod-UnionBody">UnionBody</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_120"><a href="#prod-UnionBody">UnionBody</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="UnionBody" id="prod-UnionBody">
     <emu-nt><a href="#prod-UnionBody">UnionBody</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="lauvayzn">
-        <emu-nt id="_ref_122"><a href="#prod-UnionVariantList">UnionVariantList</a></emu-nt>
+        <emu-nt id="_ref_121"><a href="#prod-UnionVariantList">UnionVariantList</a></emu-nt>
         <emu-t optional="">;<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="UnionVariantList" id="prod-UnionVariantList">
     <emu-nt><a href="#prod-UnionVariantList">UnionVariantList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="cfhz-n9b">
-        <emu-nt id="_ref_123"><a href="#prod-UnionVariant">UnionVariant</a></emu-nt>
+        <emu-nt id="_ref_122"><a href="#prod-UnionVariant">UnionVariant</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="b_wjyurc">
-        <emu-nt id="_ref_124"><a href="#prod-UnionVariantList">UnionVariantList</a></emu-nt>
+        <emu-nt id="_ref_123"><a href="#prod-UnionVariantList">UnionVariantList</a></emu-nt>
         <emu-t>;</emu-t>
-        <emu-nt id="_ref_125"><a href="#prod-UnionVariant">UnionVariant</a></emu-nt>
+        <emu-nt id="_ref_124"><a href="#prod-UnionVariant">UnionVariant</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="UnionVariant" id="prod-UnionVariant">
     <emu-nt><a href="#prod-UnionVariant">UnionVariant</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="h9gqpl1v">
-        <emu-nt optional="" id="_ref_126"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_127"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt optional="" id="_ref_125"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_126"><a href="#prod-Identifier">Identifier</a></emu-nt>
         <emu-t>:</emu-t>
-        <emu-nt id="_ref_128"><a href="#prod-Expression">Expression</a></emu-nt>
+        <emu-nt id="_ref_127"><a href="#prod-Expression">Expression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="2mhcutnm">
-        <emu-nt optional="" id="_ref_129"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_130"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
+        <emu-nt optional="" id="_ref_128"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_129"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
         <emu-t>:</emu-t>
-        <emu-nt id="_ref_131"><a href="#prod-Expression">Expression</a></emu-nt>
+        <emu-nt id="_ref_130"><a href="#prod-Expression">Expression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="EnumStatement" id="prod-EnumStatement">
     <emu-nt><a href="#prod-EnumStatement">EnumStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="i7ob7wbq">
-        <emu-nt optional="" id="_ref_132"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_131"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>enum</emu-t>
-        <emu-nt id="_ref_133"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_132"><a href="#prod-Identifier">Identifier</a></emu-nt>
         <emu-t>{</emu-t>
-        <emu-nt optional="" id="_ref_134"><a href="#prod-EnumBody">EnumBody</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_133"><a href="#prod-EnumBody">EnumBody</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="EnumBody" id="prod-EnumBody">
     <emu-nt><a href="#prod-EnumBody">EnumBody</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ag--srfg">
-        <emu-nt id="_ref_135"><a href="#prod-EnumMemberList">EnumMemberList</a></emu-nt>
+        <emu-nt id="_ref_134"><a href="#prod-EnumMemberList">EnumMemberList</a></emu-nt>
         <emu-t optional="">,<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
     </emu-rhs>
     <emu-rhs a="vfvqnt4z">
-        <emu-nt id="_ref_136"><a href="#prod-EnumMemberList">EnumMemberList</a></emu-nt>
+        <emu-nt id="_ref_135"><a href="#prod-EnumMemberList">EnumMemberList</a></emu-nt>
         <emu-t optional="">;<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="EnumMemberList" id="prod-EnumMemberList">
     <emu-nt><a href="#prod-EnumMemberList">EnumMemberList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="vflanevg">
-        <emu-nt id="_ref_137"><a href="#prod-EnumMember">EnumMember</a></emu-nt>
+        <emu-nt id="_ref_136"><a href="#prod-EnumMember">EnumMember</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="7dn-cbj2">
-        <emu-nt id="_ref_138"><a href="#prod-EnumMemberList">EnumMemberList</a></emu-nt>
+        <emu-nt id="_ref_137"><a href="#prod-EnumMemberList">EnumMemberList</a></emu-nt>
         <emu-t>,</emu-t>
-        <emu-nt id="_ref_139"><a href="#prod-EnumMember">EnumMember</a></emu-nt>
+        <emu-nt id="_ref_138"><a href="#prod-EnumMember">EnumMember</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="qjf2au36">
-        <emu-nt id="_ref_140"><a href="#prod-EnumMemberList">EnumMemberList</a></emu-nt>
+        <emu-nt id="_ref_139"><a href="#prod-EnumMemberList">EnumMemberList</a></emu-nt>
         <emu-t>;</emu-t>
-        <emu-nt id="_ref_141"><a href="#prod-EnumMember">EnumMember</a></emu-nt>
+        <emu-nt id="_ref_140"><a href="#prod-EnumMember">EnumMember</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="EnumMember" id="prod-EnumMember">
     <emu-nt><a href="#prod-EnumMember">EnumMember</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="htyyapxs">
-        <emu-nt optional="" id="_ref_142"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_143"><a href="#prod-Identifier">Identifier</a></emu-nt>
-        <emu-nt optional="" id="_ref_144"><a href="#prod-EnumMemberValue">EnumMemberValue</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_141"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_142"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt optional="" id="_ref_143"><a href="#prod-EnumMemberValue">EnumMemberValue</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
     <emu-rhs a="d-ggnl4a">
-        <emu-nt optional="" id="_ref_145"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_146"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
-        <emu-nt optional="" id="_ref_147"><a href="#prod-EnumMemberValue">EnumMemberValue</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_144"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_145"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
+        <emu-nt optional="" id="_ref_146"><a href="#prod-EnumMemberValue">EnumMemberValue</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="EnumMemberValue" id="prod-EnumMemberValue">
     <emu-nt><a href="#prod-EnumMemberValue">EnumMemberValue</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="qbuxgevr">
         <emu-t>:</emu-t>
-        <emu-nt id="_ref_148"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
+        <emu-nt id="_ref_147"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="ib128nab">
         <emu-t>:</emu-t>
-        <emu-nt id="_ref_149"><a href="#prod-NumericLiteral">NumericLiteral</a></emu-nt>
+        <emu-nt id="_ref_148"><a href="#prod-NumericLiteral">NumericLiteral</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="AliasStatement" id="prod-AliasStatement">
     <emu-nt><a href="#prod-AliasStatement">AliasStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="vcp2vkl0">
         <emu-t>alias</emu-t>
-        <emu-nt id="_ref_150"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_149"><a href="#prod-Identifier">Identifier</a></emu-nt>
         <emu-nt optional="">TemplateParameters<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>=</emu-t>
-        <emu-nt id="_ref_151"><a href="#prod-Expression">Expression</a></emu-nt>
+        <emu-nt id="_ref_150"><a href="#prod-Expression">Expression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="n0rgsga2">
         <emu-nt>TemplateParameters</emu-nt>
     </emu-rhs>
     <emu-rhs a="bedwy-8u">
         <emu-t>&lt;</emu-t>
-        <emu-nt id="_ref_152"><a href="#prod-TemplateParameterList">TemplateParameterList</a></emu-nt>
+        <emu-nt id="_ref_151"><a href="#prod-TemplateParameterList">TemplateParameterList</a></emu-nt>
         <emu-t>&gt;</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="TemplateParameterList" id="prod-TemplateParameterList">
     <emu-nt><a href="#prod-TemplateParameterList">TemplateParameterList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ejiqpl9p">
-        <emu-nt id="_ref_153"><a href="#prod-TemplateParameter">TemplateParameter</a></emu-nt>
+        <emu-nt id="_ref_152"><a href="#prod-TemplateParameter">TemplateParameter</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="sxsfhd-n">
-        <emu-nt id="_ref_154"><a href="#prod-TemplateParameterList">TemplateParameterList</a></emu-nt>
+        <emu-nt id="_ref_153"><a href="#prod-TemplateParameterList">TemplateParameterList</a></emu-nt>
         <emu-t>,</emu-t>
-        <emu-nt id="_ref_155"><a href="#prod-TemplateParameter">TemplateParameter</a></emu-nt>
+        <emu-nt id="_ref_154"><a href="#prod-TemplateParameter">TemplateParameter</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="TemplateParameter" id="prod-TemplateParameter">
     <emu-nt><a href="#prod-TemplateParameter">TemplateParameter</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="pzfwtbdz">
-        <emu-nt id="_ref_156"><a href="#prod-Identifier">Identifier</a></emu-nt>
-        <emu-nt optional="" id="_ref_157"><a href="#prod-TemplateParameterDefault">TemplateParameterDefault</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_155"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt optional="" id="_ref_156"><a href="#prod-TemplateParameterDefault">TemplateParameterDefault</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="TemplateParameterDefault" id="prod-TemplateParameterDefault">
     <emu-nt><a href="#prod-TemplateParameterDefault">TemplateParameterDefault</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="a5ipakza">
         <emu-t>=</emu-t>
-        <emu-nt id="_ref_158"><a href="#prod-Expression">Expression</a></emu-nt>
+        <emu-nt id="_ref_157"><a href="#prod-Expression">Expression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="IdentifierList" id="prod-IdentifierList">
     <emu-nt><a href="#prod-IdentifierList">IdentifierList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bras6mo_">
-        <emu-nt id="_ref_159"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_158"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="btxjxlll">
-        <emu-nt id="_ref_160"><a href="#prod-IdentifierList">IdentifierList</a></emu-nt>
+        <emu-nt id="_ref_159"><a href="#prod-IdentifierList">IdentifierList</a></emu-nt>
         <emu-t>,</emu-t>
-        <emu-nt id="_ref_161"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_160"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="NamespaceStatement" id="prod-NamespaceStatement">
     <emu-nt><a href="#prod-NamespaceStatement">NamespaceStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="lrsdvje0">
-        <emu-nt optional="" id="_ref_162"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_161"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>namespace</emu-t>
-        <emu-nt id="_ref_163"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
+        <emu-nt id="_ref_162"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
         <emu-t>{</emu-t>
-        <emu-nt optional="" id="_ref_164"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_163"><a href="#prod-StatementList">StatementList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="OperationSignatureDeclaration" id="prod-OperationSignatureDeclaration">
     <emu-nt><a href="#prod-OperationSignatureDeclaration">OperationSignatureDeclaration</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="fv6fbcct">
         <emu-t>(</emu-t>
-        <emu-nt optional="" id="_ref_165"><a href="#prod-ModelPropertyList">ModelPropertyList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_164"><a href="#prod-ModelPropertyList">ModelPropertyList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>)</emu-t>
         <emu-t>:</emu-t>
-        <emu-nt id="_ref_166"><a href="#prod-Expression">Expression</a></emu-nt>
+        <emu-nt id="_ref_165"><a href="#prod-Expression">Expression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="OperationSignatureReference" id="prod-OperationSignatureReference">
     <emu-nt><a href="#prod-OperationSignatureReference">OperationSignatureReference</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="_vfnudru">
         <emu-t>:</emu-t>
-        <emu-nt id="_ref_167"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
+        <emu-nt id="_ref_166"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="OperationSignature" id="prod-OperationSignature">
     <emu-nt><a href="#prod-OperationSignature">OperationSignature</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="auwsgpwa">
-        <emu-nt id="_ref_168"><a href="#prod-OperationSignatureDeclaration">OperationSignatureDeclaration</a></emu-nt>
+        <emu-nt id="_ref_167"><a href="#prod-OperationSignatureDeclaration">OperationSignatureDeclaration</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="pffyodoe">
-        <emu-nt id="_ref_169"><a href="#prod-OperationSignatureReference">OperationSignatureReference</a></emu-nt>
+        <emu-nt id="_ref_168"><a href="#prod-OperationSignatureReference">OperationSignatureReference</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="OperationStatement" id="prod-OperationStatement">
     <emu-nt><a href="#prod-OperationStatement">OperationStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="actcwu87">
-        <emu-nt optional="" id="_ref_170"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_169"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>op</emu-t>
-        <emu-nt id="_ref_171"><a href="#prod-Identifier">Identifier</a></emu-nt>
-        <emu-nt optional="" id="_ref_172"><a href="#prod-TemplateArguments">TemplateArguments</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_173"><a href="#prod-OperationSignature">OperationSignature</a></emu-nt>
+        <emu-nt id="_ref_170"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt optional="" id="_ref_171"><a href="#prod-TemplateArguments">TemplateArguments</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_172"><a href="#prod-OperationSignature">OperationSignature</a></emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="Expression" id="prod-Expression">
     <emu-nt><a href="#prod-Expression">Expression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="otzlm2nv">
-        <emu-nt id="_ref_174"><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_173"><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="UnionExpressionOrHigher" id="prod-UnionExpressionOrHigher">
     <emu-nt><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="l4bpz882">
-        <emu-nt id="_ref_175"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_174"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="oiwllrbb">
         <emu-t optional="">|<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
-        <emu-nt id="_ref_176"><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_175"><a href="#prod-UnionExpressionOrHigher">UnionExpressionOrHigher</a></emu-nt>
         <emu-t>|</emu-t>
-        <emu-nt id="_ref_177"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_176"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="IntersectionExpressionOrHigher" id="prod-IntersectionExpressionOrHigher">
     <emu-nt><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="fxst_igc">
-        <emu-nt id="_ref_178"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_177"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="cgkcj8yb">
         <emu-t optional="">&amp;<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
-        <emu-nt id="_ref_179"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_178"><a href="#prod-IntersectionExpressionOrHigher">IntersectionExpressionOrHigher</a></emu-nt>
         <emu-t>&amp;</emu-t>
-        <emu-nt id="_ref_180"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_179"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ArrayExpressionOrHigher" id="prod-ArrayExpressionOrHigher">
     <emu-nt><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="jvcvemtw">
-        <emu-nt id="_ref_181"><a href="#prod-PrimaryExpression">PrimaryExpression</a></emu-nt>
+        <emu-nt id="_ref_180"><a href="#prod-PrimaryExpression">PrimaryExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="8k-eixnj">
-        <emu-nt id="_ref_182"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt>
+        <emu-nt id="_ref_181"><a href="#prod-ArrayExpressionOrHigher">ArrayExpressionOrHigher</a></emu-nt>
         <emu-t>[</emu-t>
         <emu-t>]</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="PrimaryExpression" id="prod-PrimaryExpression">
     <emu-nt><a href="#prod-PrimaryExpression">PrimaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="kul-a19e">
-        <emu-nt id="_ref_183"><a href="#prod-Literal">Literal</a></emu-nt>
+        <emu-nt id="_ref_182"><a href="#prod-Literal">Literal</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="mpejatd_">
-        <emu-nt id="_ref_184"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
+        <emu-nt id="_ref_183"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="k5j7cutc">
-        <emu-nt id="_ref_185"><a href="#prod-ParenthesizedExpression">ParenthesizedExpression</a></emu-nt>
+        <emu-nt id="_ref_184"><a href="#prod-ParenthesizedExpression">ParenthesizedExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="d007fnkw">
-        <emu-nt id="_ref_186"><a href="#prod-ModelExpression">ModelExpression</a></emu-nt>
+        <emu-nt id="_ref_185"><a href="#prod-ModelExpression">ModelExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="rmcinm4a">
-        <emu-nt id="_ref_187"><a href="#prod-TupleExpression">TupleExpression</a></emu-nt>
+        <emu-nt id="_ref_186"><a href="#prod-TupleExpression">TupleExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="Literal" id="prod-Literal">
     <emu-nt><a href="#prod-Literal">Literal</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="xhtltz00">
-        <emu-nt id="_ref_188"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
+        <emu-nt id="_ref_187"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="nqjh_sxl">
-        <emu-nt id="_ref_189"><a href="#prod-BooleanLiteral">BooleanLiteral</a></emu-nt>
+        <emu-nt id="_ref_188"><a href="#prod-BooleanLiteral">BooleanLiteral</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="pui0b1rt">
-        <emu-nt id="_ref_190"><a href="#prod-NumericLiteral">NumericLiteral</a></emu-nt>
+        <emu-nt id="_ref_189"><a href="#prod-NumericLiteral">NumericLiteral</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ReferenceExpression" id="prod-ReferenceExpression">
     <emu-nt><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="mzr2yu9j">
-        <emu-nt id="_ref_191"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
-        <emu-nt optional="" id="_ref_192"><a href="#prod-TemplateArguments">TemplateArguments</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_190"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
+        <emu-nt optional="" id="_ref_191"><a href="#prod-TemplateArguments">TemplateArguments</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ReferenceExpressionList" id="prod-ReferenceExpressionList">
     <emu-nt><a href="#prod-ReferenceExpressionList">ReferenceExpressionList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="mpejatd_">
-        <emu-nt id="_ref_193"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
+        <emu-nt id="_ref_192"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="ry70nwgl">
-        <emu-nt id="_ref_194"><a href="#prod-ReferenceExpressionList">ReferenceExpressionList</a></emu-nt>
+        <emu-nt id="_ref_193"><a href="#prod-ReferenceExpressionList">ReferenceExpressionList</a></emu-nt>
         <emu-t>,</emu-t>
-        <emu-nt id="_ref_195"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
+        <emu-nt id="_ref_194"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="IdentifierOrMemberExpression" id="prod-IdentifierOrMemberExpression">
     <emu-nt><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bras6mo_">
-        <emu-nt id="_ref_196"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_195"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="fagplbkz">
-        <emu-nt id="_ref_197"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
+        <emu-nt id="_ref_196"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
         <emu-t>.</emu-t>
-        <emu-nt id="_ref_198"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_197"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="TemplateArguments" id="prod-TemplateArguments">
     <emu-nt><a href="#prod-TemplateArguments">TemplateArguments</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="erulm7dq">
         <emu-t>&lt;</emu-t>
-        <emu-nt id="_ref_199"><a href="#prod-ExpressionList">ExpressionList</a></emu-nt>
+        <emu-nt id="_ref_198"><a href="#prod-ExpressionList">ExpressionList</a></emu-nt>
         <emu-t>&gt;</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionArguments" id="prod-ProjectionArguments">
     <emu-nt><a href="#prod-ProjectionArguments">ProjectionArguments</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="gq6jlu5e">
         <emu-t>(</emu-t>
-        <emu-nt optional="" id="_ref_200"><a href="#prod-ExpressionList">ExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_199"><a href="#prod-ExpressionList">ExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ParenthesizedExpression" id="prod-ParenthesizedExpression">
     <emu-nt><a href="#prod-ParenthesizedExpression">ParenthesizedExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="s6bvnd5v">
         <emu-t>(</emu-t>
-        <emu-nt id="_ref_201"><a href="#prod-Expression">Expression</a></emu-nt>
+        <emu-nt id="_ref_200"><a href="#prod-Expression">Expression</a></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ModelExpression" id="prod-ModelExpression">
     <emu-nt><a href="#prod-ModelExpression">ModelExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="p9stvizw">
         <emu-t>{</emu-t>
-        <emu-nt optional="" id="_ref_202"><a href="#prod-ModelBody">ModelBody</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_201"><a href="#prod-ModelBody">ModelBody</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="TupleExpression" id="prod-TupleExpression">
     <emu-nt><a href="#prod-TupleExpression">TupleExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="lfcd3ro5">
         <emu-t>[</emu-t>
-        <emu-nt optional="" id="_ref_203"><a href="#prod-ExpressionList">ExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_202"><a href="#prod-ExpressionList">ExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>]</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ExpressionList" id="prod-ExpressionList">
     <emu-nt><a href="#prod-ExpressionList">ExpressionList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="l7avubnp">
-        <emu-nt id="_ref_204"><a href="#prod-Expression">Expression</a></emu-nt>
+        <emu-nt id="_ref_203"><a href="#prod-Expression">Expression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="8cbmyyhk">
-        <emu-nt id="_ref_205"><a href="#prod-ExpressionList">ExpressionList</a></emu-nt>
+        <emu-nt id="_ref_204"><a href="#prod-ExpressionList">ExpressionList</a></emu-nt>
         <emu-t>,</emu-t>
-        <emu-nt id="_ref_206"><a href="#prod-Expression">Expression</a></emu-nt>
+        <emu-nt id="_ref_205"><a href="#prod-Expression">Expression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="DecoratorList" id="prod-DecoratorList">
     <emu-nt><a href="#prod-DecoratorList">DecoratorList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="a6fvhq_2">
-        <emu-nt optional="" id="_ref_207"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_208"><a href="#prod-Decorator">Decorator</a></emu-nt>
+        <emu-nt optional="" id="_ref_206"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_207"><a href="#prod-Decorator">Decorator</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="Decorator" id="prod-Decorator">
     <emu-nt><a href="#prod-Decorator">Decorator</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="p1dbtqtg">
         <emu-t>@</emu-t>
-        <emu-nt id="_ref_209"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
-        <emu-nt optional="" id="_ref_210"><a href="#prod-DecoratorArguments">DecoratorArguments</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_208"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
+        <emu-nt optional="" id="_ref_209"><a href="#prod-DecoratorArguments">DecoratorArguments</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="DecoratorArguments" id="prod-DecoratorArguments">
     <emu-nt><a href="#prod-DecoratorArguments">DecoratorArguments</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="gq6jlu5e">
         <emu-t>(</emu-t>
-        <emu-nt optional="" id="_ref_211"><a href="#prod-ExpressionList">ExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_210"><a href="#prod-ExpressionList">ExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionStatement" id="prod-ProjectionStatement">
     <emu-nt><a href="#prod-ProjectionStatement">ProjectionStatement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="_13j6y1k">
         <emu-t>projection</emu-t>
-        <emu-nt id="_ref_212"><a href="#prod-ProjectionSelector">ProjectionSelector</a></emu-nt>
-        <emu-nt id="_ref_213"><a href="#prod-ProjectionDirection">ProjectionDirection</a></emu-nt>
-        <emu-nt id="_ref_214"><a href="#prod-ProjectionTag">ProjectionTag</a></emu-nt>
-        <emu-nt optional="" id="_ref_215"><a href="#prod-ProjectionParameters">ProjectionParameters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_211"><a href="#prod-ProjectionSelector">ProjectionSelector</a></emu-nt>
+        <emu-nt id="_ref_212"><a href="#prod-ProjectionDirection">ProjectionDirection</a></emu-nt>
+        <emu-nt id="_ref_213"><a href="#prod-ProjectionTag">ProjectionTag</a></emu-nt>
+        <emu-nt optional="" id="_ref_214"><a href="#prod-ProjectionParameters">ProjectionParameters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>{</emu-t>
-        <emu-nt id="_ref_216"><a href="#prod-ProjectionBody">ProjectionBody</a></emu-nt>
+        <emu-nt id="_ref_215"><a href="#prod-ProjectionBody">ProjectionBody</a></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
@@ -3465,7 +3461,7 @@ li.menu-search-result-term:before {
         <emu-t>union</emu-t>
     </emu-rhs>
     <emu-rhs a="mpejatd_">
-        <emu-nt id="_ref_217"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
+        <emu-nt id="_ref_216"><a href="#prod-ReferenceExpression">ReferenceExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionDirection" id="prod-ProjectionDirection">
@@ -3479,29 +3475,29 @@ li.menu-search-result-term:before {
 <emu-production name="ProjectionTag" id="prod-ProjectionTag">
     <emu-nt><a href="#prod-ProjectionTag">ProjectionTag</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="pkshwqzc">
         <emu-t>#</emu-t>
-        <emu-nt id="_ref_218"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_217"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionParameters" id="prod-ProjectionParameters">
     <emu-nt><a href="#prod-ProjectionParameters">ProjectionParameters</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="yyjrc85a">
         <emu-t>(</emu-t>
-        <emu-nt optional="" id="_ref_219"><a href="#prod-IdentifierList">IdentifierList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_218"><a href="#prod-IdentifierList">IdentifierList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionBody" id="prod-ProjectionBody">
     <emu-nt><a href="#prod-ProjectionBody">ProjectionBody</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bxmgst2s">
-        <emu-nt id="_ref_220"><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt>
+        <emu-nt id="_ref_219"><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionStatementList" id="prod-ProjectionStatementList">
     <emu-nt><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="8jls0kgx">
-        <emu-nt id="_ref_221"><a href="#prod-ProjectionStatementItem">ProjectionStatementItem</a></emu-nt>
+        <emu-nt id="_ref_220"><a href="#prod-ProjectionStatementItem">ProjectionStatementItem</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="123mhtoq">
-        <emu-nt id="_ref_222"><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt>
+        <emu-nt id="_ref_221"><a href="#prod-ProjectionStatementList">ProjectionStatementList</a></emu-nt>
         <emu-t>;</emu-t>
-        <emu-nt id="_ref_223"><a href="#prod-ProjectionStatementItem">ProjectionStatementItem</a></emu-nt>
+        <emu-nt id="_ref_222"><a href="#prod-ProjectionStatementItem">ProjectionStatementItem</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionStatementItem" id="prod-ProjectionStatementItem">
@@ -3511,165 +3507,165 @@ li.menu-search-result-term:before {
 </emu-production>
 <emu-production name="ProjectionExpression" id="prod-ProjectionExpression">
     <emu-nt><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="vzsiuzn4">
-        <emu-nt id="_ref_224"><a href="#prod-ProjectionReturnExpression">ProjectionReturnExpression</a></emu-nt>
+        <emu-nt id="_ref_223"><a href="#prod-ProjectionReturnExpression">ProjectionReturnExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionReturnExpression" id="prod-ProjectionReturnExpression">
     <emu-nt><a href="#prod-ProjectionReturnExpression">ProjectionReturnExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="24gnoobj">
-        <emu-nt id="_ref_225"><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt>
+        <emu-nt id="_ref_224"><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="mxa7it1a">
         <emu-t>return</emu-t>
-        <emu-nt id="_ref_226"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_225"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionLogicalOrExpression" id="prod-ProjectionLogicalOrExpression">
     <emu-nt><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="aawamjyo">
-        <emu-nt id="_ref_227"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt>
+        <emu-nt id="_ref_226"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="k589waww">
-        <emu-nt id="_ref_228"><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt>
+        <emu-nt id="_ref_227"><a href="#prod-ProjectionLogicalOrExpression">ProjectionLogicalOrExpression</a></emu-nt>
         <emu-t>||</emu-t>
-        <emu-nt id="_ref_229"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt>
+        <emu-nt id="_ref_228"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionLogicalAndExpression" id="prod-ProjectionLogicalAndExpression">
     <emu-nt><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="nttyzhj4">
-        <emu-nt id="_ref_230"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_229"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="evmo1uol">
-        <emu-nt id="_ref_231"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt>
+        <emu-nt id="_ref_230"><a href="#prod-ProjectionLogicalAndExpression">ProjectionLogicalAndExpression</a></emu-nt>
         <emu-t>&amp;&amp;</emu-t>
-        <emu-nt id="_ref_232"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_231"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionEqualityExpression" id="prod-ProjectionEqualityExpression">
     <emu-nt><a href="#prod-ProjectionEqualityExpression">ProjectionEqualityExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="nttyzhj4">
-        <emu-nt id="_ref_233"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_232"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="lackn1tw">
-        <emu-nt id="_ref_234"><a href="#prod-ProjectionEqualityExpression">ProjectionEqualityExpression</a></emu-nt>
+        <emu-nt id="_ref_233"><a href="#prod-ProjectionEqualityExpression">ProjectionEqualityExpression</a></emu-nt>
         <emu-t>==</emu-t>
-        <emu-nt id="_ref_235"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_234"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="mlrnlbcv">
-        <emu-nt id="_ref_236"><a href="#prod-ProjectionEqualityExpression">ProjectionEqualityExpression</a></emu-nt>
+        <emu-nt id="_ref_235"><a href="#prod-ProjectionEqualityExpression">ProjectionEqualityExpression</a></emu-nt>
         <emu-t>!=</emu-t>
-        <emu-nt id="_ref_237"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_236"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionRelationalExpression" id="prod-ProjectionRelationalExpression">
     <emu-nt><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="flky6l5a">
-        <emu-nt id="_ref_238"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+        <emu-nt id="_ref_237"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="7lkhh7co">
-        <emu-nt id="_ref_239"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_238"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
         <emu-t>&lt;</emu-t>
-        <emu-nt id="_ref_240"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+        <emu-nt id="_ref_239"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="jwbqdqyk">
-        <emu-nt id="_ref_241"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_240"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
         <emu-t>&gt;</emu-t>
-        <emu-nt id="_ref_242"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+        <emu-nt id="_ref_241"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="rg5xsl8u">
-        <emu-nt id="_ref_243"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_242"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
         <emu-t>&lt;=</emu-t>
-        <emu-nt id="_ref_244"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+        <emu-nt id="_ref_243"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="y-qu2tqb">
-        <emu-nt id="_ref_245"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
+        <emu-nt id="_ref_244"><a href="#prod-ProjectionRelationalExpression">ProjectionRelationalExpression</a></emu-nt>
         <emu-t>&gt;=</emu-t>
-        <emu-nt id="_ref_246"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+        <emu-nt id="_ref_245"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionAdditiveExpression" id="prod-ProjectionAdditiveExpression">
     <emu-nt><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="eked4n7k">
-        <emu-nt id="_ref_247"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
+        <emu-nt id="_ref_246"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="iiox3k7e">
-        <emu-nt id="_ref_248"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+        <emu-nt id="_ref_247"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
         <emu-t>+</emu-t>
-        <emu-nt id="_ref_249"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
+        <emu-nt id="_ref_248"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="xy3v8nqo">
-        <emu-nt id="_ref_250"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
+        <emu-nt id="_ref_249"><a href="#prod-ProjectionAdditiveExpression">ProjectionAdditiveExpression</a></emu-nt>
         <emu-t>-</emu-t>
-        <emu-nt id="_ref_251"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
+        <emu-nt id="_ref_250"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionMultiplicativeExpression" id="prod-ProjectionMultiplicativeExpression">
     <emu-nt><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="eosbpz0i">
-        <emu-nt id="_ref_252"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
+        <emu-nt id="_ref_251"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="oklvxhw2">
-        <emu-nt id="_ref_253"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
+        <emu-nt id="_ref_252"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
         <emu-t>*</emu-t>
-        <emu-nt id="_ref_254"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
+        <emu-nt id="_ref_253"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="vmdvvwy0">
-        <emu-nt id="_ref_255"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
+        <emu-nt id="_ref_254"><a href="#prod-ProjectionMultiplicativeExpression">ProjectionMultiplicativeExpression</a></emu-nt>
         <emu-t>/</emu-t>
-        <emu-nt id="_ref_256"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
+        <emu-nt id="_ref_255"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionUnaryExpression" id="prod-ProjectionUnaryExpression">
     <emu-nt><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="y0pnlb1i">
-        <emu-nt id="_ref_257"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
+        <emu-nt id="_ref_256"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="xbyln6wd">
         <emu-t>!</emu-t>
-        <emu-nt id="_ref_258"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
+        <emu-nt id="_ref_257"><a href="#prod-ProjectionUnaryExpression">ProjectionUnaryExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionCallExpression" id="prod-ProjectionCallExpression">
     <emu-nt><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bovlf96p">
-        <emu-nt id="_ref_259"><a href="#prod-ProjectionDecoratorReferenceExpression">ProjectionDecoratorReferenceExpression</a></emu-nt>
+        <emu-nt id="_ref_258"><a href="#prod-ProjectionDecoratorReferenceExpression">ProjectionDecoratorReferenceExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="dskpubvk">
-        <emu-nt id="_ref_260"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
-        <emu-nt id="_ref_261"><a href="#prod-ProjectionCallArguments">ProjectionCallArguments</a></emu-nt>
+        <emu-nt id="_ref_259"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
+        <emu-nt id="_ref_260"><a href="#prod-ProjectionCallArguments">ProjectionCallArguments</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="mlqh18ki">
-        <emu-nt id="_ref_262"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
+        <emu-nt id="_ref_261"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
         <emu-t>.</emu-t>
-        <emu-nt id="_ref_263"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_262"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="o5cqmytw">
-        <emu-nt id="_ref_264"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
+        <emu-nt id="_ref_263"><a href="#prod-ProjectionCallExpression">ProjectionCallExpression</a></emu-nt>
         <emu-t>::</emu-t>
-        <emu-nt id="_ref_265"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_264"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionCallArguments" id="prod-ProjectionCallArguments">
     <emu-nt><a href="#prod-ProjectionCallArguments">ProjectionCallArguments</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="j4chh_gn">
         <emu-t>(</emu-t>
-        <emu-nt optional="" id="_ref_266"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_265"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionDecoratorReferenceExpression" id="prod-ProjectionDecoratorReferenceExpression">
     <emu-nt><a href="#prod-ProjectionDecoratorReferenceExpression">ProjectionDecoratorReferenceExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="upl3vrmk">
-        <emu-nt id="_ref_267"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt>
+        <emu-nt id="_ref_266"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="ifcyd-aq">
         <emu-t>@</emu-t>
-        <emu-nt id="_ref_268"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
+        <emu-nt id="_ref_267"><a href="#prod-IdentifierOrMemberExpression">IdentifierOrMemberExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionMemberExpression" id="prod-ProjectionMemberExpression">
     <emu-nt><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="0yuqksdg">
-        <emu-nt id="_ref_269"><a href="#prod-ProjectionPrimaryExpression">ProjectionPrimaryExpression</a></emu-nt>
+        <emu-nt id="_ref_268"><a href="#prod-ProjectionPrimaryExpression">ProjectionPrimaryExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="jew6aiq_">
-        <emu-nt id="_ref_270"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt>
+        <emu-nt id="_ref_269"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt>
         <emu-t>.</emu-t>
-        <emu-nt id="_ref_271"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_270"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="rdfgqhl2">
-        <emu-nt id="_ref_272"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt>
+        <emu-nt id="_ref_271"><a href="#prod-ProjectionMemberExpression">ProjectionMemberExpression</a></emu-nt>
         <emu-t>::</emu-t>
-        <emu-nt id="_ref_273"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_272"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionPrimaryExpression" id="prod-ProjectionPrimaryExpression">
@@ -3677,147 +3673,147 @@ li.menu-search-result-term:before {
         <emu-t>self</emu-t>
     </emu-rhs>
     <emu-rhs a="bras6mo_">
-        <emu-nt id="_ref_274"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt id="_ref_273"><a href="#prod-Identifier">Identifier</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="cjpglqhg">
-        <emu-nt id="_ref_275"><a href="#prod-ProjectionIfExpression">ProjectionIfExpression</a></emu-nt>
+        <emu-nt id="_ref_274"><a href="#prod-ProjectionIfExpression">ProjectionIfExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="kwuqjwk9">
-        <emu-nt id="_ref_276"><a href="#prod-ProjectionLambdaExpression">ProjectionLambdaExpression</a></emu-nt>
+        <emu-nt id="_ref_275"><a href="#prod-ProjectionLambdaExpression">ProjectionLambdaExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="kul-a19e">
-        <emu-nt id="_ref_277"><a href="#prod-Literal">Literal</a></emu-nt>
+        <emu-nt id="_ref_276"><a href="#prod-Literal">Literal</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="pmeanrkf">
-        <emu-nt id="_ref_278"><a href="#prod-ProjectionModelExpression">ProjectionModelExpression</a></emu-nt>
+        <emu-nt id="_ref_277"><a href="#prod-ProjectionModelExpression">ProjectionModelExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="0ehfrlsm">
-        <emu-nt id="_ref_279"><a href="#prod-ProjectionTupleExpression">ProjectionTupleExpression</a></emu-nt>
+        <emu-nt id="_ref_278"><a href="#prod-ProjectionTupleExpression">ProjectionTupleExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="ult0-wp7">
-        <emu-nt id="_ref_280"><a href="#prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">CoverProjectionParenthesizedExpressionAndLambdaParameterList</a></emu-nt>
+        <emu-nt id="_ref_279"><a href="#prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">CoverProjectionParenthesizedExpressionAndLambdaParameterList</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="CoverProjectionParenthesizedExpressionAndLambdaParameterList" id="prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">
     <emu-nt><a href="#prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">CoverProjectionParenthesizedExpressionAndLambdaParameterList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="b22wugnz">
         <emu-t>(</emu-t>
-        <emu-nt id="_ref_281"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt>
+        <emu-nt id="_ref_280"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionExpressionList" id="prod-ProjectionExpressionList">
     <emu-nt><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="emksbnr7">
-        <emu-nt id="_ref_282"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_281"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="if8za0tg">
-        <emu-nt id="_ref_283"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt>
+        <emu-nt id="_ref_282"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt>
         <emu-t>,</emu-t>
-        <emu-nt id="_ref_284"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_283"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionIfExpression" id="prod-ProjectionIfExpression">
     <emu-nt><a href="#prod-ProjectionIfExpression">ProjectionIfExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="4wt0s7kz">
         <emu-t>if</emu-t>
-        <emu-nt id="_ref_285"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_284"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
         <emu-nt>BlockExpression</emu-nt>
     </emu-rhs>
     <emu-rhs a="uh-blucs">
         <emu-t>if</emu-t>
-        <emu-nt id="_ref_286"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_285"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
         <emu-nt>BlockExpression</emu-nt>
         <emu-t>else</emu-t>
-        <emu-nt id="_ref_287"><a href="#prod-ProjectionBlockExpression">ProjectionBlockExpression</a></emu-nt>
+        <emu-nt id="_ref_286"><a href="#prod-ProjectionBlockExpression">ProjectionBlockExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="o_gymffi">
         <emu-t>if</emu-t>
-        <emu-nt id="_ref_288"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_287"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
         <emu-nt>BlockExpression</emu-nt>
         <emu-t>else</emu-t>
-        <emu-nt id="_ref_289"><a href="#prod-ProjectionIfExpression">ProjectionIfExpression</a></emu-nt>
+        <emu-nt id="_ref_288"><a href="#prod-ProjectionIfExpression">ProjectionIfExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionModelExpression" id="prod-ProjectionModelExpression">
     <emu-nt><a href="#prod-ProjectionModelExpression">ProjectionModelExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="uni6ofws">
         <emu-t>{</emu-t>
-        <emu-nt optional="" id="_ref_290"><a href="#prod-ProjectionModelBody">ProjectionModelBody</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_289"><a href="#prod-ProjectionModelBody">ProjectionModelBody</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionModelBody" id="prod-ProjectionModelBody">
     <emu-nt><a href="#prod-ProjectionModelBody">ProjectionModelBody</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="rtfwbkzz">
-        <emu-nt id="_ref_291"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
+        <emu-nt id="_ref_290"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
         <emu-t optional="">,<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
     </emu-rhs>
     <emu-rhs a="foktbtgh">
-        <emu-nt id="_ref_292"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
+        <emu-nt id="_ref_291"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
         <emu-t optional="">;<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionModelPropertyList" id="prod-ProjectionModelPropertyList">
     <emu-nt><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="qnv19o8r">
-        <emu-nt id="_ref_293"><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt>
+        <emu-nt id="_ref_292"><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="k06km7_w">
-        <emu-nt id="_ref_294"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
+        <emu-nt id="_ref_293"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
         <emu-t>,</emu-t>
-        <emu-nt id="_ref_295"><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt>
+        <emu-nt id="_ref_294"><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="xtycdbqj">
-        <emu-nt id="_ref_296"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
+        <emu-nt id="_ref_295"><a href="#prod-ProjectionModelPropertyList">ProjectionModelPropertyList</a></emu-nt>
         <emu-t>;</emu-t>
-        <emu-nt id="_ref_297"><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt>
+        <emu-nt id="_ref_296"><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionModelProperty" id="prod-ProjectionModelProperty">
     <emu-nt><a href="#prod-ProjectionModelProperty">ProjectionModelProperty</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="noc7fhyz">
-        <emu-nt id="_ref_298"><a href="#prod-ProjectionModelSpreadProperty">ProjectionModelSpreadProperty</a></emu-nt>
+        <emu-nt id="_ref_297"><a href="#prod-ProjectionModelSpreadProperty">ProjectionModelSpreadProperty</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="6zpn0h3k">
-        <emu-nt optional="" id="_ref_299"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_300"><a href="#prod-Identifier">Identifier</a></emu-nt>
+        <emu-nt optional="" id="_ref_298"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_299"><a href="#prod-Identifier">Identifier</a></emu-nt>
         <emu-t optional="">?<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
         <emu-t>:</emu-t>
-        <emu-nt id="_ref_301"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_300"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="oncm7e4f">
-        <emu-nt optional="" id="_ref_302"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_303"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
+        <emu-nt optional="" id="_ref_301"><a href="#prod-DecoratorList">DecoratorList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_302"><a href="#prod-StringLiteral">StringLiteral</a></emu-nt>
         <emu-t optional="">?<emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-t>
         <emu-t>:</emu-t>
-        <emu-nt id="_ref_304"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_303"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionModelSpreadProperty" id="prod-ProjectionModelSpreadProperty">
     <emu-nt><a href="#prod-ProjectionModelSpreadProperty">ProjectionModelSpreadProperty</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="npvsjwgu">
         <emu-t>...</emu-t>
-        <emu-nt id="_ref_305"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
+        <emu-nt id="_ref_304"><a href="#prod-ProjectionExpression">ProjectionExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionTupleExpression" id="prod-ProjectionTupleExpression">
     <emu-nt><a href="#prod-ProjectionTupleExpression">ProjectionTupleExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="zhtv_ku5">
         <emu-t>[</emu-t>
-        <emu-nt optional="" id="_ref_306"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_305"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>]</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionLambdaExpression" id="prod-ProjectionLambdaExpression">
     <emu-nt><a href="#prod-ProjectionLambdaExpression">ProjectionLambdaExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="wjv4b-0b">
-        <emu-nt id="_ref_307"><a href="#prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">CoverProjectionParenthesizedExpressionAndLambdaParameterList</a></emu-nt>
+        <emu-nt id="_ref_306"><a href="#prod-CoverProjectionParenthesizedExpressionAndLambdaParameterList">CoverProjectionParenthesizedExpressionAndLambdaParameterList</a></emu-nt>
         <emu-t>=&gt;</emu-t>
-        <emu-nt id="_ref_308"><a href="#prod-ProjectionBlockExpression">ProjectionBlockExpression</a></emu-nt>
+        <emu-nt id="_ref_307"><a href="#prod-ProjectionBlockExpression">ProjectionBlockExpression</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="ProjectionBlockExpression" id="prod-ProjectionBlockExpression">
     <emu-nt><a href="#prod-ProjectionBlockExpression">ProjectionBlockExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="qsr0aizg">
         <emu-t>{</emu-t>
-        <emu-nt id="_ref_309"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt>
+        <emu-nt id="_ref_308"><a href="#prod-ProjectionExpressionList">ProjectionExpressionList</a></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="LambdaParameters" id="prod-LambdaParameters">
     <emu-nt><a href="#prod-LambdaParameters">LambdaParameters</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="yyjrc85a">
         <emu-t>(</emu-t>
-        <emu-nt optional="" id="_ref_310"><a href="#prod-IdentifierList">IdentifierList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_309"><a href="#prod-IdentifierList">IdentifierList</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>)</emu-t>
     </emu-rhs>
 </emu-production>

--- a/packages/cadl-vscode/src/tmlanguage.ts
+++ b/packages/cadl-vscode/src/tmlanguage.ts
@@ -416,6 +416,28 @@ const operationParameters: BeginEndRule = {
   patterns: [token, decorator, modelProperty, modelSpreadProperty, punctuationComma],
 };
 
+const operationSignatureReference: BeginEndRule = {
+  key: "operation-signature-reference",
+  scope: meta,
+  begin: "\\b(is)\\b",
+  beginCaptures: {
+    "1": { scope: "keyword.other.cadl" },
+  },
+  end: `((?=\\{)|${universalEndExceptComma})`,
+  patterns: [typeAnnotation],
+};
+
+const operationSignatureDeclaration: BeginEndRule = {
+  key: "operation-signature-declaration",
+  scope: meta,
+  begin: "\\b(is)\\b",
+  beginCaptures: {
+    "1": { scope: "keyword.other.cadl" },
+  },
+  end: `((?=\\{)|${universalEndExceptComma})`,
+  patterns: [typeAnnotation],
+};
+
 const operationStatement: BeginEndRule = {
   key: "operation-statement",
   scope: meta,
@@ -426,7 +448,8 @@ const operationStatement: BeginEndRule = {
   end: universalEnd,
   patterns: [
     token,
-    operationName,
+    identifierExpression,
+    typeArguments,
     operationParameters,
     typeAnnotation, // return type
   ],

--- a/packages/cadl-vscode/src/tmlanguage.ts
+++ b/packages/cadl-vscode/src/tmlanguage.ts
@@ -416,26 +416,24 @@ const operationParameters: BeginEndRule = {
   patterns: [token, decorator, modelProperty, modelSpreadProperty, punctuationComma],
 };
 
-const operationSignatureReference: BeginEndRule = {
-  key: "operation-signature-reference",
+const operationHeritage: BeginEndRule = {
+  key: "operation-heritage",
   scope: meta,
   begin: "\\b(is)\\b",
   beginCaptures: {
     "1": { scope: "keyword.other.cadl" },
   },
-  end: `((?=\\{)|${universalEndExceptComma})`,
-  patterns: [typeAnnotation],
+  end: universalEnd,
+  patterns: [expression],
 };
 
-const operationSignatureDeclaration: BeginEndRule = {
-  key: "operation-signature-declaration",
-  scope: meta,
-  begin: "\\b(is)\\b",
-  beginCaptures: {
-    "1": { scope: "keyword.other.cadl" },
-  },
-  end: `((?=\\{)|${universalEndExceptComma})`,
-  patterns: [typeAnnotation],
+const operationSignature: IncludeRule = {
+  key: "operation-signature",
+  patterns: [
+    operationHeritage,
+    operationParameters,
+    typeAnnotation, // return type
+  ],
 };
 
 const operationStatement: BeginEndRule = {
@@ -446,13 +444,7 @@ const operationStatement: BeginEndRule = {
     "1": { scope: "keyword.other.cadl" },
   },
   end: universalEnd,
-  patterns: [
-    token,
-    identifierExpression,
-    typeArguments,
-    operationParameters,
-    typeAnnotation, // return type
-  ],
+  patterns: [token, operationName, operationSignature],
 };
 
 const interfaceMember: BeginEndRule = {
@@ -464,7 +456,7 @@ const interfaceMember: BeginEndRule = {
     "2": { scope: "entity.name.function.cadl" },
   },
   end: universalEnd,
-  patterns: [token, operationParameters, typeAnnotation],
+  patterns: [token, operationSignature],
 };
 
 const interfaceHeritage: BeginEndRule = {

--- a/packages/cadl-vscode/src/tmlanguage.ts
+++ b/packages/cadl-vscode/src/tmlanguage.ts
@@ -388,20 +388,6 @@ const namespaceStatement: BeginEndRule = {
   patterns: [token, namespaceName, namespaceBody],
 };
 
-const functionName: MatchRule = {
-  key: "function-name",
-  scope: "entity.name.function.cadl",
-  match: identifier,
-};
-
-const operationName: BeginEndRule = {
-  key: "operation-name",
-  scope: meta,
-  begin: beforeIdentifier,
-  end: `((?=\\()|${universalEnd})`,
-  patterns: [token, functionName],
-};
-
 const operationParameters: BeginEndRule = {
   key: "operation-parameters",
   scope: meta,
@@ -430,6 +416,7 @@ const operationHeritage: BeginEndRule = {
 const operationSignature: IncludeRule = {
   key: "operation-signature",
   patterns: [
+    typeArguments,
     operationHeritage,
     operationParameters,
     typeAnnotation, // return type
@@ -439,12 +426,13 @@ const operationSignature: IncludeRule = {
 const operationStatement: BeginEndRule = {
   key: "operation-statement",
   scope: meta,
-  begin: "\\b(op)\\b",
+  begin: `\\b(op)\\b\\s+(${identifier})`,
   beginCaptures: {
     "1": { scope: "keyword.other.cadl" },
+    "2": { scope: "entity.name.function.cadl" },
   },
   end: universalEnd,
-  patterns: [token, operationName, operationSignature],
+  patterns: [token, operationSignature],
 };
 
 const interfaceMember: BeginEndRule = {

--- a/packages/cadl-vscode/test/interface.test.ts
+++ b/packages/cadl-vscode/test/interface.test.ts
@@ -86,4 +86,24 @@ describe("vscode: tmlanguage: interfaces", () => {
       Token.punctuation.closeBrace,
     ]);
   });
+
+  it("interface operation that copies the signature of another operation", async () => {
+    const tokens = await tokenize(`
+    interface Foo {
+      bar is ResourceRead<Widget>
+    }`);
+
+    deepStrictEqual(tokens, [
+      Token.keywords.interface,
+      Token.identifiers.type("Foo"),
+      Token.punctuation.openBrace,
+      Token.identifiers.functionName("bar"),
+      Token.keywords.is,
+      Token.identifiers.type("ResourceRead"),
+      Token.punctuation.typeParameters.begin,
+      Token.identifiers.type("Widget"),
+      Token.punctuation.typeParameters.end,
+      Token.punctuation.closeBrace,
+    ]);
+  });
 });

--- a/packages/cadl-vscode/test/operation.test.ts
+++ b/packages/cadl-vscode/test/operation.test.ts
@@ -89,7 +89,6 @@ describe("vscode: tmlanguage: Operations", () => {
       Token.keywords.operation,
       Token.identifiers.functionName("foo"),
       Token.keywords.is,
-      Token.operators.typeAnnotation,
       Token.identifiers.type("ResourceRead"),
       Token.punctuation.typeParameters.begin,
       Token.identifiers.type("Widget"),

--- a/packages/cadl-vscode/test/operation.test.ts
+++ b/packages/cadl-vscode/test/operation.test.ts
@@ -82,4 +82,18 @@ describe("vscode: tmlanguage: Operations", () => {
       Token.identifiers.type("string"),
     ]);
   });
+
+  it("operation that copies the signature of another operation", async () => {
+    const tokens = await tokenize("op foo is ResourceRead<Widget>");
+    deepStrictEqual(tokens, [
+      Token.keywords.operation,
+      Token.identifiers.functionName("foo"),
+      Token.keywords.is,
+      Token.operators.typeAnnotation,
+      Token.identifiers.type("ResourceRead"),
+      Token.punctuation.typeParameters.begin,
+      Token.identifiers.type("Widget"),
+      Token.punctuation.typeParameters.end,
+    ]);
+  });
 });

--- a/packages/cadl-vscode/test/operation.test.ts
+++ b/packages/cadl-vscode/test/operation.test.ts
@@ -95,4 +95,24 @@ describe("vscode: tmlanguage: Operations", () => {
       Token.punctuation.typeParameters.end,
     ]);
   });
+
+  it("defining a templated operation signature", async () => {
+    const tokens = await tokenize(
+      "op ResourceRead<TResource> is ResourceReadBase<TResource, DefaultOptions>"
+    );
+    deepStrictEqual(tokens, [
+      Token.keywords.operation,
+      Token.identifiers.functionName("ResourceRead"),
+      Token.punctuation.typeParameters.begin,
+      Token.identifiers.type("TResource"),
+      Token.punctuation.typeParameters.end,
+      Token.keywords.is,
+      Token.identifiers.type("ResourceReadBase"),
+      Token.punctuation.typeParameters.begin,
+      Token.identifiers.type("TResource"),
+      Token.punctuation.comma,
+      Token.identifiers.type("DefaultOptions"),
+      Token.punctuation.typeParameters.end,
+    ]);
+  });
 });

--- a/packages/compiler/core/binder.ts
+++ b/packages/compiler/core/binder.ts
@@ -10,6 +10,7 @@ import {
   ModelStatementNode,
   NamespaceStatementNode,
   Node,
+  OperationInstanceNode,
   OperationStatementNode,
   ProjectionLambdaExpressionNode,
   ProjectionLambdaParameterDeclarationNode,
@@ -202,6 +203,9 @@ export function createBinder(program: Program, options: BinderOptions = {}): Bin
       case SyntaxKind.OperationStatement:
         bindOperationStatement(node);
         break;
+      case SyntaxKind.OperationInstance:
+        bindOperationStatement(node);
+        break;
       case SyntaxKind.TemplateParameterDeclaration:
         bindTemplateParameterDeclaration(node);
         break;
@@ -386,7 +390,7 @@ export function createBinder(program: Program, options: BinderOptions = {}): Bin
     (currentFile.usings as UsingStatementNode[]).push(statement);
   }
 
-  function bindOperationStatement(statement: OperationStatementNode) {
+  function bindOperationStatement(statement: OperationStatementNode | OperationInstanceNode) {
     if (scope.kind !== SyntaxKind.InterfaceStatement) {
       declareSymbol(statement, SymbolFlags.Operation);
     }

--- a/packages/compiler/core/binder.ts
+++ b/packages/compiler/core/binder.ts
@@ -10,7 +10,6 @@ import {
   ModelStatementNode,
   NamespaceStatementNode,
   Node,
-  OperationInstanceNode,
   OperationStatementNode,
   ProjectionLambdaExpressionNode,
   ProjectionLambdaParameterDeclarationNode,
@@ -203,9 +202,6 @@ export function createBinder(program: Program, options: BinderOptions = {}): Bin
       case SyntaxKind.OperationStatement:
         bindOperationStatement(node);
         break;
-      case SyntaxKind.OperationInstance:
-        bindOperationStatement(node);
-        break;
       case SyntaxKind.TemplateParameterDeclaration:
         bindTemplateParameterDeclaration(node);
         break;
@@ -390,7 +386,7 @@ export function createBinder(program: Program, options: BinderOptions = {}): Bin
     (currentFile.usings as UsingStatementNode[]).push(statement);
   }
 
-  function bindOperationStatement(statement: OperationStatementNode | OperationInstanceNode) {
+  function bindOperationStatement(statement: OperationStatementNode) {
     if (scope.kind !== SyntaxKind.InterfaceStatement) {
       declareSymbol(statement, SymbolFlags.Operation);
     }

--- a/packages/compiler/core/binder.ts
+++ b/packages/compiler/core/binder.ts
@@ -389,6 +389,7 @@ export function createBinder(program: Program, options: BinderOptions = {}): Bin
   function bindOperationStatement(statement: OperationStatementNode) {
     if (scope.kind !== SyntaxKind.InterfaceStatement) {
       declareSymbol(statement, SymbolFlags.Operation);
+      statement.locals = new SymbolTable();
     }
   }
 
@@ -451,6 +452,7 @@ function hasScope(node: Node): node is ScopeNode {
     case SyntaxKind.AliasStatement:
     case SyntaxKind.CadlScript:
     case SyntaxKind.InterfaceStatement:
+    case SyntaxKind.OperationStatement:
     case SyntaxKind.UnionStatement:
     case SyntaxKind.Projection:
     case SyntaxKind.ProjectionLambdaExpression:

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -1057,7 +1057,7 @@ export function createChecker(program: Program): Checker {
 
     // Is this a definition or reference?
     let parameters: ModelType, returnType: Type;
-    if (node.signature.kind === "OperationReference") {
+    if (node.signature.kind === SyntaxKind.OperationSignatureReference) {
       // Attempt to resolve the operation
       const baseOperation = checkOperationIs(node, node.signature.baseOperation);
       if (!baseOperation) {

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -55,6 +55,7 @@ import {
   NodeFlags,
   NumericLiteralNode,
   NumericLiteralType,
+  OperationInstanceNode,
   OperationStatementNode,
   OperationType,
   ProjectionArithmeticExpressionNode,
@@ -382,6 +383,8 @@ export function createChecker(program: Program): Checker {
         return checkNamespace(node);
       case SyntaxKind.OperationStatement:
         return checkOperation(node);
+      case SyntaxKind.OperationInstance:
+        return checkOperation(node);
       case SyntaxKind.NumericLiteral:
         return checkNumericLiteral(node);
       case SyntaxKind.BooleanLiteral:
@@ -467,7 +470,13 @@ export function createChecker(program: Program): Checker {
    * Return a fully qualified id of node
    */
   function getNodeSymId(
-    node: ModelStatementNode | AliasStatementNode | InterfaceStatementNode | UnionStatementNode
+    node:
+      | ModelStatementNode
+      | AliasStatementNode
+      | InterfaceStatementNode
+      | OperationStatementNode
+      | OperationInstanceNode
+      | UnionStatementNode
   ): number {
     return node.symbol!.id!;
   }
@@ -493,6 +502,8 @@ export function createChecker(program: Program): Checker {
     const parentNode = node.parent! as
       | ModelStatementNode
       | InterfaceStatementNode
+      | OperationStatementNode
+      | OperationInstanceNode
       | UnionStatementNode
       | AliasStatementNode;
     const links = getSymbolLinks(node.symbol);
@@ -679,12 +690,18 @@ export function createChecker(program: Program): Checker {
     const args = checkTypeReferenceArgs(node);
     if (
       sym.flags &
-      (SymbolFlags.Model | SymbolFlags.Alias | SymbolFlags.Interface | SymbolFlags.Union)
+      (SymbolFlags.Model |
+        SymbolFlags.Alias |
+        SymbolFlags.Interface |
+        SymbolFlags.Operation |
+        SymbolFlags.Union)
     ) {
       const decl = sym.declarations[0] as
         | ModelStatementNode
         | AliasStatementNode
         | InterfaceStatementNode
+        | OperationStatementNode
+        | OperationInstanceNode
         | UnionStatementNode;
       if (decl.templateParameters.length === 0) {
         if (args.length > 0) {
@@ -707,6 +724,8 @@ export function createChecker(program: Program): Checker {
               ? checkAlias(decl as AliasStatementNode)
               : sym.flags & SymbolFlags.Interface
               ? checkInterface(decl as InterfaceStatementNode)
+              : sym.flags & SymbolFlags.Operation
+              ? checkOperation(decl as OperationStatementNode)
               : checkUnion(decl as UnionStatementNode);
         }
       } else {
@@ -720,6 +739,8 @@ export function createChecker(program: Program): Checker {
             ? checkAlias(decl as AliasStatementNode)
             : sym.flags & SymbolFlags.Interface
             ? checkInterface(decl as InterfaceStatementNode)
+            : sym.flags & SymbolFlags.Operation
+            ? checkOperation(decl as OperationStatementNode)
             : checkUnion(decl as UnionStatementNode);
         }
 
@@ -770,6 +791,8 @@ export function createChecker(program: Program): Checker {
       | ModelStatementNode
       | AliasStatementNode
       | InterfaceStatementNode
+      | OperationStatementNode
+      | OperationInstanceNode
       | UnionStatementNode,
     args: Type[]
   ): Type {
@@ -959,6 +982,7 @@ export function createChecker(program: Program): Checker {
       | ModelStatementNode
       | NamespaceStatementNode
       | OperationStatementNode
+      | OperationInstanceNode
       | EnumStatementNode
       | InterfaceStatementNode
       | UnionStatementNode
@@ -972,6 +996,7 @@ export function createChecker(program: Program): Checker {
         if (
           parent.kind === SyntaxKind.ModelStatement ||
           parent.kind === SyntaxKind.OperationStatement ||
+          parent.kind === SyntaxKind.OperationInstance ||
           parent.kind === SyntaxKind.EnumStatement ||
           parent.kind === SyntaxKind.InterfaceStatement ||
           parent.kind === SyntaxKind.UnionStatement ||
@@ -986,7 +1011,7 @@ export function createChecker(program: Program): Checker {
     }
 
     if (
-      node.kind === SyntaxKind.OperationStatement &&
+      (node.kind === SyntaxKind.OperationStatement || node.kind === SyntaxKind.OperationInstance) &&
       node.parent &&
       node.parent.kind === SyntaxKind.InterfaceStatement
     ) {
@@ -1022,35 +1047,130 @@ export function createChecker(program: Program): Checker {
   }
 
   function checkOperation(
-    node: OperationStatementNode,
+    node: OperationStatementNode | OperationInstanceNode,
     parentInterface?: InterfaceType
-  ): OperationType {
+  ): OperationType | ErrorType {
+    const links = getSymbolLinks(node.symbol);
+    const instantiatingThisTemplate = instantiatingTemplate === node;
+    if (links.declaredType && !instantiatingThisTemplate) {
+      // we're not instantiating this operation and we've already checked it
+      return links.declaredType as OperationType;
+    }
+
     const namespace = getParentNamespaceType(node);
     const name = node.id.sv;
     const decorators = checkDecorators(node);
-    const type: OperationType = createType({
+
+    // Is this a definition or instance?
+    let parameters: ModelType, returnType: Type;
+    if (node.kind === SyntaxKind.OperationInstance) {
+      // Attempt to resolve the operation
+      const baseOperation = checkOperationIs(node, node.baseOperation);
+      if (!baseOperation) {
+        // TODO: Are the proper diagnostics written already?
+        return errorType;
+      }
+
+      // Reference the same return type and create the parameters type
+      returnType = baseOperation.returnType;
+      parameters = createType({
+        kind: "Model",
+        name: "",
+        node: baseOperation.parameters.node, // TODO: This seems bad!
+        properties: new Map<string, ModelTypeProperty>(),
+        namespace: getParentNamespaceType(node),
+        decorators: [],
+        derivedModels: [],
+      });
+
+      // Copy parameters of the base operation
+      for (const prop of baseOperation.parameters.properties.values()) {
+        console.log("copying param:", prop.name, (prop.type as any).kind);
+        // Don't use the same property, clone it and finish it to execute the decorators again
+        parameters.properties.set(
+          prop.name,
+          finishType({
+            ...prop,
+          })
+        );
+      }
+    } else {
+      parameters = getTypeForNode(node.parameters) as ModelType;
+      returnType = getTypeForNode(node.returnType);
+    }
+
+    const operationType: OperationType = createType({
       kind: "Operation",
       name,
       namespace,
       node,
-      parameters: getTypeForNode(node.parameters) as ModelType,
-      returnType: getTypeForNode(node.returnType),
-      decorators,
+      parameters,
+      returnType,
+      decorators, // TODO: Concatenate base operation decorators recursively!
       interface: parentInterface,
     });
 
-    type.parameters.namespace = namespace;
+    operationType.parameters.namespace = namespace;
 
     if (node.parent!.kind === SyntaxKind.InterfaceStatement) {
-      if (shouldCreateTypeForTemplate(node.parent!)) {
-        finishType(type);
+      if (shouldCreateTypeForTemplate(node.parent!) || shouldCreateTypeForTemplate(node)) {
+        finishType(operationType);
       }
     } else {
-      finishType(type);
-      namespace?.operations.set(name, type);
+      if (shouldCreateTypeForTemplate(node)) {
+        finishType(operationType);
+      }
+
+      namespace?.operations.set(name, operationType);
     }
 
-    return type;
+    if (!instantiatingThisTemplate) {
+      links.declaredType = operationType;
+      links.instantiations = new TypeInstantiationMap();
+    }
+
+    return operationType;
+  }
+
+  function checkOperationIs(
+    operation: OperationInstanceNode,
+    opReference: TypeReferenceNode | undefined
+  ): OperationType | undefined {
+    if (!opReference) return undefined;
+
+    // Ensure that we don't end up with a circular reference to the same operation
+    const opSymId = getNodeSymId(operation);
+    pendingResolutions.add(opSymId);
+
+    const target = resolveTypeReference(opReference);
+    if (target === undefined) {
+      return undefined;
+    }
+
+    // Did we encounter a circular operation reference?
+    if (pendingResolutions.has(getNodeSymId(target.declarations[0] as any))) {
+      if (!isInstantiatingTemplateType()) {
+        reportDiagnostic(program, {
+          code: "circular-base-type",
+          format: { typeName: (target.declarations[0] as any).id.sv },
+          target: target,
+        });
+      }
+
+      return undefined;
+    }
+
+    // Resolve the base operation type
+    const baseOperation = checkTypeReferenceSymbol(target, opReference);
+    pendingResolutions.delete(opSymId);
+
+    // Was the wrong type referenced?
+    if (baseOperation.kind !== "Operation") {
+      program.reportDiagnostic(createDiagnostic({ code: "is-operation", target: opReference }));
+      return;
+    }
+
+    return baseOperation;
   }
 
   function getGlobalNamespaceType() {
@@ -2070,11 +2190,7 @@ export function createChecker(program: Program): Checker {
       interfaceType.operations.set(k, v);
     }
 
-    if (
-      (instantiatingThisTemplate &&
-        templateInstantiation.every((t) => t.kind !== "TemplateParameter")) ||
-      node.templateParameters.length === 0
-    ) {
+    if (shouldCreateTypeForTemplate(node)) {
       finishType(interfaceType);
     }
 
@@ -2094,17 +2210,19 @@ export function createChecker(program: Program): Checker {
   ) {
     for (const opNode of node.operations) {
       const opType = checkOperation(opNode, interfaceType);
-      if (members.has(opType.name)) {
-        program.reportDiagnostic(
-          createDiagnostic({
-            code: "interface-duplicate",
-            format: { name: opType.name },
-            target: opNode,
-          })
-        );
-        continue;
+      if (opType.kind === "Operation") {
+        if (members.has(opType.name)) {
+          program.reportDiagnostic(
+            createDiagnostic({
+              code: "interface-duplicate",
+              format: { name: opType.name },
+              target: opNode,
+            })
+          );
+          continue;
+        }
+        members.set(opType.name, opType);
       }
-      members.set(opType.name, opType);
     }
   }
 

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -287,6 +287,12 @@ const diagnostics = {
       default: "Model `is` must specify another model.",
     },
   },
+  "is-operation": {
+    severity: "error",
+    messages: {
+      default: "Operation can only reuse the signature of another operation.",
+    },
+  },
   "spread-model": {
     severity: "error",
     messages: {

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -604,10 +604,13 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
     const id = parseIdentifier();
     const templateParameters = inInterface ? [] : parseTemplateParameterList();
 
+    // Make sure the next token is one that is expected
+    const token = expectTokenIsOneOf(Token.OpenParen, Token.Colon);
+
     // Check if we're parsing a declaration or reuse of another operation
     let signature: OperationSignature;
     const signaturePos = tokenPos();
-    if (token() === Token.OpenParen) {
+    if (token === Token.OpenParen) {
       const parameters = parseOperationParameters();
       parseExpected(Token.Colon);
       const returnType = parseExpression();

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -605,7 +605,7 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
     const templateParameters = inInterface ? [] : parseTemplateParameterList();
 
     // Make sure the next token is one that is expected
-    const token = expectTokenIsOneOf(Token.OpenParen, Token.Colon);
+    const token = expectTokenIsOneOf(Token.OpenParen, Token.IsKeyword);
 
     // Check if we're parsing a declaration or reuse of another operation
     let signature: OperationSignature;
@@ -622,7 +622,7 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
         ...finishNode(signaturePos),
       };
     } else {
-      parseExpected(Token.Colon);
+      parseExpected(Token.IsKeyword);
       const opReference = parseReferenceExpression();
 
       signature = {

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -393,6 +393,8 @@ export enum SyntaxKind {
   NamespaceStatement,
   UsingStatement,
   OperationStatement,
+  OperationSignatureDeclaration,
+  OperationSignatureReference,
   ModelStatement,
   ModelExpression,
   ModelProperty,
@@ -506,6 +508,8 @@ export type Node =
   | ModelPropertyNode
   | UnionVariantNode
   | OperationStatementNode
+  | OperationSignatureDeclarationNode
+  | OperationSignatureReferenceNode
   | EnumMemberNode
   | ModelSpreadPropertyNode
   | DecoratorExpressionNode
@@ -673,18 +677,20 @@ export interface UsingStatementNode extends BaseNode {
   readonly name: IdentifierNode | MemberExpressionNode;
 }
 
-export interface OperationSignatureDeclaration {
-  readonly kind: "OperationDeclaration";
+export interface OperationSignatureDeclarationNode extends BaseNode {
+  readonly kind: SyntaxKind.OperationSignatureDeclaration;
   readonly parameters: ModelExpressionNode;
   readonly returnType: Expression;
 }
 
-export interface OperationSignatureReference {
-  readonly kind: "OperationReference";
+export interface OperationSignatureReferenceNode extends BaseNode {
+  readonly kind: SyntaxKind.OperationSignatureReference;
   readonly baseOperation: TypeReferenceNode;
 }
 
-export type OperationSignature = OperationSignatureDeclaration | OperationSignatureReference;
+export type OperationSignature =
+  | OperationSignatureDeclarationNode
+  | OperationSignatureReferenceNode;
 
 export interface OperationStatementNode extends BaseNode, DeclarationNode, TemplateDeclarationNode {
   readonly kind: SyntaxKind.OperationStatement;

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -209,9 +209,9 @@ export interface EnumMemberType extends BaseType, DecoratedType {
   value?: string | number;
 }
 
-export interface OperationType extends BaseType, DecoratedType {
+export interface OperationType extends BaseType, DecoratedType, TemplatedType {
   kind: "Operation";
-  node: OperationStatementNode;
+  node: OperationStatementNode | OperationInstanceNode;
   name: string;
   namespace?: NamespaceType;
   interface?: InterfaceType;
@@ -393,6 +393,7 @@ export enum SyntaxKind {
   NamespaceStatement,
   UsingStatement,
   OperationStatement,
+  OperationInstance,
   ModelStatement,
   ModelExpression,
   ModelProperty,
@@ -506,6 +507,7 @@ export type Node =
   | ModelPropertyNode
   | UnionVariantNode
   | OperationStatementNode
+  | OperationInstanceNode
   | EnumMemberNode
   | ModelSpreadPropertyNode
   | DecoratorExpressionNode
@@ -556,6 +558,7 @@ export type Statement =
   | EnumStatementNode
   | AliasStatementNode
   | OperationStatementNode
+  | OperationInstanceNode
   | EmptyStatementNode
   | InvalidStatementNode
   | ProjectionStatementNode;
@@ -570,6 +573,7 @@ export type Declaration =
   | UnionStatementNode
   | NamespaceStatementNode
   | OperationStatementNode
+  | OperationInstanceNode
   | TemplateParameterDeclarationNode
   | ProjectionStatementNode
   | ProjectionParameterDeclarationNode
@@ -673,10 +677,16 @@ export interface UsingStatementNode extends BaseNode {
   readonly name: IdentifierNode | MemberExpressionNode;
 }
 
-export interface OperationStatementNode extends BaseNode, DeclarationNode {
+export interface OperationStatementNode extends BaseNode, DeclarationNode, TemplateDeclarationNode {
   readonly kind: SyntaxKind.OperationStatement;
   readonly parameters: ModelExpressionNode;
   readonly returnType: Expression;
+  readonly decorators: readonly DecoratorExpressionNode[];
+}
+
+export interface OperationInstanceNode extends BaseNode, DeclarationNode, TemplateDeclarationNode {
+  readonly kind: SyntaxKind.OperationInstance;
+  readonly baseOperation: TypeReferenceNode;
   readonly decorators: readonly DecoratorExpressionNode[];
 }
 

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -211,7 +211,7 @@ export interface EnumMemberType extends BaseType, DecoratedType {
 
 export interface OperationType extends BaseType, DecoratedType, TemplatedType {
   kind: "Operation";
-  node: OperationStatementNode | OperationInstanceNode;
+  node: OperationStatementNode;
   name: string;
   namespace?: NamespaceType;
   interface?: InterfaceType;
@@ -393,7 +393,6 @@ export enum SyntaxKind {
   NamespaceStatement,
   UsingStatement,
   OperationStatement,
-  OperationInstance,
   ModelStatement,
   ModelExpression,
   ModelProperty,
@@ -507,7 +506,6 @@ export type Node =
   | ModelPropertyNode
   | UnionVariantNode
   | OperationStatementNode
-  | OperationInstanceNode
   | EnumMemberNode
   | ModelSpreadPropertyNode
   | DecoratorExpressionNode
@@ -558,7 +556,6 @@ export type Statement =
   | EnumStatementNode
   | AliasStatementNode
   | OperationStatementNode
-  | OperationInstanceNode
   | EmptyStatementNode
   | InvalidStatementNode
   | ProjectionStatementNode;
@@ -573,7 +570,6 @@ export type Declaration =
   | UnionStatementNode
   | NamespaceStatementNode
   | OperationStatementNode
-  | OperationInstanceNode
   | TemplateParameterDeclarationNode
   | ProjectionStatementNode
   | ProjectionParameterDeclarationNode
@@ -677,16 +673,22 @@ export interface UsingStatementNode extends BaseNode {
   readonly name: IdentifierNode | MemberExpressionNode;
 }
 
-export interface OperationStatementNode extends BaseNode, DeclarationNode, TemplateDeclarationNode {
-  readonly kind: SyntaxKind.OperationStatement;
+export interface OperationSignatureDeclaration {
+  readonly kind: "OperationDeclaration";
   readonly parameters: ModelExpressionNode;
   readonly returnType: Expression;
-  readonly decorators: readonly DecoratorExpressionNode[];
 }
 
-export interface OperationInstanceNode extends BaseNode, DeclarationNode, TemplateDeclarationNode {
-  readonly kind: SyntaxKind.OperationInstance;
+export interface OperationSignatureReference {
+  readonly kind: "OperationReference";
   readonly baseOperation: TypeReferenceNode;
+}
+
+export type OperationSignature = OperationSignatureDeclaration | OperationSignatureReference;
+
+export interface OperationStatementNode extends BaseNode, DeclarationNode, TemplateDeclarationNode {
+  readonly kind: SyntaxKind.OperationStatement;
+  readonly signature: OperationSignature;
   readonly decorators: readonly DecoratorExpressionNode[];
 }
 

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -863,6 +863,7 @@ export function printOperationStatement(
   print: PrettierChildPrint
 ) {
   const inInterface = (path.getParentNode()?.kind as any) === SyntaxKind.InterfaceStatement;
+  const templateParams = printTemplateParameters(path, options, print, "templateParameters");
   const { decorators } = printDecorators(path as AstPath<DecorableNode>, options, print, {
     tryInline: true,
   });
@@ -873,6 +874,7 @@ export function printOperationStatement(
       decorators,
       inInterface ? "" : "op ",
       path.call(print, "id"),
+      templateParams,
       "(",
       path.call(print, "signature", "parameters"),
       "): ",
@@ -884,6 +886,8 @@ export function printOperationStatement(
       decorators,
       inInterface ? "" : "op ",
       path.call(print, "id"),
+      templateParams,
+      ": ",
       path.call(print, "signature", "baseOperation"),
       `;`,
     ];

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -880,7 +880,7 @@ export function printOperationSignatureReference(
   options: CadlPrettierOptions,
   print: PrettierChildPrint
 ) {
-  return [": ", path.call(print, "baseOperation")];
+  return [" is ", path.call(print, "baseOperation")];
 }
 
 export function printOperationStatement(

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -23,6 +23,7 @@ import {
   Node,
   NodeFlags,
   NumericLiteralNode,
+  OperationInstanceNode,
   OperationStatementNode,
   Statement,
   StringLiteralNode,
@@ -85,6 +86,8 @@ export function printNode(
       return [`using `, path.call(print, "name"), `;`];
     case SyntaxKind.OperationStatement:
       return printOperationStatement(path as AstPath<OperationStatementNode>, options, print);
+    case SyntaxKind.OperationInstance:
+      return printOperationInstance(path as AstPath<OperationInstanceNode>, options, print);
     case SyntaxKind.NamespaceStatement:
       return printNamespaceStatement(path as AstPath<NamespaceStatementNode>, options, print);
     case SyntaxKind.ModelStatement:
@@ -871,6 +874,25 @@ export function printOperationStatement(
     path.call(print, "parameters"),
     "): ",
     path.call(print, "returnType"),
+    `;`,
+  ];
+}
+
+export function printOperationInstance(
+  path: AstPath<OperationInstanceNode>,
+  options: CadlPrettierOptions,
+  print: PrettierChildPrint
+) {
+  const inInterface = (path.getParentNode()?.kind as any) === SyntaxKind.InterfaceStatement;
+  const { decorators } = printDecorators(path as AstPath<DecorableNode>, options, print, {
+    tryInline: true,
+  });
+
+  return [
+    decorators,
+    inInterface ? "" : "op ",
+    path.call(print, "id"),
+    path.call(print, "baseOperation"),
     `;`,
   ];
 }

--- a/packages/compiler/test/checker/operations.ts
+++ b/packages/compiler/test/checker/operations.ts
@@ -150,7 +150,7 @@ describe("cadl: operations", () => {
     expectDiagnostics(diagnostics, [
       {
         code: "token-expected",
-        message: `':' expected.`,
+        message: `'(', or ':' expected.`,
       },
       {
         code: "token-expected",

--- a/packages/compiler/test/checker/operations.ts
+++ b/packages/compiler/test/checker/operations.ts
@@ -48,7 +48,7 @@ describe("cadl: operations", () => {
     testHost.addCadlFile(
       "main.cadl",
       `op foo<TName, TPayload>(name: TName, payload: TPayload): boolean;
-      op newFooBase<TParam>: foo<string, TParam>;
+      op newFooBase<TPayload>: foo<string, TPayload>;
 
       @test
       op newFoo: newFooBase<string>;`
@@ -118,7 +118,7 @@ describe("cadl: operations", () => {
       op foo<TName, TPayload>(name: TName, payload: TPayload): boolean;
 
       @beta
-      op newFooBase<TParam>: foo<string, TParam>;
+      op newFooBase<TPayload>: foo<string, TPayload>;
 
       @test
       @kappa

--- a/packages/compiler/test/checker/operations.ts
+++ b/packages/compiler/test/checker/operations.ts
@@ -1,6 +1,6 @@
 import { strictEqual } from "assert";
 import { IntrinsicType, OperationType } from "../../core/types.js";
-import { createTestHost, TestHost } from "../../testing/index.js";
+import { createTestHost, expectDiagnostics, TestHost } from "../../testing/index.js";
 
 describe("cadl: operations", () => {
   let testHost: TestHost;
@@ -20,5 +20,45 @@ describe("cadl: operations", () => {
     const { foo } = (await testHost.compile("./main.cadl")) as { foo: OperationType };
     strictEqual(foo.returnType.kind, "Intrinsic");
     strictEqual((foo.returnType as IntrinsicType).name, "void");
+  });
+
+  it.only("can be templated", async () => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `@test op foo<TString, TPayload>(name: TString, payload: TPayload): boolean;
+
+      @test
+      op newFoo: foo<string, string>;`
+    );
+
+    const [result, diagnostics] = await testHost.compileAndDiagnose("./main.cadl");
+    expectDiagnostics(diagnostics, []);
+
+    const { newFoo } = result as { newFoo: OperationType };
+    strictEqual(newFoo.parameters.properties.size, 2);
+    const props = Array.from(newFoo.parameters.properties.values());
+
+    strictEqual(props[0].name, "name");
+    strictEqual(props[1].name, "payload");
+  });
+
+  it.only("can reuse operation instances", async () => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `@test op foo<TString, TPayload>(name: TString, payload: TPayload): boolean;
+
+      op newFooBase<TPayload>: foo<string, TPayload>;
+      op newFoo: newFooBase<string>;`
+    );
+
+    const [result, diagnostics] = await testHost.compileAndDiagnose("./main.cadl");
+    expectDiagnostics(diagnostics, []);
+
+    const { newFoo } = result as { newFoo: OperationType };
+    strictEqual(newFoo.parameters.properties.size, 2);
+    const props = Array.from(newFoo.parameters.properties.values());
+
+    strictEqual(props[0].name, "name");
+    strictEqual(props[1].name, "payload");
   });
 });

--- a/packages/compiler/test/test-parser.ts
+++ b/packages/compiler/test/test-parser.ts
@@ -638,6 +638,7 @@ function dynamicVisitChildren(node: Node, cb: (key: string, child: any) => void)
   for (const [key, value] of Object.entries(node)) {
     switch (key) {
       case "parent":
+      case "signature": // OperationStatementNode.signature doesn't have a node type
       case "parseDiagnostics":
         return;
     }

--- a/packages/rest/src/route.ts
+++ b/packages/rest/src/route.ts
@@ -418,9 +418,15 @@ function buildRoutes(
       continue;
     }
 
+    // Skip templated operations
+    if (op.templateArguments && op.templateArguments.length > 0) {
+      continue;
+    }
+
     const route = getPathForOperation(program, diagnostics, op, parentFragments, options);
     const verb = getVerbForOperation(program, diagnostics, op, route.parameters);
     const responses = diagnostics.pipe(getResponsesForOperation(program, op));
+
     operations.push({
       path: route.path,
       pathFragment: route.pathFragment,

--- a/packages/samples/signatures/main.cadl
+++ b/packages/samples/signatures/main.cadl
@@ -1,0 +1,1 @@
+import "./signatures.cadl";

--- a/packages/samples/signatures/signatures.cadl
+++ b/packages/samples/signatures/signatures.cadl
@@ -13,12 +13,17 @@ model CodeSignAccount {
 }
 
 @get
+@doc("Reads an instance of the {name} resource.", TResource)
 op ResourceReadBase<TResource, TError>(@path name: string): TResource | TError;
+op ResourceRead<TResource>: ResourceReadBase<TResource, ErrorDetails>;
 
-@doc("Reads an instance of the {name} resource.", T)
-op ResourceRead<T>: ResourceReadBase<T, ErrorDetails>;
+@post
+@doc("Reads an instance of the {name} resource.", TResource)
+op ResourceCreateBase<TResource, TError>(@body resource: TResource): TResource | TError;
+op ResourceCreate<TResource>: ResourceCreateBase<TResource, ErrorDetails>;
 
 @route("codeSignAccounts")
 interface CodeSignAccounts {
   get: ResourceRead<CodeSignAccount>;
+  create: ResourceCreate<CodeSignAccount>;
 }

--- a/packages/samples/signatures/signatures.cadl
+++ b/packages/samples/signatures/signatures.cadl
@@ -38,5 +38,4 @@ interface ResourceOperations<TResource> {
 }
 
 @route("accountProfiles")
-interface AccountProfiles extends ResourceOperations<AccountProfile> {
-}
+interface AccountProfiles extends ResourceOperations<AccountProfile> {}

--- a/packages/samples/signatures/signatures.cadl
+++ b/packages/samples/signatures/signatures.cadl
@@ -1,0 +1,24 @@
+import "@cadl-lang/rest";
+
+using Cadl.Http;
+
+@error
+model ErrorDetails {
+  code: int32;
+  message: string;
+}
+
+model CodeSignAccount {
+  name: string;
+}
+
+@get
+op ResourceReadBase<TResource, TError>(@path name: string): TResource | TError;
+
+@doc("Reads an instance of the {name} resource.", T)
+op ResourceRead<T>: ResourceReadBase<T, ErrorDetails>;
+
+@route("codeSignAccounts")
+interface CodeSignAccounts {
+  get: ResourceRead<CodeSignAccount>;
+}

--- a/packages/samples/signatures/signatures.cadl
+++ b/packages/samples/signatures/signatures.cadl
@@ -19,22 +19,22 @@ model AccountProfile {
 @get
 @doc("Reads an instance of the {name} resource.", TResource)
 op ResourceReadBase<TResource, TError>(@path name: string): TResource | TError;
-op ResourceRead<TResource>: ResourceReadBase<TResource, ErrorDetails>;
+op ResourceRead<TResource> is ResourceReadBase<TResource, ErrorDetails>;
 
 @post
 @doc("Reads an instance of the {name} resource.", TResource)
 op ResourceCreateBase<TResource, TError>(@body resource: TResource): TResource | TError;
-op ResourceCreate<TResource>: ResourceCreateBase<TResource, ErrorDetails>;
+op ResourceCreate<TResource> is ResourceCreateBase<TResource, ErrorDetails>;
 
 @route("codeSignAccounts")
 interface CodeSignAccounts {
-  get: ResourceRead<CodeSignAccount>;
-  create: ResourceCreate<CodeSignAccount>;
+  get is ResourceRead<CodeSignAccount>;
+  create is ResourceCreate<CodeSignAccount>;
 }
 
 interface ResourceOperations<TResource> {
-  get: ResourceRead<TResource>;
-  create: ResourceCreate<TResource>;
+  get is ResourceRead<TResource>;
+  create is ResourceCreate<TResource>;
 }
 
 @route("accountProfiles")

--- a/packages/samples/signatures/signatures.cadl
+++ b/packages/samples/signatures/signatures.cadl
@@ -12,6 +12,10 @@ model CodeSignAccount {
   name: string;
 }
 
+model AccountProfile {
+  value: int32;
+}
+
 @get
 @doc("Reads an instance of the {name} resource.", TResource)
 op ResourceReadBase<TResource, TError>(@path name: string): TResource | TError;
@@ -26,4 +30,13 @@ op ResourceCreate<TResource>: ResourceCreateBase<TResource, ErrorDetails>;
 interface CodeSignAccounts {
   get: ResourceRead<CodeSignAccount>;
   create: ResourceCreate<CodeSignAccount>;
+}
+
+interface ResourceOperations<TResource> {
+  get: ResourceRead<TResource>;
+  create: ResourceCreate<TResource>;
+}
+
+@route("accountProfiles")
+interface AccountProfiles extends ResourceOperations<AccountProfile> {
 }

--- a/packages/samples/test/output/signatures/openapi.json
+++ b/packages/samples/test/output/signatures/openapi.json
@@ -1,0 +1,79 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "(title)",
+    "version": "0000-00-00"
+  },
+  "tags": [],
+  "paths": {
+    "/codeSignAccounts/{name}": {
+      "get": {
+        "operationId": "CodeSignAccounts_get",
+        "description": "Reads an instance of the CodeSignAccount resource.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CodeSignAccount"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CodeSignAccount": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "ErrorDetails": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ]
+      }
+    }
+  }
+}

--- a/packages/samples/test/output/signatures/openapi.json
+++ b/packages/samples/test/output/signatures/openapi.json
@@ -43,6 +43,44 @@
           }
         }
       }
+    },
+    "/codeSignAccounts": {
+      "post": {
+        "operationId": "CodeSignAccounts_create",
+        "description": "Reads an instance of the CodeSignAccount resource.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CodeSignAccount"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorDetails"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CodeSignAccount"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/packages/samples/test/output/signatures/openapi.json
+++ b/packages/samples/test/output/signatures/openapi.json
@@ -81,6 +81,82 @@
           }
         }
       }
+    },
+    "/accountProfiles/{name}": {
+      "get": {
+        "operationId": "AccountProfiles_get",
+        "description": "Reads an instance of the AccountProfile resource.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountProfile"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/accountProfiles": {
+      "post": {
+        "operationId": "AccountProfiles_create",
+        "description": "Reads an instance of the AccountProfile resource.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountProfile"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorDetails"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountProfile"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -110,6 +186,18 @@
         "required": [
           "code",
           "message"
+        ]
+      },
+      "AccountProfile": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "required": [
+          "value"
         ]
       }
     }

--- a/packages/spec/src/spec.emu.html
+++ b/packages/spec/src/spec.emu.html
@@ -384,7 +384,7 @@ OperationSignatureDeclaration :
   `(` ModelPropertyList? `)` `:` Expression
 
 OperationSignatureReference :
-  `:` ReferenceExpression
+  `is` ReferenceExpression
 
 OperationSignature :
   OperationSignatureDeclaration

--- a/packages/spec/src/spec.emu.html
+++ b/packages/spec/src/spec.emu.html
@@ -320,7 +320,7 @@ InterfaceMemberList :
     InterfaceMemberList `;` InterfaceMember
 
 InterfaceMember :
-    `op`? Identifier `(` ModelPropertyList? `)` `:` Expression
+    `op`? Identifier OperationSignature
 
 
 UnionStatement :

--- a/packages/spec/src/spec.emu.html
+++ b/packages/spec/src/spec.emu.html
@@ -377,11 +377,21 @@ IdentifierList :
     Identifier
     IdentifierList `,` Identifier
 
-NamespaceStatement: 
+NamespaceStatement : 
     DecoratorList? `namespace` IdentifierOrMemberExpression `{` StatementList? `}`
 
+OperationSignatureDeclaration :
+  `(` ModelPropertyList? `)` `:` Expression
+
+OperationSignatureReference :
+  `:` ReferenceExpression
+
+OperationSignature :
+  OperationSignatureDeclaration
+  OperationSignatureReference
+
 OperationStatement :
-    DecoratorList? `op` Identifier `(` ModelPropertyList? `)` `:` Expression `;`
+    DecoratorList? `op` Identifier TemplateArguments? OperationSignature `;`
 
 Expression :
     UnionExpressionOrHigher


### PR DESCRIPTION
This change fixes #459 by implementing support for both templated operations and the definition of operations that are based on the signature of another operation (no matter how it was defined).

Here's a contrived example (sample output [here](https://github.com/daviwil/cadl/blob/operation-templates/packages/samples/test/output/signatures/openapi.json)):

```
import "@cadl-lang/rest";

using Cadl.Http;

@error
model ErrorDetails {
  code: int32;
  message: string;
}

model CodeSignAccount {
  name: string;
}

model AccountProfile {
  value: int32;
}

@get
@doc("Reads an instance of the {name} resource.", TResource)
op ResourceReadBase<TResource, TError>(@path name: string): TResource | TError;
op ResourceRead<TResource>: ResourceReadBase<TResource, ErrorDetails>;

@post
@doc("Reads an instance of the {name} resource.", TResource)
op ResourceCreateBase<TResource, TError>(@body resource: TResource): TResource | TError;
op ResourceCreate<TResource>: ResourceCreateBase<TResource, ErrorDetails>;

@route("codeSignAccounts")
interface CodeSignAccounts {
  get: ResourceRead<CodeSignAccount>;
  create: ResourceCreate<CodeSignAccount>;
}

interface ResourceOperations<TResource> {
  get: ResourceRead<TResource>;
  create: ResourceCreate<TResource>;
}

@route("accountProfiles")
interface AccountProfiles extends ResourceOperations<AccountProfile> {
}
```

A couple of important things to note:

- You can base an operation on the signature of an operation that was derived from yet another operation (to aid in building abstractions)
- Decorators applied to operations that you reference are applied directly to the final operation, similar to `model is` semantics
