### PR TITLE
Eslint plugin for linting Cadl Typescript code

### DIFF
--- a/common/changes/@cadl-lang/eslint-plugin/library-linter-eslint_2022-05-27-20-46.json
+++ b/common/changes/@cadl-lang/eslint-plugin/library-linter-eslint_2022-05-27-20-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/eslint-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/eslint-plugin"
+}

--- a/common/changes/@cadl-lang/openapi/library-linter-eslint_2022-05-27-20-46.json
+++ b/common/changes/@cadl-lang/openapi/library-linter-eslint_2022-05-27-20-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/openapi3/library-linter-eslint_2022-05-27-20-46.json
+++ b/common/changes/@cadl-lang/openapi3/library-linter-eslint_2022-05-27-20-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/library-linter-eslint_2022-05-27-20-46.json
+++ b/common/changes/@cadl-lang/rest/library-linter-eslint_2022-05-27-20-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/versioning/library-linter-eslint_2022-05-27-20-46.json
+++ b/common/changes/@cadl-lang/versioning/library-linter-eslint_2022-05-27-20-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -14,6 +14,7 @@ specifiers:
   '@rush-temp/cadl-vscode': file:./projects/cadl-vscode.tgz
   '@rush-temp/compiler': file:./projects/compiler.tgz
   '@rush-temp/eslint-config-cadl': file:./projects/eslint-config-cadl.tgz
+  '@rush-temp/eslint-plugin': file:./projects/eslint-plugin.tgz
   '@rush-temp/html-program-viewer': file:./projects/html-program-viewer.tgz
   '@rush-temp/internal-build-utils': file:./projects/internal-build-utils.tgz
   '@rush-temp/library-linter': file:./projects/library-linter.tgz
@@ -46,6 +47,7 @@ specifiers:
   '@types/yargs': ~17.0.2
   '@typescript-eslint/eslint-plugin': ^5.16.0
   '@typescript-eslint/parser': ^5.16.0
+  '@typescript-eslint/utils': ~5.26.0
   '@vitejs/plugin-react': ~1.3.1
   ajv: ~8.9.0
   autorest: ~3.3.2
@@ -107,6 +109,7 @@ dependencies:
   '@rush-temp/cadl-vscode': file:projects/cadl-vscode.tgz
   '@rush-temp/compiler': file:projects/compiler.tgz
   '@rush-temp/eslint-config-cadl': file:projects/eslint-config-cadl.tgz_prettier@2.6.2
+  '@rush-temp/eslint-plugin': file:projects/eslint-plugin.tgz
   '@rush-temp/html-program-viewer': file:projects/html-program-viewer.tgz
   '@rush-temp/internal-build-utils': file:projects/internal-build-utils.tgz
   '@rush-temp/library-linter': file:projects/library-linter.tgz
@@ -139,6 +142,7 @@ dependencies:
   '@types/yargs': 17.0.10
   '@typescript-eslint/eslint-plugin': 5.18.0_f634834830b3cce5385c59ca2d60ec0b
   '@typescript-eslint/parser': 5.18.0_eslint@8.13.0+typescript@4.7.2
+  '@typescript-eslint/utils': 5.26.0_eslint@8.13.0+typescript@4.7.2
   '@vitejs/plugin-react': 1.3.2
   ajv: 8.9.0
   autorest: 3.3.2
@@ -959,6 +963,14 @@ packages:
       '@typescript-eslint/visitor-keys': 5.18.0
     dev: false
 
+  /@typescript-eslint/scope-manager/5.26.0:
+    resolution: {integrity: sha512-gVzTJUESuTwiju/7NiTb4c5oqod8xt5GhMbExKsCTp6adU3mya6AGJ4Pl9xC7x2DX9UYFsjImC0mA62BCY22Iw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.26.0
+      '@typescript-eslint/visitor-keys': 5.26.0
+    dev: false
+
   /@typescript-eslint/type-utils/5.18.0_eslint@8.13.0+typescript@4.7.2:
     resolution: {integrity: sha512-vcn9/6J5D6jtHxpEJrgK8FhaM8r6J1/ZiNu70ZUJN554Y3D9t3iovi6u7JF8l/e7FcBIxeuTEidZDR70UuCIfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -983,6 +995,11 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
+  /@typescript-eslint/types/5.26.0:
+    resolution: {integrity: sha512-8794JZFE1RN4XaExLWLI2oSXsVImNkl79PzTOOWt9h0UHROwJedNOD2IJyfL0NbddFllcktGIO2aOu10avQQyA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: false
+
   /@typescript-eslint/typescript-estree/5.18.0_typescript@4.7.2:
     resolution: {integrity: sha512-wa+2VAhOPpZs1bVij9e5gyVu60ReMi/KuOx4LKjGx2Y3XTNUDJgQ+5f77D49pHtqef/klglf+mibuHs9TrPxdQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -997,7 +1014,28 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.6
+      semver: 7.3.7
+      tsutils: 3.21.0_typescript@4.7.2
+      typescript: 4.7.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/typescript-estree/5.26.0_typescript@4.7.2:
+    resolution: {integrity: sha512-EyGpw6eQDsfD6jIqmXP3rU5oHScZ51tL/cZgFbFBvWuCwrIptl+oueUZzSmLtxFuSOQ9vDcJIs+279gnJkfd1w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.26.0
+      '@typescript-eslint/visitor-keys': 5.26.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.7
       tsutils: 3.21.0_typescript@4.7.2
       typescript: 4.7.2
     transitivePeerDependencies:
@@ -1022,11 +1060,37 @@ packages:
       - typescript
     dev: false
 
+  /@typescript-eslint/utils/5.26.0_eslint@8.13.0+typescript@4.7.2:
+    resolution: {integrity: sha512-PJFwcTq2Pt4AMOKfe3zQOdez6InIDOjUJJD3v3LyEtxHGVVRK3Vo7Dd923t/4M9hSH2q2CLvcTdxlLPjcIk3eg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.26.0
+      '@typescript-eslint/types': 5.26.0
+      '@typescript-eslint/typescript-estree': 5.26.0_typescript@4.7.2
+      eslint: 8.13.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.13.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
   /@typescript-eslint/visitor-keys/5.18.0:
     resolution: {integrity: sha512-Hf+t+dJsjAKpKSkg3EHvbtEpFFb/1CiOHnvI8bjHgOD4/wAw3gKrA0i94LrbekypiZVanJu3McWJg7rWDMzRTg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.18.0
+      eslint-visitor-keys: 3.3.0
+    dev: false
+
+  /@typescript-eslint/visitor-keys/5.26.0:
+    resolution: {integrity: sha512-wei+ffqHanYDOQgg/fS6Hcar6wAWv0CUPQ3TZzOWd2BLfgP539rb49bwua8WRAs7R6kOSLn82rfEu2ro6Llt8Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.26.0
       eslint-visitor-keys: 3.3.0
     dev: false
 
@@ -3124,7 +3188,7 @@ packages:
     resolution: {integrity: sha512-tzua9qWWi7iW4I42vUPKM+SfaF0vQSLAm4yO5J83mSwB7GeoWrDKC/K+8YCnYNwqP5duwazbw2X9l4m8SC2cUw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.3.6
+      semver: 7.3.7
     dev: false
 
   /node-addon-api/4.3.0:
@@ -3648,6 +3712,14 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 7.8.1
+    dev: false
+
+  /semver/7.3.7:
+    resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
     dev: false
 
   /sentence-case/3.0.4:
@@ -4523,6 +4595,23 @@ packages:
       - supports-color
     dev: false
 
+  file:projects/eslint-plugin.tgz:
+    resolution: {integrity: sha512-Ba7aORFV3PR0hqTUAhTGJGCBI1j7eG0RR1+pQB2HGuqpdvUdKhNiC0/iMHYhRlJHiNq4x0wKjv1QJ8PK8ymmDw==, tarball: file:projects/eslint-plugin.tgz}
+    name: '@rush-temp/eslint-plugin'
+    version: 0.0.0
+    dependencies:
+      '@types/mocha': 9.1.0
+      '@types/node': 16.0.3
+      '@typescript-eslint/utils': 5.26.0_eslint@8.13.0+typescript@4.7.2
+      c8: 7.11.0
+      eslint: 8.13.0
+      mocha: 9.2.2
+      rimraf: 3.0.2
+      typescript: 4.7.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   file:projects/html-program-viewer.tgz:
     resolution: {integrity: sha512-u0o6xrGI3cKnsYpP5zEKZv6sfWgim8S0u9J28w3/fW7Lm8yXRRDgC8ed84XfiHycr2xSeBERL4dcD9rtei6BxA==, tarball: file:projects/html-program-viewer.tgz}
     name: '@rush-temp/html-program-viewer'
@@ -4576,6 +4665,7 @@ packages:
     dependencies:
       '@types/mocha': 9.1.0
       '@types/node': 16.0.3
+      '@typescript-eslint/utils': 5.26.0_eslint@8.13.0+typescript@4.7.2
       c8: 7.11.0
       eslint: 8.13.0
       mocha: 9.2.2
@@ -4586,7 +4676,7 @@ packages:
     dev: false
 
   file:projects/openapi.tgz:
-    resolution: {integrity: sha512-DVTOuNxChQbCPWwEIq5mclF7Y8XbKwE7LizttYtNtBjmwR6il1xj27aAZYTwSvlxm8t70FQ7nTKG7jxTa7t1/Q==, tarball: file:projects/openapi.tgz}
+    resolution: {integrity: sha512-auwIgX/qWTj1y2fA9qn//s4ztICelBKa5Z1A7YeqnngMqosX6GwRot7bfg1MIJCsvQ+0uj4eH3Vn7+iNsS4xhw==, tarball: file:projects/openapi.tgz}
     name: '@rush-temp/openapi'
     version: 0.0.0
     dependencies:

--- a/packages/eslint-plugin-cadl/.c8rc.json
+++ b/packages/eslint-plugin-cadl/.c8rc.json
@@ -1,0 +1,3 @@
+{
+  "reporter": ["cobertura", "json", "text"]
+}

--- a/packages/eslint-plugin-cadl/.eslintrc.cjs
+++ b/packages/eslint-plugin-cadl/.eslintrc.cjs
@@ -1,7 +1,6 @@
 require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
-  plugins: ["@cadl-lang/eslint-plugin"],
-  extends: ["@cadl-lang/eslint-config-cadl", "plugin:@cadl-lang/eslint-plugin/recommended"],
+  extends: "@cadl-lang/eslint-config-cadl",
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/eslint-plugin-cadl/.mocharc.yaml
+++ b/packages/eslint-plugin-cadl/.mocharc.yaml
@@ -1,0 +1,4 @@
+timeout: 5000
+require: source-map-support/register
+spec: "dist/test/**/*.js"
+ignore: "dist/test/manual/**/*.js"

--- a/packages/eslint-plugin-cadl/LICENSE
+++ b/packages/eslint-plugin-cadl/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/packages/eslint-plugin-cadl/README.md
+++ b/packages/eslint-plugin-cadl/README.md
@@ -1,24 +1,22 @@
-# Cadl Library Linter
+# Cadl Eslint Plugin
 
 ## Installation
 
 Install the package as a dev dependency.
 
 ```
-npm install -D @cadl-lang/library-linter
+npm install -D @cadl-lang/eslint-plugin
 ```
 
 ## Usage
 
-Compile your library package. Any errors or warnings will be reported as cadl diagnostics.
+Add the following to your eslint config
 
-```bash
-# At the root of your cadl library.
-cadl compile . --import @cadl-lang/library-linter
+```yaml
+plugins: ["@cadl-lang/eslint-plugin"],
+extends: ["plugin:@cadl-lang/eslint-plugin/recommended"],
 ```
 
-## Cadl Library Best rules and best practices
+## Rules
 
-| Rule name           | Description                                                                                                      |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `missing-namespace` | Validate that every exported element from the library(Models, JS functions, operations, etc.) is in a namespace. |
+- [call-decorator](./docs/rules/call-decorator.md)

--- a/packages/eslint-plugin-cadl/README.md
+++ b/packages/eslint-plugin-cadl/README.md
@@ -1,0 +1,24 @@
+# Cadl Library Linter
+
+## Installation
+
+Install the package as a dev dependency.
+
+```
+npm install -D @cadl-lang/library-linter
+```
+
+## Usage
+
+Compile your library package. Any errors or warnings will be reported as cadl diagnostics.
+
+```bash
+# At the root of your cadl library.
+cadl compile . --import @cadl-lang/library-linter
+```
+
+## Cadl Library Best rules and best practices
+
+| Rule name           | Description                                                                                                      |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `missing-namespace` | Validate that every exported element from the library(Models, JS functions, operations, etc.) is in a namespace. |

--- a/packages/eslint-plugin-cadl/docs/rules/call-decorator.md
+++ b/packages/eslint-plugin-cadl/docs/rules/call-decorator.md
@@ -1,0 +1,59 @@
+# `call-decorator`
+
+Enforces calling other Cadl decorator using `context.call` instead of calling the decorator function directly.
+
+Calling the decorator function directly can result in diagnostics with incorrect location.
+
+## Rule Details
+
+## How to Use
+
+```jsonc
+{
+  "@cadl-lang/call-decorator": "warn"
+}
+```
+
+<!--tabs-->
+
+#### ❌ Incorrect
+
+```ts
+function $foo(context: DecoratorContext, target: Type) {}
+
+function $bar(context: DecoratorContext, target: Type) {
+  $foo(context, target);
+}
+```
+
+```ts
+function $foo(context: DecoratorContext, target: Type, name: string) {}
+
+function $bar(context: DecoratorContext, target: Type, name: string) {
+  $foo(context, target, `bar.${name}`);
+}
+```
+
+#### ✅ Correct
+
+```ts
+function $foo(context: DecoratorContext, target: Type) {}
+
+function $bar(context: DecoratorContext, target: Type) {
+  context.call($foo, target);
+}
+```
+
+```ts
+function $foo(context: DecoratorContext, target: Type, name: string) {}
+
+function $bar(context: DecoratorContext, target: Type, name: string) {
+  context.call($foo, target, `bar.${name}`);
+}
+```
+
+## Attributes
+
+- [x] ✅ Recommended
+- [x] 🔧 Fixable
+- [x] 💭 Requires type information

--- a/packages/eslint-plugin-cadl/package.json
+++ b/packages/eslint-plugin-cadl/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@cadl-lang/eslint-plugin",
+  "version": "0.1.0",
+  "author": "Microsoft Corporation",
+  "description": "Eslint plugin providing set of rules to be used in the JS/TS code of Cadl libraries",
+  "homepage": "https://github.com/Microsoft/cadl",
+  "readme": "https://github.com/Microsoft/cadl/blob/main/README.md",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Microsoft/cadl.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Microsoft/cadl/issues"
+  },
+  "keywords": [
+    "cadl"
+  ],
+  "type": "commonjs",
+  "main": "dist/src/index.js",
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "scripts": {
+    "clean": "rimraf ./dist ./temp",
+    "build": "tsc -p .",
+    "watch": "tsc -p . --watch",
+    "test": "mocha",
+    "test-official": "c8 mocha --forbid-only",
+    "lint": "eslint . --ext .ts --max-warnings=0",
+    "lint:fix": "eslint . --fix --ext .ts"
+  },
+  "files": [
+    "lib/*.cadl",
+    "dist/**",
+    "!dist/test/**"
+  ],
+  "peerDependencies": {
+    "eslint": ">=0.8.0"
+  },
+  "devDependencies": {
+    "@types/mocha": "~9.1.0",
+    "@types/node": "~16.0.3",
+    "@cadl-lang/eslint-config-cadl": "~0.3.0",
+    "eslint": "^8.12.0",
+    "mocha": "~9.2.0",
+    "c8": "~7.11.0",
+    "rimraf": "~3.0.2",
+    "typescript": "~4.7.2"
+  },
+  "dependencies": {
+    "@typescript-eslint/utils": "~5.26.0"
+  }
+}

--- a/packages/eslint-plugin-cadl/src/index.ts
+++ b/packages/eslint-plugin-cadl/src/index.ts
@@ -1,0 +1,13 @@
+import { callDecoratorRule } from "./rules/call-decorator.js";
+
+export const rules = {
+  "call-decorator": callDecoratorRule,
+};
+
+export const configs = {
+  recommended: {
+    rules: {
+      "@cadl-lang/call-decorator": "warn",
+    },
+  },
+};

--- a/packages/eslint-plugin-cadl/src/rules/call-decorator.ts
+++ b/packages/eslint-plugin-cadl/src/rules/call-decorator.ts
@@ -1,0 +1,34 @@
+import { createRule } from "../utils.js";
+
+const messages = {
+  default: "Use context.call to call a decorator function.",
+};
+
+export const callDecoratorRule = createRule<never[], keyof typeof messages>({
+  create(context) {
+    return {
+      FunctionDeclaration(node) {
+        if (node.id != null) {
+          if (/^[a-z]/.test(node.id.name)) {
+            context.report({
+              messageId: "default",
+              node: node.id,
+            });
+          }
+        }
+      },
+    };
+  },
+  name: "call-decorator",
+  meta: {
+    docs: {
+      description: "Calling a Cadl decorator from JS/TS code should be done with context.call",
+      recommended: "warn",
+    },
+    messages,
+
+    type: "suggestion",
+    schema: [],
+  },
+  defaultOptions: [],
+});

--- a/packages/eslint-plugin-cadl/src/rules/call-decorator.ts
+++ b/packages/eslint-plugin-cadl/src/rules/call-decorator.ts
@@ -1,10 +1,10 @@
 import { ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
-import * as ts from "typescript";
+import ts from "typescript";
 import { createRule } from "../utils.js";
 
 const messages = {
-  default: "Use context.call to call a decorator function.",
-  suggestReplaceWithContextCall: "Replace with context.calll",
+  default: "Use context.call to call a Cadl decorator function.",
+  suggestReplaceWithContextCall: "Replace with context.call",
 };
 
 export const callDecoratorRule = createRule<never[], keyof typeof messages>({

--- a/packages/eslint-plugin-cadl/src/utils.ts
+++ b/packages/eslint-plugin-cadl/src/utils.ts
@@ -3,5 +3,5 @@ import { ESLintUtils } from "@typescript-eslint/utils";
 // TODO get rule url
 export const createRule = ESLintUtils.RuleCreator(
   (name) =>
-    `https://github.com/microsoft/cadl/tree/main/packages/library-linter/src/eslint/rules/${name}`
+    `https://github.com/microsoft/cadl/tree/main/packages/eslint-plugin-cadl/docs/rules/${name}.md`
 );

--- a/packages/eslint-plugin-cadl/src/utils.ts
+++ b/packages/eslint-plugin-cadl/src/utils.ts
@@ -1,0 +1,7 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+// TODO get rule url
+export const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/microsoft/cadl/tree/main/packages/library-linter/src/eslint/rules/${name}`
+);

--- a/packages/eslint-plugin-cadl/test/fixtures/tsconfig.json
+++ b/packages/eslint-plugin-cadl/test/fixtures/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "experimentalDecorators": true
+  },
+  "include": ["file.ts"]
+}

--- a/packages/eslint-plugin-cadl/test/rules/call-decorator.test.ts
+++ b/packages/eslint-plugin-cadl/test/rules/call-decorator.test.ts
@@ -47,15 +47,31 @@ interface DecoratorContext {}; interface Type {};
 function $foo(context: DecoratorContext, target: Type) {}
 
 function $bar(context: DecoratorContext, target: Type) {
-  $bar(context, target);
+  $foo(context, target);
 }
     `,
       errors: [
         {
           line: 7,
           messageId: "default",
+          suggestions: [
+            {
+              messageId: "suggestReplaceWithContextCall",
+              output: `
+interface DecoratorContext {}; interface Type {};
+
+function $foo(context: DecoratorContext, target: Type) {}
+
+function $bar(context: DecoratorContext, target: Type) {
+  context.call($foo, target);
+}
+    `,
+            },
+          ],
         },
       ],
     },
   ],
 });
+
+ruleTester.run;

--- a/packages/eslint-plugin-cadl/test/rules/call-decorator.test.ts
+++ b/packages/eslint-plugin-cadl/test/rules/call-decorator.test.ts
@@ -1,0 +1,61 @@
+import { ESLintUtils } from "@typescript-eslint/utils";
+import { callDecoratorRule } from "../../src/rules/call-decorator";
+import { getFixturesRootDir } from "./utils";
+
+const rootDir = getFixturesRootDir();
+
+const ruleTester = new ESLintUtils.RuleTester({
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: "./tsconfig.json",
+    tsconfigRootDir: rootDir,
+  },
+});
+
+ruleTester.run("call-decorator", callDecoratorRule, {
+  valid: [
+    {
+      name: "Valid if using .call to call decorator",
+      code: `
+interface DecoratorContext {}; interface Type {};
+
+function $foo(context: DecoratorContext, target: Type) {}
+
+function $bar(context: DecoratorContext, target: Type) {
+  context.call($bar, target);
+}
+    `,
+    },
+    {
+      name: "Valid if passing context to a non decorator function",
+      code: `
+interface DecoratorContext {}; interface Type {};
+
+function setFoo(context: DecoratorContext, target: Type) {}
+
+function $bar(context: DecoratorContext, target: Type) {
+  setFoo(context, target);
+}
+    `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+interface DecoratorContext {}; interface Type {};
+
+function $foo(context: DecoratorContext, target: Type) {}
+
+function $bar(context: DecoratorContext, target: Type) {
+  $bar(context, target);
+}
+    `,
+      errors: [
+        {
+          line: 7,
+          messageId: "default",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-cadl/test/rules/utils.ts
+++ b/packages/eslint-plugin-cadl/test/rules/utils.ts
@@ -1,0 +1,5 @@
+import { resolve } from "path";
+
+export function getFixturesRootDir(): string {
+  return resolve(__dirname, "../../../test/fixtures");
+}

--- a/packages/eslint-plugin-cadl/tsconfig.json
+++ b/packages/eslint-plugin-cadl/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.json",
+  "references": [
+    { "path": "../compiler/tsconfig.json" },
+    { "path": "../rest/tsconfig.json" },
+    { "path": "../openapi/tsconfig.json" }
+  ],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo",
+    "types": ["node", "mocha"],
+    "module": "CommonJS"
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/library-linter/package.json
+++ b/packages/library-linter/package.json
@@ -51,8 +51,7 @@
     "!dist/test/**"
   ],
   "peerDependencies": {
-    "@cadl-lang/compiler": "~0.31.0",
-    "@cadl-lang/eslint-plugin": "~0.1.0"
+    "@cadl-lang/compiler": "~0.31.0"
   },
   "devDependencies": {
     "@types/mocha": "~9.1.0",

--- a/packages/library-linter/package.json
+++ b/packages/library-linter/package.json
@@ -51,7 +51,8 @@
     "!dist/test/**"
   ],
   "peerDependencies": {
-    "@cadl-lang/compiler": "~0.31.0"
+    "@cadl-lang/compiler": "~0.31.0",
+    "@cadl-lang/eslint-plugin": "~0.1.0"
   },
   "devDependencies": {
     "@types/mocha": "~9.1.0",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -43,7 +43,7 @@
     "lint-cadl-library": "cadl compile . --import @cadl-lang/library-linter",
     "test": "mocha",
     "test-official": "c8 mocha --forbid-only",
-    "lint": "eslint src/decorators.ts --ext .ts --max-warnings=0",
+    "lint": "eslint . --ext .ts --max-warnings=0",
     "lint:fix": "eslint . --fix --ext .ts"
   },
   "files": [
@@ -61,7 +61,6 @@
     "@cadl-lang/compiler": "~0.31.0",
     "@cadl-lang/rest": "~0.14.0",
     "@cadl-lang/eslint-config-cadl": "~0.3.0",
-    "@cadl-lang/eslint-plugin": "~0.1.0",
     "@cadl-lang/library-linter": "~0.1.0",
     "eslint": "^8.12.0",
     "mocha": "~9.2.0",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -61,6 +61,7 @@
     "@cadl-lang/compiler": "~0.31.0",
     "@cadl-lang/rest": "~0.14.0",
     "@cadl-lang/eslint-config-cadl": "~0.3.0",
+    "@cadl-lang/eslint-plugin": "~0.1.0",
     "@cadl-lang/library-linter": "~0.1.0",
     "eslint": "^8.12.0",
     "mocha": "~9.2.0",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -43,7 +43,7 @@
     "lint-cadl-library": "cadl compile . --import @cadl-lang/library-linter",
     "test": "mocha",
     "test-official": "c8 mocha --forbid-only",
-    "lint": "eslint . --ext .ts --max-warnings=0",
+    "lint": "eslint src/decorators.ts --ext .ts --max-warnings=0",
     "lint:fix": "eslint . --fix --ext .ts"
   },
   "files": [

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -62,6 +62,7 @@
     "@cadl-lang/rest": "~0.14.0",
     "@cadl-lang/eslint-config-cadl": "~0.3.0",
     "@cadl-lang/library-linter": "~0.1.0",
+    "@cadl-lang/eslint-plugin": "~0.1.0",
     "eslint": "^8.12.0",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -22,8 +22,6 @@ export function $operationId(context: DecoratorContext, entity: Type, opId: stri
   ) {
     return;
   }
-  // TODO remove for testing only
-  $extension(context, entity, "x-abc", "foo");
   context.program.stateMap(operationIdsKey).set(entity, opId);
 }
 
@@ -34,17 +32,17 @@ export function getOperationId(program: Program, entity: Type): string | undefin
 export type ExtensionKey = `x-${string}`;
 const openApiExtensionKey = Symbol("openApiExtension");
 export function $extension(
-  context2: DecoratorContext,
+  context: DecoratorContext,
   entity: Type,
   extensionName: string,
   value: CadlValue
 ) {
-  if (!validateDecoratorParamType(context2.program, entity, extensionName, "String")) {
+  if (!validateDecoratorParamType(context.program, entity, extensionName, "String")) {
     return;
   }
 
   if (!isOpenAPIExtensionKey(extensionName)) {
-    reportDiagnostic(context2.program, {
+    reportDiagnostic(context.program, {
       code: "invalid-extension-key",
       format: { value: extensionName },
       target: entity,
@@ -53,9 +51,9 @@ export function $extension(
 
   const [data, diagnostics] = cadlTypeToJson(value, entity);
   if (diagnostics.length > 0) {
-    context2.program.reportDiagnostics(diagnostics);
+    context.program.reportDiagnostics(diagnostics);
   }
-  setExtension(context2.program, entity, extensionName as ExtensionKey, data);
+  setExtension(context.program, entity, extensionName as ExtensionKey, data);
 }
 
 export function setExtension(

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -22,6 +22,8 @@ export function $operationId(context: DecoratorContext, entity: Type, opId: stri
   ) {
     return;
   }
+  // TODO remove for testing only
+  $extension(context, entity, "x-abc", "foo");
   context.program.stateMap(operationIdsKey).set(entity, opId);
 }
 
@@ -32,17 +34,17 @@ export function getOperationId(program: Program, entity: Type): string | undefin
 export type ExtensionKey = `x-${string}`;
 const openApiExtensionKey = Symbol("openApiExtension");
 export function $extension(
-  context: DecoratorContext,
+  context2: DecoratorContext,
   entity: Type,
   extensionName: string,
   value: CadlValue
 ) {
-  if (!validateDecoratorParamType(context.program, entity, extensionName, "String")) {
+  if (!validateDecoratorParamType(context2.program, entity, extensionName, "String")) {
     return;
   }
 
   if (!isOpenAPIExtensionKey(extensionName)) {
-    reportDiagnostic(context.program, {
+    reportDiagnostic(context2.program, {
       code: "invalid-extension-key",
       format: { value: extensionName },
       target: entity,
@@ -51,9 +53,9 @@ export function $extension(
 
   const [data, diagnostics] = cadlTypeToJson(value, entity);
   if (diagnostics.length > 0) {
-    context.program.reportDiagnostics(diagnostics);
+    context2.program.reportDiagnostics(diagnostics);
   }
-  setExtension(context.program, entity, extensionName as ExtensionKey, data);
+  setExtension(context2.program, entity, extensionName as ExtensionKey, data);
 }
 
 export function setExtension(

--- a/packages/openapi3/.eslintrc.cjs
+++ b/packages/openapi3/.eslintrc.cjs
@@ -1,6 +1,7 @@
 require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
-  extends: "@cadl-lang/eslint-config-cadl",
+  plugins: ["@cadl-lang/eslint-plugin"],
+  extends: ["@cadl-lang/eslint-config-cadl", "plugin:@cadl-lang/eslint-plugin/recommended"],
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/openapi3/package.json
+++ b/packages/openapi3/package.json
@@ -66,6 +66,7 @@
     "@cadl-lang/versioning": "~0.5.0",
     "@cadl-lang/eslint-config-cadl": "~0.3.0",
     "@cadl-lang/library-linter": "~0.1.0",
+    "@cadl-lang/eslint-plugin": "~0.1.0",
     "eslint": "^8.12.0",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",

--- a/packages/rest/.eslintrc.cjs
+++ b/packages/rest/.eslintrc.cjs
@@ -1,6 +1,7 @@
 require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
-  extends: "@cadl-lang/eslint-config-cadl",
+  plugins: ["@cadl-lang/eslint-plugin"],
+  extends: ["@cadl-lang/eslint-config-cadl", "plugin:@cadl-lang/eslint-plugin/recommended"],
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -60,6 +60,7 @@
     "@cadl-lang/compiler": "~0.31.0",
     "@cadl-lang/eslint-config-cadl": "~0.3.0",
     "@cadl-lang/library-linter": "~0.1.0",
+    "@cadl-lang/eslint-plugin": "~0.1.0",
     "eslint": "^8.12.0",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",

--- a/packages/rest/src/resource.ts
+++ b/packages/rest/src/resource.ts
@@ -109,7 +109,7 @@ function cloneKeyProperties(context: DecoratorContext, target: ModelType, resour
         args: [{ node: target.node, value: resourceType }],
       }
     );
-    $path(context, newProp, undefined as any);
+    context.call($path, newProp, undefined as any);
 
     target.properties.set(keyName, newProp);
   }

--- a/packages/rest/src/rest.ts
+++ b/packages/rest/src/rest.ts
@@ -94,13 +94,13 @@ export function $segmentOf(context: DecoratorContext, entity: Type, resourceType
   if (resourceKey) {
     const keySegment = getSegment(context.program, resourceKey.keyProperty);
     if (keySegment) {
-      $segment(context, entity, keySegment);
+      context.call($segment, entity, keySegment);
     }
   } else {
     // Does the model itself have a segment attached?
     const modelSegment = getSegment(context.program, resourceType);
     if (modelSegment) {
-      $segment(context, entity, modelSegment);
+      context.call($segment, entity, modelSegment);
     }
   }
 }
@@ -161,7 +161,7 @@ export function $readsResource(context: DecoratorContext, entity: Type, resource
 
 export function $createsResource(context: DecoratorContext, entity: Type, resourceType: Type) {
   // Add path segment for resource type key
-  $segmentOf(context, entity, resourceType);
+  context.call($segmentOf, entity, resourceType);
 
   setResourceOperation(context.program, entity, resourceType, "create");
 }
@@ -184,10 +184,10 @@ export function $deletesResource(context: DecoratorContext, entity: Type, resour
 
 export function $listsResource(context: DecoratorContext, entity: Type, resourceType: Type) {
   // Add the @list decorator too so that collection routes are generated correctly
-  $list(context, entity, resourceType);
+  context.call($list, entity, resourceType);
 
   // Add path segment for resource type key
-  $segmentOf(context, entity, resourceType);
+  context.call($segmentOf, entity, resourceType);
 
   setResourceOperation(context.program, entity, resourceType, "list");
 }
@@ -204,7 +204,7 @@ export function $action(context: DecoratorContext, entity: Type, name?: string) 
 
   // Generate the action name and add it as an operation path segment
   const action = lowerCaseFirstChar(name || entity.name);
-  $segment(context, entity, action);
+  context.call($segment, entity, action);
 
   context.program.stateMap(actionsKey).set(entity, action);
 }

--- a/packages/versioning/.eslintrc.cjs
+++ b/packages/versioning/.eslintrc.cjs
@@ -1,6 +1,7 @@
 require("@cadl-lang/eslint-config-cadl/patch/modern-module-resolution");
 
 module.exports = {
-  extends: "@cadl-lang/eslint-config-cadl",
+  plugins: ["@cadl-lang/eslint-plugin"],
+  extends: ["@cadl-lang/eslint-config-cadl", "plugin:@cadl-lang/eslint-plugin/recommended"],
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/versioning/package.json
+++ b/packages/versioning/package.json
@@ -59,6 +59,7 @@
     "@types/node": "~16.0.3",
     "@cadl-lang/eslint-config-cadl": "~0.3.0",
     "@cadl-lang/library-linter": "~0.1.0",
+    "@cadl-lang/eslint-plugin": "~0.1.0",
     "eslint": "^8.12.0",
     "mocha": "~9.2.0",
     "c8": "~7.11.0",

--- a/rush.json
+++ b/rush.json
@@ -127,6 +127,12 @@
       "shouldPublish": true
     },
     {
+      "packageName": "@cadl-lang/eslint-plugin",
+      "projectFolder": "packages/eslint-plugin-cadl",
+      "reviewCategory": "production",
+      "shouldPublish": true
+    },
+    {
       "packageName": "@cadl-lang/openapi3",
       "projectFolder": "packages/openapi3",
       "reviewCategory": "production",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     { "path": "packages/versioning/tsconfig.json" },
     { "path": "packages/rest/tsconfig.json" },
     { "path": "packages/library-linter/tsconfig.json" },
+    { "path": "packages/eslint-plugin-cadl/tsconfig.json" },
     { "path": "packages/openapi/tsconfig.json" },
     { "path": "packages/openapi3/tsconfig.json" },
     { "path": "packages/cadl-vscode/tsconfig.json" },


### PR DESCRIPTION
Right now only adding validation to make sure you use `context.call` when calling another decorator.

Rule documentation https://github.com/microsoft/cadl/blob/0a7b99e139a5e3327b52884ff0370c5620a2c5ed/packages/eslint-plugin-cadl/docs/rules/call-decorator.md

Had to make a new packages for a few reason:
- ESLint plugin needs to be CommonJS Still
- ESlint plugin need to have `eslint-plugin` prefix.
![image](https://user-images.githubusercontent.com/1031227/170787243-2733c218-1ad0-4d4e-99f5-c7df91f93b5c.png)


Added auto fixing
![context-call-autofix](https://user-images.githubusercontent.com/1031227/170788841-4ec85878-f64a-4d7d-9427-8d20c3888bb8.gif)

