### PR TITLE
Fix logic for deciding what are external packages

### DIFF
--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -24,6 +24,7 @@ interface PackageJson {
   name: string;
   main: string;
   cadlMain?: string;
+  peerDependencies: string[];
   dependencies: string[];
 }
 
@@ -113,7 +114,9 @@ async function createRollupConfig(libraryPath: string): Promise<RollupOptions> {
     ],
     shimMissingExports: true,
     external: (id) => {
-      return !!id.match(/^@cadl-lang\/[a-z-]+$/);
+      return (
+        !!id.match(/^@cadl-lang\/[a-z-]+$/) || (pkg.peerDependencies && id in pkg.peerDependencies)
+      );
     },
     onwarn: (warning, warn) => {
       if (warning.code === "THIS_IS_UNDEFINED" || warning.code === "CIRCULAR_DEPENDENCY") {


### PR DESCRIPTION
Was previously only excluding `@cadl-lang/` packages which was causing issue in the cadl-azure playground. 
Any peerDependency should probably be excluded and bundled as well. We might need a dedicated config later to say which are the packages you want external but for now that seems like it cover all the cases we have