### PR TITLE
Various playground fixes around compiler mismatch version and add deprecated tag support

### DIFF
--- a/packages/playground/src/app.tsx
+++ b/packages/playground/src/app.tsx
@@ -1,25 +1,22 @@
-import {
-  compile,
-  DiagnosticTarget,
-  getSourceLocation,
-  NoTarget,
-  Program,
-} from "@cadl-lang/compiler";
+import { DiagnosticTarget, getSourceLocation, NoTarget, Program } from "@cadl-lang/compiler";
 import { CadlProgramViewer } from "@cadl-lang/html-program-viewer";
 import debounce from "debounce";
 import lzutf8 from "lzutf8";
 import { editor, KeyCode, KeyMod, MarkerSeverity, Uri } from "monaco-editor";
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from "react";
+import { CompletionItemTag } from "vscode-languageserver";
 import { createBrowserHost } from "./browserHost";
 import { CadlEditor, OutputEditor } from "./components/cadl-editor";
 import { useMonacoModel } from "./components/editor";
 import { Footer } from "./components/footer";
 import { OutputTabs, Tab } from "./components/output-tabs";
 import { SamplesDropdown } from "./components/samples-dropdown";
+import { importCadlCompiler } from "./core";
 import { PlaygroundManifest } from "./manifest";
 import { attachServices } from "./services";
+
 const host = await createBrowserHost();
-attachServices(host);
+await attachServices(host);
 
 export const App: FunctionComponent = () => {
   const cadlModel = useMonacoModel("inmemory://test/main.cadl", "cadl");
@@ -80,6 +77,7 @@ export const App: FunctionComponent = () => {
   async function doCompile(content: string) {
     await host.writeFile("main.cadl", content);
     await emptyOutputDir();
+    const { compile } = await importCadlCompiler();
     const program = await compile("main.cadl", host, {
       outputPath: "cadl-output",
       swaggerOutputFile: "cadl-output/openapi.json",
@@ -89,7 +87,8 @@ export const App: FunctionComponent = () => {
     const markers: editor.IMarkerData[] = program.diagnostics.map((diag) => ({
       ...getMarkerLocation(diag.target),
       message: diag.message,
-      severity: MarkerSeverity.Error,
+      severity: diag.severity === "error" ? MarkerSeverity.Error : MarkerSeverity.Warning,
+      tags: diag.code === "deprecated" ? [CompletionItemTag.Deprecated] : undefined,
     }));
 
     editor.setModelMarkers(cadlModel, "owner", markers ?? []);
@@ -221,6 +220,4 @@ export const OutputView: FunctionComponent<OutputViewProps> = (props) => {
   );
 };
 
-type ViewSelection =
-  | { type: "file"; filename: string; content: string }
-  | { type: "type-graph" };
+type ViewSelection = { type: "file"; filename: string; content: string } | { type: "type-graph" };

--- a/packages/playground/src/core.ts
+++ b/packages/playground/src/core.ts
@@ -1,0 +1,5 @@
+export async function importCadlCompiler(): Promise<typeof import("@cadl-lang/compiler")> {
+  // We need to do this so the compiler loaded is the same as the one loaded by the bundled libraries.
+  const name = "@cadl-lang/compiler";
+  return import(/* @vite-ignore */ name) as any;
+}

--- a/packages/playground/src/services.ts
+++ b/packages/playground/src/services.ts
@@ -1,7 +1,6 @@
 import {
   CadlLanguageConfiguration,
   createScanner,
-  createServer,
   createSourceFile,
   ServerHost,
   Token,
@@ -10,9 +9,10 @@ import * as monaco from "monaco-editor";
 import * as lsp from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { BrowserHost } from "./browserHost";
+import { importCadlCompiler } from "./core";
 import "./style.css";
 
-export function attachServices(host: BrowserHost) {
+export async function attachServices(host: BrowserHost) {
   monaco.languages.register({ id: "cadl" });
   monaco.languages.setLanguageConfiguration("cadl", CadlLanguageConfiguration as any);
 
@@ -27,6 +27,7 @@ export function attachServices(host: BrowserHost) {
     log: console.log,
   };
 
+  const { createServer } = await importCadlCompiler();
   const serverLib = createServer(serverHost);
   const lsConfig = serverLib.initialize({
     capabilities: {},
@@ -148,6 +149,7 @@ export function attachServices(host: BrowserHost) {
           range,
           commitCharacters:
             item.commitCharacters ?? lsConfig.capabilities.completionProvider!.allCommitCharacters,
+          tags: item.tags,
         });
       }
 


### PR DESCRIPTION
Example showing up deprecated as a warning not an error as well as strikethrough in completion
 https://cadlplayground.z22.web.core.windows.net/prs/574/?c=QGRlcHJlY2F0ZWQoImZvbyIpDQptb2RlbCBCYXIgew0KICBuYW1lOiBzdHJpbmc7DQp9DQoNCm9wIHRlc3QoKTrEKDs%3D