### PR TITLE
Better decorator param validation

### DIFF
--- a/common/changes/@cadl-lang/compiler/decorator-param-validation_2022-06-03-23-18.json
+++ b/common/changes/@cadl-lang/compiler/decorator-param-validation_2022-06-03-23-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Added new decorator signatgure validation helper",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/rest/decorator-param-validation_2022-06-03-23-18.json
+++ b/common/changes/@cadl-lang/rest/decorator-param-validation_2022-06-03-23-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Uptake changes to compiler with decorator validator helpers",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/compiler/core/decorator-utils.ts
+++ b/packages/compiler/core/decorator-utils.ts
@@ -207,8 +207,6 @@ export function createDecoratorDefinition<
           return false;
         }
       } else if (!isCadlValueTypeOf(arg, paramDefinition.kind)) {
-        console.log("Report diagnostic", index, arg, context.getArgumentTarget(index));
-
         reportDiagnostic(context.program, {
           code: "invalid-argument",
           format: {

--- a/packages/compiler/core/decorator-utils.ts
+++ b/packages/compiler/core/decorator-utils.ts
@@ -115,34 +115,13 @@ function getTypeKind(target: CadlValue): Type["kind"] | undefined {
 }
 
 /**
- * Emit diagnostic if the number of arguments passed to decorator is more or less than the expected count.
- */
-export function validateDecoratorParamCount(
-  program: Program,
-  target: Type,
-  args: unknown[],
-  expected: number
-) {
-  if (args.length !== expected) {
-    reportDiagnostic(program, {
-      code: "invalid-argument-count",
-      format: {
-        actual: args.length.toString(),
-        expected: expected.toString(),
-      },
-      target,
-    });
-    return;
-  }
-}
-
-/**
  * Validate a decorator parameter has the correct type.
  * @param program Program
  * @param target Decorator target
  * @param value Value of the parameter.
  * @param expectedType Expected type or list of expected type
  * @returns true if the value is of one of the type in the list of expected types. If not emit a diagnostic.
+ * @deprecated use @see createDecoratorDefinition#validate instead.
  */
 export function validateDecoratorParamType<K extends Type["kind"]>(
   program: Program,
@@ -160,6 +139,131 @@ export function validateDecoratorParamType<K extends Type["kind"]>(
       },
       target,
     });
+    return false;
+  }
+  return true;
+}
+
+export interface DecoratorDefinition<
+  T extends Type["kind"],
+  P extends readonly DecoratorParamDefinition<any>[]
+> {
+  readonly name: string;
+  readonly target: T | T[];
+  readonly args: P;
+}
+
+export interface DecoratorParamDefinition<K extends Type["kind"]> {
+  readonly kind: K | K[];
+  readonly optional?: boolean;
+}
+
+type InferParameters<P extends readonly DecoratorParamDefinition<any>[]> = {
+  [K in keyof P]: InferParameter<P[K]>;
+};
+type InferParameter<P extends DecoratorParamDefinition<any>> = P["optional"] extends true
+  ? InferredCadlValue<P["kind"]> | undefined
+  : InferredCadlValue<P["kind"]>;
+
+export interface DecoratorValidator<
+  T extends Type["kind"],
+  P extends readonly DecoratorParamDefinition<any>[]
+> {
+  validate(
+    context: DecoratorContext,
+    target: InferredCadlValue<T>,
+    parameters: InferParameters<P>
+  ): boolean;
+}
+
+export function createDecoratorDefinition<
+  T extends Type["kind"],
+  P extends readonly DecoratorParamDefinition<any>[]
+>(definition: DecoratorDefinition<T, P>): DecoratorValidator<T, P> {
+  const minParams = definition.args.filter((x) => !x.optional).length;
+  const maxParams = definition.args.length;
+
+  function validate(context: DecoratorContext, target: Type, args: CadlValue[]) {
+    if (
+      !validateDecoratorTarget(context, target, definition.name, definition.target) ||
+      !validateDecoratorParamCount(context, minParams, maxParams, args)
+    ) {
+      return false;
+    }
+
+    for (const [index, arg] of args.entries()) {
+      const paramDefinition = definition.args[index];
+      if (arg === undefined) {
+        if (!paramDefinition.optional) {
+          reportDiagnostic(context.program, {
+            code: "invalid-argument",
+            format: {
+              value: "undefined",
+              actual: "undefined",
+              expected: expectedTypeList(paramDefinition.kind),
+            },
+            target: context.getArgumentTarget(index)!,
+          });
+          return false;
+        }
+      } else if (!isCadlValueTypeOf(arg, paramDefinition.kind)) {
+        console.log("Report diagnostic", index, arg, context.getArgumentTarget(index));
+
+        reportDiagnostic(context.program, {
+          code: "invalid-argument",
+          format: {
+            value: prettyValue(context.program, arg),
+            actual: getTypeKind(arg)!,
+            expected: expectedTypeList(paramDefinition.kind),
+          },
+          target: context.getArgumentTarget(index)!,
+        });
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  return {
+    validate(context: DecoratorContext, target, parameters) {
+      return validate(context, target as any, parameters as any);
+    },
+  };
+}
+
+function expectedTypeList(expectedType: Type["kind"] | Type["kind"][]) {
+  return typeof expectedType === "string" ? expectedType : expectedType.join(", ");
+}
+
+export function validateDecoratorParamCount(
+  context: DecoratorContext,
+  min: number,
+  max: number,
+  parameters: unknown[]
+): boolean {
+  if (parameters.length < min || parameters.length > max) {
+    if (min === max) {
+      reportDiagnostic(context.program, {
+        code: "invalid-argument-count",
+        format: {
+          actual: parameters.length.toString(),
+          expected: min.toString(),
+        },
+        target: context.decoratorTarget,
+      });
+    } else {
+      reportDiagnostic(context.program, {
+        code: "invalid-argument-count",
+        messageId: "between",
+        format: {
+          actual: parameters.length.toString(),
+          min: min.toString(),
+          max: max.toString(),
+        },
+        target: context.decoratorTarget,
+      });
+    }
     return false;
   }
   return true;

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -459,6 +459,7 @@ const diagnostics = {
     severity: "error",
     messages: {
       default: paramMessage`Expected ${"expected"} arguments, but got ${"actual"}.`,
+      between: paramMessage`Expected between ${"min"} and ${"max"} arguments, but got ${"actual"}.`,
     },
   },
   "known-values-invalid-enum": {

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -18,7 +18,7 @@ export interface DecoratorApplication {
 }
 
 export interface DecoratorFunction {
-  (program: DecoratorContext, target: Type, ...customArgs: any[]): void;
+  (program: DecoratorContext, target: any, ...customArgs: any[]): void;
   namespace?: string;
 }
 

--- a/packages/rest/src/http.ts
+++ b/packages/rest/src/http.ts
@@ -1,4 +1,5 @@
 import {
+  createDecoratorDefinition,
   DecoratorContext,
   ModelType,
   ModelTypeProperty,
@@ -11,13 +12,14 @@ import {
 } from "@cadl-lang/compiler";
 import { reportDiagnostic } from "./diagnostics.js";
 
+const headerDecorator = createDecoratorDefinition({
+  name: "@header",
+  target: "ModelProperty",
+  args: [{ kind: "String", optional: true }],
+} as const);
 const headerFieldsKey = Symbol("header");
-export function $header(context: DecoratorContext, entity: Type, headerName?: string) {
-  if (!validateDecoratorTarget(context, entity, "@header", "ModelProperty")) {
-    return;
-  }
-
-  if (headerName && !validateDecoratorParamType(context.program, entity, headerName, "String")) {
+export function $header(context: DecoratorContext, entity: ModelTypeProperty, headerName?: string) {
+  if (!headerDecorator.validate(context, entity, [headerName])) {
     return;
   }
 
@@ -122,13 +124,19 @@ export function $statusCode(context: DecoratorContext, entity: Type) {
           codes.push(String(option.value));
         }
       } else {
-        reportDiagnostic(context.program, { code: "status-code-invalid", target: entity });
+        reportDiagnostic(context.program, {
+          code: "status-code-invalid",
+          target: entity,
+        });
       }
     }
   } else if (entity.type.kind === "TemplateParameter") {
     // Ignore template parameters
   } else {
-    reportDiagnostic(context.program, { code: "status-code-invalid", target: entity });
+    reportDiagnostic(context.program, {
+      code: "status-code-invalid",
+      target: entity,
+    });
   }
   setStatusCode(context.program, entity, codes);
 }
@@ -241,38 +249,38 @@ export function getOperationVerb(program: Program, entity: Type): HttpVerb | und
 }
 
 export function $get(context: DecoratorContext, entity: Type, ...args: unknown[]) {
-  validateVerbNoArgs(context.program, entity, args);
+  validateVerbNoArgs(context, args);
   setOperationVerb(context.program, entity, "get");
 }
 
 export function $put(context: DecoratorContext, entity: Type, ...args: unknown[]) {
-  validateVerbNoArgs(context.program, entity, args);
+  validateVerbNoArgs(context, args);
   setOperationVerb(context.program, entity, "put");
 }
 
 export function $post(context: DecoratorContext, entity: Type, ...args: unknown[]) {
-  validateVerbNoArgs(context.program, entity, args);
+  validateVerbNoArgs(context, args);
   setOperationVerb(context.program, entity, "post");
 }
 
 export function $patch(context: DecoratorContext, entity: Type, ...args: unknown[]) {
-  validateVerbNoArgs(context.program, entity, args);
+  validateVerbNoArgs(context, args);
   setOperationVerb(context.program, entity, "patch");
 }
 
 export function $delete(context: DecoratorContext, entity: Type, ...args: unknown[]) {
-  validateVerbNoArgs(context.program, entity, args);
+  validateVerbNoArgs(context, args);
   setOperationVerb(context.program, entity, "delete");
 }
 
 export function $head(context: DecoratorContext, entity: Type, ...args: unknown[]) {
-  validateVerbNoArgs(context.program, entity, args);
+  validateVerbNoArgs(context, args);
   setOperationVerb(context.program, entity, "head");
 }
 
 // TODO: replace with built-in decorator validation https://github.com/Azure/cadl-azure/issues/1022
-function validateVerbNoArgs(program: Program, target: Type, args: unknown[]) {
-  validateDecoratorParamCount(program, target, args, 0);
+function validateVerbNoArgs(context: DecoratorContext, args: unknown[]) {
+  validateDecoratorParamCount(context, 0, 0, args);
 }
 
 setDecoratorNamespace(


### PR DESCRIPTION
Created a new validator helper that provide a few upgrade to the current system:

- Make use of `context.getArgumentAt` to report the right target for an incorrect param
  ![image](https://user-images.githubusercontent.com/1031227/171965499-d132b040-51c7-4a36-925a-fd4f43f47c1c.png)
- Provide additional validation for optional params
- Provide validation for the number of params passed
- Make it that you should update the decorator signature types to be what you expect which will be what we'll want for the decorator signature proposal
  ```
  // Before to be type safe and then we used the validator assertion to guide the typing
  export function $foo(context: DecoratorContext, target: Type, arg1: CadlValue) {}

  // Now just define ahead of time which is incorrect without the validation but the validator typing makes sure it is in sync with the definition
  export function $foo(context: DecoratorContext, target: ModelType, arg1: string) {}
  ```

## Usage

```ts
// Step 1: define the decorator definition: This is pretty much what we had before but as individual function call
const headerDecorator = createDecoratorDefinition({
  name: "@header",
  target: "ModelProperty",
  args: [{ kind: "String", optional: true }],
} as const);

// Step 2: update decorator signature to be the types you want
  export function $header(context: DecoratorContext, entity: ModelTypeProperty, headerName?: string)

// Step 3: call validator
if (!headerDecorator.validate(context, entity, [headerName])) {
    return;
  }

```