### PR TITLE
Fix: Vscode language config was excluded from packaged extension

### DIFF
--- a/common/changes/cadl-vscode/fix-vscode-language-config_2022-06-06-22-33.json
+++ b/common/changes/cadl-vscode/fix-vscode-language-config_2022-06-06-22-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vscode",
+      "comment": "Resolve issue with `language-configuration.json` being excluded from extension",
+      "type": "patch"
+    }
+  ],
+  "packageName": "cadl-vscode"
+}

--- a/packages/cadl-vscode/.vscodeignore
+++ b/packages/cadl-vscode/.vscodeignore
@@ -8,8 +8,8 @@
 !dist/**/*.tmLanguage
 !dist/**/*.js
 !dist/**/*.js.map
+!dist/**/language-configuration.json
 !extension-shim.js
-!language-configuration.json
 !markdown-cadl.json
 !README.md
 !ThirdPartyNotices.txt


### PR DESCRIPTION
This means all the out of box functionality provided by the language-configuration(toggle comment, auto close bracket, bracket matching, etc.) was not working unless using the debugger.