### PR TITLE
Allow `using` before blockless `namespace`

### DIFF
--- a/common/changes/@cadl-lang/compiler/using-before-blockless-namespace_2022-06-07-17-04.json
+++ b/common/changes/@cadl-lang/compiler/using-before-blockless-namespace_2022-06-07-17-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Allow `using` before blockless `namespace`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -287,6 +287,7 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
     const stmts: Statement[] = [];
     let seenBlocklessNs = false;
     let seenDecl = false;
+    let seenUsing = false;
     while (token() !== Token.EndOfFile) {
       const pos = tokenPos();
       const directives = parseDirectiveList();
@@ -348,9 +349,11 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
         }
         seenBlocklessNs = true;
       } else if (item.kind === SyntaxKind.ImportStatement) {
-        if (seenDecl || seenBlocklessNs) {
+        if (seenDecl || seenBlocklessNs || seenUsing) {
           error({ code: "import-first" });
         }
+      } else if (item.kind === SyntaxKind.UsingStatement) {
+        seenUsing = true;
       } else {
         seenDecl = true;
       }

--- a/packages/compiler/test/test-parser.ts
+++ b/packages/compiler/test/test-parser.ts
@@ -12,6 +12,7 @@ describe("compiler: syntax", () => {
       ['namespace Foo { import "x"; }', [/Imports must be top-level/]],
       ['namespace Foo { } import "x";', [/Imports must come prior/]],
       ['model Foo { } import "x";', [/Imports must come prior/]],
+      ['using Bar; import "x";', [/Imports must come prior/]],
     ]);
   });
 
@@ -224,7 +225,13 @@ describe("compiler: syntax", () => {
   });
 
   describe("using statements", () => {
-    parseEach(["using A;", "using A.B;", "namespace Foo { using A; }"]);
+    parseEach([
+      "using A;",
+      "using A.B;",
+      "namespace Foo { using A; }",
+      // Allow using before blockless namespace
+      "using A.B; namespace Foo;",
+    ]);
   });
 
   describe("multiple statements", () => {

--- a/packages/samples/petstore/petstore.cadl
+++ b/packages/samples/petstore/petstore.cadl
@@ -2,12 +2,12 @@ import "@cadl-lang/rest";
 import "@cadl-lang/openapi";
 import "./decorators.js";
 
+using Cadl.Http;
+
 @serviceTitle("Pet Store Service")
 @serviceVersion("2021-03-25")
 @doc("This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.")
 namespace PetStore;
-
-using Cadl.Http;
 
 // Model types
 model Pet {


### PR DESCRIPTION
fix [#1320](https://github.com/Azure/cadl-azure/issues/1320) as part of #337

Allow having 
```
import "@cadl-lang/rest";

using Cadl.Http;

namespace MyService;
```

instead of 
```
import "@cadl-lang/rest";

namespace MyService;

using Cadl.Http;
```

https://cadlplayground.z22.web.core.windows.net/prs/590/?c=aW1wb3J0ICJAY2FkbC1sYW5nL3Jlc3QiOwoKdXNpbmcgQ2FkbC5IdHRwOwoKQHNlcnZpY2VUaXRsZSgiV2lkZ2V0IFPGFSIpCm5hbWVzcGFjZSBEZW1vxxg7CgoKbW9kZWwgxzB7CiAgQGtleSBpZDogc3RyaW5nOwogIHdlaWdodDogaW50MzLEEWNvbG9yOiAicmVkIiB8ICJibHVlIjsKfQoKQGVycm9yx1ZFxAzFVWNvZGXLQG1lc3NhZ2XKZH0KCmludGVyZuQAouYAjecApMU%2FQOQAnWxpc3QoKTrHH1tdIHzGYcRRQHJvdXRlKCJ3xRxzL3tpZH0iKcY4cmVhZChAcGF0aOsA18lIzUZwb3N0IGNyZWF0ZShAYm9keSDEBcgr1jTHemN1c3RvbUdldMh3yRHqALTKOH0K