### PR TITLE
Fix completion between `.` and `)`

### DIFF
--- a/common/changes/@cadl-lang/compiler/complete-before-paren_2022-06-07-19-22.json
+++ b/common/changes/@cadl-lang/compiler/complete-before-paren_2022-06-07-19-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix completion between `.` and `)`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -334,7 +334,7 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
           item = parseEmptyStatement();
           break;
         default:
-          item = parseInvalidStatement(decorators);
+          item = parseInvalidStatement(pos, decorators);
           break;
       }
 
@@ -423,7 +423,7 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
           item = parseEmptyStatement();
           break;
         default:
-          item = parseInvalidStatement(decorators);
+          item = parseInvalidStatement(pos, decorators);
           break;
       }
       item.directives = directives;
@@ -1995,12 +1995,14 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
     return { kind: SyntaxKind.EmptyStatement, ...finishNode(pos) };
   }
 
-  function parseInvalidStatement(decorators: DecoratorExpressionNode[]): InvalidStatementNode {
+  function parseInvalidStatement(
+    pos: number,
+    decorators: DecoratorExpressionNode[]
+  ): InvalidStatementNode {
     // Error recovery: avoid an avalanche of errors when we get cornered into
     // parsing statements where none exist. Skip until we find a statement
     // keyword or decorator and only report one error for a contiguous range of
     // neither.
-    const pos = tokenPos();
     do {
       nextToken();
     } while (

--- a/packages/compiler/test/server/completion.ts
+++ b/packages/compiler/test/server/completion.ts
@@ -239,7 +239,7 @@ describe("compiler: server: completion", () => {
        namespace N {
         op test(): void;
        }
-       @dec(N.┆
+       @dec(N.┆)
       `
     );
 

--- a/packages/compiler/test/test-parser.ts
+++ b/packages/compiler/test/test-parser.ts
@@ -596,6 +596,10 @@ describe("compiler: syntax", () => {
       ]);
     });
   });
+
+  describe("invalid statement", () => {
+    parseErrorEach([["@dec(N.)", [/Identifier expected/]]]);
+  });
 });
 
 type Callback = (node: CadlScriptNode) => void;
@@ -744,7 +748,7 @@ function parseErrorEach(
   }
 }
 
-function dumpAST(astNode: Node, file?: SourceFile) {
+export function dumpAST(astNode: Node, file?: SourceFile) {
   if (!file && astNode.kind === SyntaxKind.CadlScript) {
     file = astNode.file;
   }


### PR DESCRIPTION
Fix #584 Turns out this was limited to the case of a decorated invalid statement, which commonly happens when you type a decorator before you type the statement it will apply to. The <= end problem theorized on the bug was not the issue.

We were not using the correct position for the invalid statement. It should start where its decorators start.