### PR TITLE
Remove duplicate server state for tracking file types

### DIFF
--- a/common/changes/@cadl-lang/compiler/no-additional-open-doc-state_2022-06-10-15-41.json
+++ b/common/changes/@cadl-lang/compiler/no-additional-open-doc-state_2022-06-10-15-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Improve tracking of open documents in language server",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/server/server.ts
+++ b/packages/compiler/server/server.ts
@@ -38,7 +38,7 @@ function main() {
     log(message: string) {
       connection.console.log(message);
     },
-    getDocumentByURL(url: string) {
+    getOpenDocumentByURL(url: string) {
       return documents.get(url);
     },
   };
@@ -72,7 +72,6 @@ function main() {
   connection.onPrepareRename(s.prepareRename);
   documents.onDidChangeContent(s.checkChange);
   documents.onDidClose(s.documentClosed);
-  documents.onDidOpen(s.documentOpen);
 
   documents.listen(connection);
   connection.listen();

--- a/packages/compiler/test/server/test-server-host.ts
+++ b/packages/compiler/test/server/test-server-host.ts
@@ -15,7 +15,7 @@ import {
 export interface TestServerHost extends ServerHost, TestFileSystem {
   server: Server;
   logMessages: readonly string[];
-  getDocument(path: string): TextDocument | undefined;
+  getOpenDocument(path: string): TextDocument | undefined;
   addOrUpdateDocument(path: string, content: string): TextDocument;
   getDiagnostics(path: string): readonly Diagnostic[];
   getURL(path: string): string;
@@ -34,11 +34,11 @@ export async function createTestServerHost(): Promise<TestServerHost> {
     ...fileSystem,
     server: undefined!, // initialized later due to cycle
     logMessages,
-    getDocumentByURL(url) {
+    getOpenDocumentByURL(url) {
       return documents.get(url);
     },
-    getDocument(path: string) {
-      return this.getDocumentByURL(this.getURL(path));
+    getOpenDocument(path: string) {
+      return this.getOpenDocumentByURL(this.getURL(path));
     },
     addOrUpdateDocument(path: string, content: string) {
       const url = this.getURL(path);

--- a/packages/playground/src/services.ts
+++ b/packages/playground/src/services.ts
@@ -18,7 +18,7 @@ export async function attachServices(host: BrowserHost) {
 
   const serverHost: ServerHost = {
     compilerHost: host,
-    getDocumentByURL(url: string) {
+    getOpenDocumentByURL(url: string) {
       const model = monaco.editor.getModel(monaco.Uri.parse(url));
       return model ? textDocumentForModel(model) : undefined;
     },


### PR DESCRIPTION
The separate state could get out of sync with the host state, for example, our test host server host wasn't sending documentOpen, which caused this.

Rather than fix that and retain future risk of getting out-of-sync a different way, eliminate the additional state by changing getSourceFileKind to look for open documents via the same existing host mechanism: `host.getDocumentByURL`, which is also renamed here to `getOpenDocumentByURL` for clarity about its purpose. Also, move the implementation of getSourceFileKind in serverlib closer to the other host method overrides that have special handling of open documents so that the pattern is clear.

(Also, sorry, it had been a while since I had to deal with open-document tracking and I neglected to spot this when I reviewed the fix that introduced getSourceFileKind.)