### PR TITLE
Enforce the library linter and fix libraries exporting without namespace

### DIFF
--- a/common/changes/@cadl-lang/compiler/namespace-cleanup_2022-06-13-16-03.json
+++ b/common/changes/@cadl-lang/compiler/namespace-cleanup_2022-06-13-16-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Rename `setDecoratorNamespace` -> `setCadlNamespace`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi/namespace-cleanup_2022-06-13-16-03.json
+++ b/common/changes/@cadl-lang/openapi/namespace-cleanup_2022-06-13-16-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/openapi3/namespace-cleanup_2022-06-13-16-03.json
+++ b/common/changes/@cadl-lang/openapi3/namespace-cleanup_2022-06-13-16-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/namespace-cleanup_2022-06-13-16-03.json
+++ b/common/changes/@cadl-lang/rest/namespace-cleanup_2022-06-13-16-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Fix decorator and functions not belonging to a namespace",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/versioning/namespace-cleanup_2022-06-13-16-03.json
+++ b/common/changes/@cadl-lang/versioning/namespace-cleanup_2022-06-13-16-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "Moved all decorators and functions to `Cadl.Versioning` namespace",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -1,6 +1,7 @@
 import {
   createProgram,
   getNormalizedAbsolutePath,
+  joinPaths,
   NodeHost,
   normalizePath,
 } from "@cadl-lang/compiler";
@@ -9,14 +10,32 @@ import json from "@rollup/plugin-json";
 import nodeResolve from "@rollup/plugin-node-resolve";
 import virtual from "@rollup/plugin-virtual";
 import { mkdir, readFile, realpath, writeFile } from "fs/promises";
-import { dirname, join, resolve } from "path";
-import { rollup, RollupBuild, RollupOptions, watch } from "rollup";
+import { basename, join, resolve } from "path";
+import { OutputChunk, rollup, RollupBuild, RollupOptions, watch } from "rollup";
 import { relativeTo } from "./utils.js";
+
+export interface CadlBundleDefinition {
+  path: string;
+  main: string;
+  packageJson: PackageJson;
+  exports: Record<string, string>;
+}
 
 export interface CadlBundle {
   /**
+   * Definition
+   */
+  definition: CadlBundleDefinition;
+
+  /**
    * Bundle content
    */
+  files: CadlBundleFile[];
+}
+
+export interface CadlBundleFile {
+  export?: string;
+  filename: string;
   content: string;
 }
 
@@ -26,21 +45,24 @@ interface PackageJson {
   cadlMain?: string;
   peerDependencies: string[];
   dependencies: string[];
+  exports?: Record<string, string>;
 }
 
 export async function createCadlBundle(libraryPath: string): Promise<CadlBundle> {
-  const rollupOptions = await createRollupConfig(libraryPath);
+  const definition = await resolveCadlBundleDefinition(libraryPath);
+  const rollupOptions = await createRollupConfig(definition);
   const bundle = await rollup(rollupOptions);
 
   try {
-    return generateCadlBundle(bundle);
+    return generateCadlBundle(definition, bundle);
   } finally {
     await bundle.close();
   }
 }
 
 export async function watchCadlBundle(libraryPath: string, onBundle: (bundle: CadlBundle) => void) {
-  const rollupOptions = await createRollupConfig(libraryPath);
+  const definition = await resolveCadlBundleDefinition(libraryPath);
+  const rollupOptions = await createRollupConfig(definition);
   const watcher = watch({
     ...rollupOptions,
     watch: {
@@ -55,31 +77,52 @@ export async function watchCadlBundle(libraryPath: string, onBundle: (bundle: Ca
         break;
       case "BUNDLE_END":
         try {
-          const cadlBundle = await generateCadlBundle(event.result);
+          const cadlBundle = await generateCadlBundle(definition, event.result);
           onBundle(cadlBundle);
         } finally {
           await event.result.close();
         }
         break;
       case "ERROR":
+        // eslint-disable-next-line no-console
+        console.error("Error bundling", event.error);
         await event.result?.close();
     }
   });
 }
 
-export async function bundleCadlLibrary(libraryPath: string, outputFile: string) {
+export async function bundleCadlLibrary(libraryPath: string, outputDir: string) {
   const bundle = await createCadlBundle(libraryPath);
-  await mkdir(dirname(outputFile), { recursive: true });
-  await writeFile(outputFile, bundle.content);
+  await mkdir(outputDir, { recursive: true });
+  for (const file of bundle.files) {
+    await writeFile(joinPaths(outputDir, file.filename), file.content);
+  }
 }
 
-async function createRollupConfig(libraryPath: string): Promise<RollupOptions> {
+async function resolveCadlBundleDefinition(libraryPath: string): Promise<CadlBundleDefinition> {
   libraryPath = normalizePath(await realpath(libraryPath));
+  const pkg = await readLibraryPackageJson(libraryPath);
+
+  const exports = pkg.exports
+    ? Object.fromEntries(
+        Object.entries(pkg.exports).filter(([k, v]) => k !== "." && k !== "./testing")
+      )
+    : {};
+
+  return {
+    path: libraryPath,
+    main: pkg.main,
+    exports,
+    packageJson: pkg,
+  };
+}
+
+async function createRollupConfig(definition: CadlBundleDefinition): Promise<RollupOptions> {
+  const libraryPath = definition.path;
   const program = await createProgram(NodeHost, libraryPath, {
     nostdlib: true,
     noEmit: true,
   });
-  const pkg = await readLibraryPackageJson(libraryPath);
   const jsFiles: string[] = [];
   for (const file of program.jsSourceFiles.keys()) {
     if (file.startsWith(libraryPath)) {
@@ -87,20 +130,28 @@ async function createRollupConfig(libraryPath: string): Promise<RollupOptions> {
     }
   }
   const cadlFiles: Record<string, string> = {
-    [normalizePath(join(libraryPath, "package.json"))]: JSON.stringify(pkg),
+    [normalizePath(join(libraryPath, "package.json"))]: JSON.stringify(definition.packageJson),
   };
   for (const [filename, sourceFile] of program.sourceFiles) {
     cadlFiles[filename] = sourceFile.file.text;
   }
   const content = createBundleEntrypoint({
     libraryPath,
-    mainFile: pkg.main,
+    mainFile: definition.main,
     jsSourceFileNames: jsFiles,
     cadlSourceFiles: cadlFiles,
   });
 
+  const extraEntry = Object.fromEntries(
+    Object.entries(definition.exports).map(([key, value]) => {
+      return [key.replace("./", ""), normalizePath(resolve(libraryPath, value))];
+    })
+  );
   return {
-    input: ["entry.js"],
+    input: {
+      index: "entry.js",
+      ...extraEntry,
+    },
     output: {
       esModule: true,
     },
@@ -115,7 +166,9 @@ async function createRollupConfig(libraryPath: string): Promise<RollupOptions> {
     shimMissingExports: true,
     external: (id) => {
       return (
-        !!id.match(/^@cadl-lang\/[a-z-]+$/) || (pkg.peerDependencies && id in pkg.peerDependencies)
+        !!id.match(/^@cadl-lang\/[a-z-]+$/) ||
+        (definition.packageJson.peerDependencies &&
+          !!Object.keys(definition.packageJson.peerDependencies).find((x) => id.startsWith(x)))
       );
     },
     onwarn: (warning, warn) => {
@@ -127,13 +180,25 @@ async function createRollupConfig(libraryPath: string): Promise<RollupOptions> {
   };
 }
 
-async function generateCadlBundle(bundle: RollupBuild): Promise<CadlBundle> {
+async function generateCadlBundle(
+  definition: CadlBundleDefinition,
+  bundle: RollupBuild
+): Promise<CadlBundle> {
   const { output } = await bundle.generate({
-    file: "lib.js",
+    dir: "virtual",
   });
 
   return {
-    content: output[0].code,
+    definition,
+    files: output
+      .filter((x): x is OutputChunk => "code" in x)
+      .map((chunk) => {
+        return {
+          filename: chunk.fileName,
+          content: chunk.code,
+          export: definition.exports[basename(chunk.fileName)],
+        };
+      }),
   };
 }
 

--- a/packages/bundler/src/cli.ts
+++ b/packages/bundler/src/cli.ts
@@ -6,7 +6,7 @@ import { bundleCadlLibrary } from "./bundler.js";
 
 const name = process.argv[2];
 const libraryPath = resolve(`../${name}`);
-bundleCadlLibrary(libraryPath, resolve(process.cwd(), "output/output.js")).catch((e) => {
+bundleCadlLibrary(libraryPath, resolve(process.cwd(), "output")).catch((e) => {
   // eslint-disable-next-line no-console
   console.error(e);
   process.exit(1);

--- a/packages/bundler/src/vite-plugin.ts
+++ b/packages/bundler/src/vite-plugin.ts
@@ -1,6 +1,7 @@
+import { resolvePath } from "@cadl-lang/compiler";
 import { resolve } from "path";
 import type { IndexHtmlTransformContext, Plugin, ResolvedConfig } from "vite";
-import { CadlBundle, createCadlBundle, watchCadlBundle } from "./bundler.js";
+import { CadlBundle, CadlBundleDefinition, createCadlBundle, watchCadlBundle } from "./bundler.js";
 
 export interface CadlBundlePluginOptions {
   folderName: string;
@@ -13,15 +14,7 @@ export interface CadlBundlePluginOptions {
 
 export function cadlBundlePlugin(options: CadlBundlePluginOptions): Plugin {
   let config: ResolvedConfig;
-  const imports: Record<string, string> = {};
-  for (const library of options.libraries) {
-    imports[library] = `./${options.folderName}/${library}.js`;
-  }
-  const importMap = {
-    imports: imports,
-    thisone: true,
-  };
-
+  const definitions: Record<string, CadlBundleDefinition> = {};
   return {
     name: "cadl-bundle",
     enforce: "pre",
@@ -33,6 +26,7 @@ export function cadlBundlePlugin(options: CadlBundlePluginOptions): Plugin {
       for (const library of options.libraries) {
         await watchBundleLibrary(config.root, library, (bundle) => {
           bundles[library] = bundle;
+          definitions[library] = bundle.definition;
           server.ws.send({ type: "full-reload" });
         });
       }
@@ -44,13 +38,36 @@ export function cadlBundlePlugin(options: CadlBundlePluginOptions): Plugin {
           return;
         }
         const start = `/${options.folderName}/`;
+
+        const resolveFilename = (path: string) => {
+          if (path === "") {
+            return "index.js";
+          } else {
+            return `${path}.js`;
+          }
+        };
+        const findPkgName = (id: string): [string, string] | undefined => {
+          const segments = id.slice(start.length, -".js".length).split("/");
+          if (bundles[segments[0]]) {
+            return [segments[0], resolveFilename(segments.slice(1).join("/"))];
+          }
+          const inFolder = segments[0] + "/" + segments[1];
+          if (bundles[inFolder]) {
+            return [inFolder, resolveFilename(segments.slice(2).join("/"))];
+          }
+          return undefined;
+        };
         if (id.startsWith(start) && id.endsWith(".js")) {
-          const pkgId = id.slice(start.length, -".js".length);
-          if (bundles[pkgId]) {
-            res.writeHead(200, "Ok", { "Content-Type": "application/javascript" });
-            res.write(bundles[pkgId].content);
-            res.end();
-            return;
+          const found = findPkgName(id);
+          if (found) {
+            const [pkgId, path] = found;
+            const file = bundles[pkgId].files.find((x) => x.filename === path);
+            if (file) {
+              res.writeHead(200, "Ok", { "Content-Type": "application/javascript" });
+              res.write(file.content);
+              res.end();
+              return;
+            }
           }
         }
         next();
@@ -60,11 +77,15 @@ export function cadlBundlePlugin(options: CadlBundlePluginOptions): Plugin {
     async generateBundle() {
       for (const name of options.libraries) {
         const bundle = await bundleLibrary(config.root, name);
-        this.emitFile({
-          type: "asset",
-          fileName: `${options.folderName}/${name}.js`,
-          source: bundle.content,
-        });
+        definitions[name] = bundle.definition;
+
+        for (const file of bundle.files) {
+          this.emitFile({
+            type: "asset",
+            fileName: `${options.folderName}/${name}/${file.filename}`,
+            source: file.content,
+          });
+        }
       }
     },
 
@@ -73,7 +94,7 @@ export function cadlBundlePlugin(options: CadlBundlePluginOptions): Plugin {
       transform: (html: string, ctx: IndexHtmlTransformContext) => {
         // Inject the importmap before the html script. Cannot just use injectTo:head-prepend as vite will inject its own script before that and cause a failure.
         const importMapTag = `<script type="importmap">\n${JSON.stringify(
-          importMap,
+          createImportMap(options.folderName, definitions),
           null,
           2
         )}\n</script>`;
@@ -83,6 +104,20 @@ export function cadlBundlePlugin(options: CadlBundlePluginOptions): Plugin {
   };
 }
 
+function createImportMap(folderName: string, definitions: Record<string, CadlBundleDefinition>) {
+  const imports: Record<string, string> = {};
+  for (const [library, definition] of Object.entries(definitions)) {
+    imports[library] = `./${folderName}/${library}/index.js`;
+    for (const name of Object.keys(definition.exports)) {
+      imports[library + "/http"] = "./" + resolvePath(`./${folderName}/${library}`, name) + ".js";
+    }
+  }
+  const importMap = {
+    imports: imports,
+  };
+
+  return importMap;
+}
 async function bundleLibrary(projectRoot: string, name: string) {
   return await createCadlBundle(resolve(projectRoot, "node_modules", name));
 }

--- a/packages/compiler/core/library.ts
+++ b/packages/compiler/core/library.ts
@@ -1,11 +1,5 @@
 import { createDiagnosticCreator } from "./diagnostics.js";
-import {
-  CadlLibrary,
-  CadlLibraryDef,
-  CallableMessage,
-  DecoratorFunction,
-  DiagnosticMessages,
-} from "./types.js";
+import { CadlLibrary, CadlLibraryDef, CallableMessage, DiagnosticMessages } from "./types.js";
 
 /**
  * Create a new Cadl library definition.
@@ -52,6 +46,14 @@ export function paramMessage<T extends string[]>(
   return template;
 }
 
-export function setDecoratorNamespace(namespace: string, ...decorators: DecoratorFunction[]): void {
-  decorators.forEach((c: any) => (c.namespace = namespace));
+/**
+ * Set the Cadl namespace for that function.
+ * @param namespace Namespace string (e.g. "Foo.Bar")
+ * @param functions Functions
+ */
+export function setCadlNamespace(
+  namespace: string,
+  ...functions: Array<(...args: any[]) => any>
+): void {
+  functions.forEach((c: any) => (c.namespace = namespace));
 }

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -40,7 +40,7 @@
     "clean": "rimraf ./dist ./temp",
     "build": "tsc -p . && npm run lint-cadl-library",
     "watch": "tsc -p . --watch",
-    "lint-cadl-library": "cadl compile . --warn-as-error --import @cadl-lang/library-linter",
+    "lint-cadl-library": "cadl compile . --warn-as-error --import @cadl-lang/library-linter --no-emit",
     "test": "mocha",
     "test-official": "c8 mocha --forbid-only",
     "lint": "eslint . --ext .ts --max-warnings=0",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -40,7 +40,7 @@
     "clean": "rimraf ./dist ./temp",
     "build": "tsc -p . && npm run lint-cadl-library",
     "watch": "tsc -p . --watch",
-    "lint-cadl-library": "cadl compile . --import @cadl-lang/library-linter",
+    "lint-cadl-library": "cadl compile . --warn-as-error --import @cadl-lang/library-linter",
     "test": "mocha",
     "test-official": "c8 mocha --forbid-only",
     "lint": "eslint . --ext .ts --max-warnings=0",

--- a/packages/openapi3/package.json
+++ b/packages/openapi3/package.json
@@ -40,7 +40,7 @@
     "clean": "rimraf ./dist ./temp",
     "build": "tsc -p . && npm run lint-cadl-library",
     "watch": "tsc -p . --watch",
-    "lint-cadl-library": "cadl compile . --warn-as-error --import @cadl-lang/library-linter",
+    "lint-cadl-library": "cadl compile . --warn-as-error --import @cadl-lang/library-linter --no-emit",
     "test": "mocha",
     "test-official": "c8 mocha --forbid-only",
     "lint": "eslint . --ext .ts --max-warnings=0",

--- a/packages/openapi3/package.json
+++ b/packages/openapi3/package.json
@@ -40,7 +40,7 @@
     "clean": "rimraf ./dist ./temp",
     "build": "tsc -p . && npm run lint-cadl-library",
     "watch": "tsc -p . --watch",
-    "lint-cadl-library": "cadl compile . --import @cadl-lang/library-linter",
+    "lint-cadl-library": "cadl compile . --warn-as-error --import @cadl-lang/library-linter",
     "test": "mocha",
     "test-official": "c8 mocha --forbid-only",
     "lint": "eslint . --ext .ts --max-warnings=0",

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -48,17 +48,18 @@ import {
   getTypeName,
   shouldInline,
 } from "@cadl-lang/openapi";
-import {
-  Discriminator,
-  getContentTypes,
-  getDiscriminator,
-  http,
-  HttpOperationResponse,
-} from "@cadl-lang/rest";
+import { Discriminator, getDiscriminator, http } from "@cadl-lang/rest";
 import {
   getAllRoutes,
+  getContentTypes,
+  getHeaderFieldName,
+  getPathParamName,
+  getQueryParamName,
+  getStatusCodeDescription,
   HttpOperationParameter,
   HttpOperationParameters,
+  HttpOperationResponse,
+  isStatusCode,
   OperationDetails,
 } from "@cadl-lang/rest/http";
 import { buildVersionProjections } from "@cadl-lang/versioning";
@@ -74,14 +75,6 @@ import {
   OpenAPI3Server,
   OpenAPI3ServerVariable,
 } from "./types.js";
-
-const {
-  getHeaderFieldName,
-  getPathParamName,
-  getQueryParamName,
-  isStatusCode,
-  getStatusCodeDescription,
-} = http;
 
 export async function $onEmit(p: Program, emitterOptions?: EmitOptionsFor<OpenAPILibrary>) {
   const options: OpenAPIEmitterOptions = {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -50,15 +50,17 @@ import {
 } from "@cadl-lang/openapi";
 import {
   Discriminator,
-  getAllRoutes,
   getContentTypes,
   getDiscriminator,
   http,
+  HttpOperationResponse,
+} from "@cadl-lang/rest";
+import {
+  getAllRoutes,
   HttpOperationParameter,
   HttpOperationParameters,
-  HttpOperationResponse,
   OperationDetails,
-} from "@cadl-lang/rest";
+} from "@cadl-lang/rest/http";
 import { buildVersionProjections } from "@cadl-lang/versioning";
 import { getOneOf, getRef } from "./decorators.js";
 import { OpenAPILibrary, reportDiagnostic } from "./lib.js";

--- a/packages/openapi3/test/test-host.ts
+++ b/packages/openapi3/test/test-host.ts
@@ -35,7 +35,7 @@ export async function openApiFor(code: string, versions?: string[]) {
   host.addCadlFile(
     "./main.cadl",
     `import "@cadl-lang/rest"; import "@cadl-lang/openapi"; import "@cadl-lang/openapi3"; ${
-      versions ? `import "@cadl-lang/versioning"; ` : ""
+      versions ? `import "@cadl-lang/versioning"; using Cadl.Versioning;` : ""
     }using Cadl.Rest;using Cadl.Http;using OpenAPI;${code}`
   );
   await host.compile("./main.cadl", {

--- a/packages/playground/e2e/playwright.config.ts
+++ b/packages/playground/e2e/playwright.config.ts
@@ -7,8 +7,6 @@ const root = resolve(__dirname, "..");
 
 const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
-  // Increase timeout from 30s => 120s due to issue https://github.com/microsoft/playwright/issues/14037
-  timeout: 120 * 1000,
   webServer: {
     command: "npm run watch",
     port: 3000,

--- a/packages/playground/samples/versioning.cadl
+++ b/packages/playground/samples/versioning.cadl
@@ -1,6 +1,8 @@
 import "@cadl-lang/rest";
 import "@cadl-lang/versioning";
 
+using Cadl.Versioning;
+
 @versioned(Versions)
 @serviceTitle("Widget Service")
 namespace DemoService;

--- a/packages/rest/lib/http.cadl
+++ b/packages/rest/lib/http.cadl
@@ -1,4 +1,4 @@
-import "../dist/src/http.js";
+import "../dist/src/http/index.js";
 
 namespace Cadl.Http;
 

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -33,8 +33,8 @@ model ResourceCollectionParameters<TResource> {
   ...ParentKeysOf<TResource>;
 }
 
-@validateHasKey(TResource)
-@validateIsError(TError)
+@Private.validateHasKey(TResource)
+@Private.validateIsError(TError)
 interface ResourceRead<TResource, TError> {
   @autoRoute
   @doc("Gets an instance of the resource.")
@@ -68,8 +68,8 @@ interface ResourceCreate<TResource, TError> {
   ): TResource | ResourceCreatedResponse<TResource> | TError;
 }
 
-@validateHasKey(TResource)
-@validateIsError(TError)
+@Private.validateHasKey(TResource)
+@Private.validateIsError(TError)
 interface ResourceUpdate<TResource, TError> {
   @autoRoute
   @doc("Updates an existing instance of the resource.")
@@ -87,8 +87,8 @@ model ResourceDeletedResponse {
   _: 200;
 }
 
-@validateHasKey(TResource)
-@validateIsError(TError)
+@Private.validateHasKey(TResource)
+@Private.validateIsError(TError)
 interface ResourceDelete<TResource, TError> {
   @autoRoute
   @doc("Deletes an existing instance of the resource.")
@@ -112,27 +112,27 @@ interface ResourceList<TResource, TError> {
   list(...ResourceCollectionParameters<TResource>): Page<TResource> | TError;
 }
 
-@validateHasKey(TResource)
-@validateIsError(TError)
+@Private.validateHasKey(TResource)
+@Private.validateIsError(TError)
 interface ResourceInstanceOperations<TResource, TError>
   extends ResourceRead<TResource, TError>,
     ResourceUpdate<TResource, TError>,
     ResourceDelete<TResource, TError> {}
 
-@validateHasKey(TResource)
-@validateIsError(TError)
+@Private.validateHasKey(TResource)
+@Private.validateIsError(TError)
 interface ResourceCollectionOperations<TResource, TError>
   extends ResourceCreate<TResource, TError>,
     ResourceList<TResource, TError> {}
 
-@validateHasKey(TResource)
-@validateIsError(TError)
+@Private.validateHasKey(TResource)
+@Private.validateIsError(TError)
 interface ResourceOperations<TResource, TError>
   extends ResourceInstanceOperations<TResource, TError>,
     ResourceCollectionOperations<TResource, TError> {}
 
-@validateHasKey(TResource)
-@validateIsError(TError)
+@Private.validateHasKey(TResource)
+@Private.validateIsError(TError)
 interface SingletonResourceRead<TSingleton, TResource, TError> {
   @autoRoute
   @doc("Gets the singleton resource.")
@@ -141,8 +141,8 @@ interface SingletonResourceRead<TSingleton, TResource, TError> {
   Get(...ResourceParameters<TResource>): TSingleton | TError;
 }
 
-@validateHasKey(TResource)
-@validateIsError(TError)
+@Private.validateHasKey(TResource)
+@Private.validateIsError(TError)
 interface SingletonResourceUpdate<TSingleton, TResource, TError> {
   @autoRoute
   @doc("Updates the singleton resource.")
@@ -158,8 +158,8 @@ interface SingletonResourceOperations<TSingleton, TResource, TError>
   extends SingletonResourceRead<TSingleton, TResource, TError>,
     SingletonResourceUpdate<TSingleton, TResource, TError> {}
 
-@validateHasKey(TResource)
-@validateIsError(TError)
+@Private.validateHasKey(TResource)
+@Private.validateIsError(TError)
 interface ExtensionResourceRead<TExtension, TResource, TError> {
   @autoRoute
   @doc("Gets an instance of the extension resource.")

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -1,5 +1,5 @@
 import "./http.cadl";
-import "../dist/src/resource.js";
+import "../dist/src/index.js";
 import "../dist/src/internal-decorators.js";
 
 namespace Cadl.Rest.Resource;

--- a/packages/rest/lib/rest.cadl
+++ b/packages/rest/lib/rest.cadl
@@ -1,5 +1,3 @@
-import "../dist/src/rest.js";
-import "../dist/src/route.js";
 import "../dist/src/validate.js";
 
 import "./http.cadl";

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -21,12 +21,16 @@
   "cadlMain": "lib/rest.cadl",
   "exports": {
     ".": "./dist/src/index.js",
+    "./http": "./dist/src/http/index.js",
     "./testing": "./dist/src/testing/index.js"
   },
   "typesVersions": {
     "*": {
       "*": [
         "./dist/src/index.d.ts"
+      ],
+      "http": [
+        "./dist/src/http/index.d.ts"
       ],
       "testing": [
         "./dist/src/testing/index.d.ts"
@@ -40,7 +44,7 @@
     "clean": "rimraf ./dist ./temp",
     "build": "tsc -p . && npm run lint-cadl-library",
     "watch": "tsc -p . --watch",
-    "lint-cadl-library": "cadl compile . --warn-as-error --import @cadl-lang/library-linter",
+    "lint-cadl-library": "cadl compile . --warn-as-error --import @cadl-lang/library-linter --no-emit",
     "test": "mocha",
     "test-official": "c8 mocha --forbid-only",
     "lint": "eslint . --ext .ts --max-warnings=0",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -40,7 +40,7 @@
     "clean": "rimraf ./dist ./temp",
     "build": "tsc -p . && npm run lint-cadl-library",
     "watch": "tsc -p . --watch",
-    "lint-cadl-library": "cadl compile . --import @cadl-lang/library-linter",
+    "lint-cadl-library": "cadl compile . --warn-as-error --import @cadl-lang/library-linter",
     "test": "mocha",
     "test-official": "c8 mocha --forbid-only",
     "lint": "eslint . --ext .ts --max-warnings=0",

--- a/packages/rest/src/http.ts
+++ b/packages/rest/src/http.ts
@@ -12,6 +12,8 @@ import {
 } from "@cadl-lang/compiler";
 import { reportDiagnostic } from "./diagnostics.js";
 
+export const namespace = "Cadl.Http";
+
 const headerDecorator = createDecoratorDefinition({
   name: "@header",
   target: "ModelProperty",
@@ -283,20 +285,6 @@ function validateVerbNoArgs(context: DecoratorContext, args: unknown[]) {
   validateDecoratorParamCount(context, 0, 0, args);
 }
 
-setDecoratorNamespace(
-  "Cadl.Http",
-  $get,
-  $put,
-  $post,
-  $delete,
-  $patch,
-  $header,
-  $query,
-  $path,
-  $body,
-  $statusCode
-);
-
 export function $plainData(context: DecoratorContext, entity: Type) {
   if (!validateDecoratorTarget(context, entity, "@plainData", "Model")) {
     return;
@@ -328,4 +316,4 @@ export function $plainData(context: DecoratorContext, entity: Type) {
   }
 }
 
-setDecoratorNamespace("Cadl.Http.Private", $plainData);
+setDecoratorNamespace("Private", $plainData);

--- a/packages/rest/src/http/decorators.ts
+++ b/packages/rest/src/http/decorators.ts
@@ -5,14 +5,14 @@ import {
   ModelTypeProperty,
   NamespaceType,
   Program,
-  setDecoratorNamespace,
+  setCadlNamespace,
   Type,
   validateDecoratorParamCount,
   validateDecoratorParamType,
   validateDecoratorTarget,
 } from "@cadl-lang/compiler";
-import { reportDiagnostic } from "./diagnostics.js";
-import { extractParamsFromPath } from "./utils.js";
+import { reportDiagnostic } from "../diagnostics.js";
+import { extractParamsFromPath } from "../utils.js";
 
 export const namespace = "Cadl.Http";
 
@@ -347,21 +347,6 @@ export function getServers(program: Program, type: NamespaceType): HttpServer[] 
   return program.stateMap(serversKey).get(type);
 }
 
-setDecoratorNamespace(
-  "Cadl.Http",
-  $get,
-  $put,
-  $post,
-  $delete,
-  $patch,
-  $header,
-  $query,
-  $path,
-  $body,
-  $statusCode,
-  $server
-);
-
 export function $plainData(context: DecoratorContext, entity: Type) {
   if (!validateDecoratorTarget(context, entity, "@plainData", "Model")) {
     return;
@@ -393,4 +378,4 @@ export function $plainData(context: DecoratorContext, entity: Type) {
   }
 }
 
-setDecoratorNamespace("Private", $plainData);
+setCadlNamespace("Private", $plainData);

--- a/packages/rest/src/http/index.ts
+++ b/packages/rest/src/http/index.ts
@@ -1,4 +1,5 @@
 export const namespace = "Cadl.Http";
 
 export * from "./decorators.js";
+export * from "./responses.js";
 export * from "./route.js";

--- a/packages/rest/src/http/index.ts
+++ b/packages/rest/src/http/index.ts
@@ -1,0 +1,4 @@
+export const namespace = "Cadl.Http";
+
+export * from "./decorators.js";
+export * from "./route.js";

--- a/packages/rest/src/http/responses.ts
+++ b/packages/rest/src/http/responses.ts
@@ -13,7 +13,7 @@ import {
   Program,
   Type,
 } from "@cadl-lang/compiler";
-import { createDiagnostic } from "./diagnostics.js";
+import { createDiagnostic } from "../diagnostics.js";
 import {
   getHeaderFieldName,
   getStatusCodeDescription,
@@ -21,7 +21,7 @@ import {
   isBody,
   isHeader,
   isStatusCode,
-} from "./http/decorators.js";
+} from "./decorators.js";
 
 export type StatusCode = `${number}` | "*";
 export interface HttpOperationResponse {

--- a/packages/rest/src/http/route.ts
+++ b/packages/rest/src/http/route.ts
@@ -12,7 +12,10 @@ import {
   Type,
   validateDecoratorTarget,
 } from "@cadl-lang/compiler";
-import { createDiagnostic, reportDiagnostic } from "./diagnostics.js";
+import { createDiagnostic, reportDiagnostic } from "../diagnostics.js";
+import { getResponsesForOperation, HttpOperationResponse } from "../responses.js";
+import { getAction, getResourceOperation, getSegment, getSegmentSeparator } from "../rest.js";
+import { extractParamsFromPath } from "../utils.js";
 import {
   getHeaderFieldName,
   getOperationVerb,
@@ -20,10 +23,7 @@ import {
   getQueryParamName,
   HttpVerb,
   isBody,
-} from "./http.js";
-import { getResponsesForOperation, HttpOperationResponse } from "./responses.js";
-import { getAction, getResourceOperation, getSegment, getSegmentSeparator } from "./rest.js";
-import { extractParamsFromPath } from "./utils.js";
+} from "./decorators.js";
 
 export type OperationContainer = NamespaceType | InterfaceType;
 
@@ -629,10 +629,4 @@ export function isAutoRoute(
   }
 
   return false;
-}
-
-setNamespaceForFile("Cadl.Http");
-
-function setNamespaceForFile(namespace: string) {
-  console.log("Caller", setNamespaceForFile.caller);
 }

--- a/packages/rest/src/http/route.ts
+++ b/packages/rest/src/http/route.ts
@@ -13,7 +13,6 @@ import {
   validateDecoratorTarget,
 } from "@cadl-lang/compiler";
 import { createDiagnostic, reportDiagnostic } from "../diagnostics.js";
-import { getResponsesForOperation, HttpOperationResponse } from "../responses.js";
 import { getAction, getResourceOperation, getSegment, getSegmentSeparator } from "../rest.js";
 import { extractParamsFromPath } from "../utils.js";
 import {
@@ -24,6 +23,7 @@ import {
   HttpVerb,
   isBody,
 } from "./decorators.js";
+import { getResponsesForOperation, HttpOperationResponse } from "./responses.js";
 
 export type OperationContainer = NamespaceType | InterfaceType;
 

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -1,6 +1,5 @@
 export const namespace = "Cadl.Rest";
 export * as http from "./http/index.js";
-export * from "./http/route.js";
 export * from "./resource.js";
 export * from "./responses.js";
 export * from "./rest.js";

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -1,5 +1,6 @@
-export * as http from "./http.js";
+export const namespace = "Cadl.Rest";
+export * as http from "./http/index.js";
+export * from "./http/route.js";
 export * from "./resource.js";
 export * from "./responses.js";
 export * from "./rest.js";
-export * from "./route.js";

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -1,6 +1,4 @@
 export const namespace = "Cadl.Rest";
 export * as http from "./http/index.js";
-export { getAllRoutes } from "./http/route.js";
 export * from "./resource.js";
-export * from "./responses.js";
 export * from "./rest.js";

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -1,5 +1,6 @@
 export const namespace = "Cadl.Rest";
 export * as http from "./http/index.js";
+export { getAllRoutes } from "./http/route.js";
 export * from "./resource.js";
 export * from "./responses.js";
 export * from "./rest.js";

--- a/packages/rest/src/internal-decorators.ts
+++ b/packages/rest/src/internal-decorators.ts
@@ -7,6 +7,8 @@ import {
 import { reportDiagnostic } from "./diagnostics.js";
 import { getResourceTypeKey } from "./resource.js";
 
+export const namespace = "Cadl.Rest.Private";
+
 const validatedMissingKey = Symbol("validatedMissing");
 // Workaround for the lack of template constraints https://github.com/microsoft/cadl/issues/377
 export function $validateHasKey(context: DecoratorContext, target: Type, value: Type) {

--- a/packages/rest/src/resource.ts
+++ b/packages/rest/src/resource.ts
@@ -10,7 +10,7 @@ import {
   validateDecoratorTarget,
 } from "@cadl-lang/compiler";
 import { reportDiagnostic } from "./diagnostics.js";
-import { $path } from "./http.js";
+import { $path } from "./http/decorators.js";
 
 export interface ResourceKey {
   resourceType: ModelType;

--- a/packages/rest/src/resource.ts
+++ b/packages/rest/src/resource.ts
@@ -6,7 +6,6 @@ import {
   ModelType,
   ModelTypeProperty,
   Program,
-  setDecoratorNamespace,
   Type,
   validateDecoratorTarget,
 } from "@cadl-lang/compiler";
@@ -203,5 +202,3 @@ export function $parentResource(context: DecoratorContext, entity: Type, parentT
     currentType = getParentResource(program, currentType);
   }
 }
-
-setDecoratorNamespace("Cadl.Rest", $parentResource, $copyResourceKeyParameters);

--- a/packages/rest/src/responses.ts
+++ b/packages/rest/src/responses.ts
@@ -21,7 +21,7 @@ import {
   isBody,
   isHeader,
   isStatusCode,
-} from "./http.js";
+} from "./http/decorators.js";
 
 export type StatusCode = `${number}` | "*";
 export interface HttpOperationResponse {

--- a/packages/rest/src/rest.ts
+++ b/packages/rest/src/rest.ts
@@ -4,7 +4,6 @@ import {
   ModelType,
   OperationType,
   Program,
-  setDecoratorNamespace,
   Type,
   validateDecoratorTarget,
 } from "@cadl-lang/compiler";
@@ -212,18 +211,3 @@ export function $action(context: DecoratorContext, entity: Type, name?: string) 
 export function getAction(program: Program, operation: OperationType): string | null | undefined {
   return program.stateMap(actionsKey).get(operation);
 }
-
-setDecoratorNamespace(
-  "Cadl.Rest",
-  $produces,
-  $consumes,
-  $segment,
-  $segmentOf,
-  $readsResource,
-  $createsResource,
-  $createsOrUpdatesResource,
-  $updatesResource,
-  $deletesResource,
-  $listsResource,
-  $action
-);

--- a/packages/rest/src/route.ts
+++ b/packages/rest/src/route.ts
@@ -9,7 +9,6 @@ import {
   NamespaceType,
   OperationType,
   Program,
-  setDecoratorNamespace,
   Type,
   validateDecoratorTarget,
 } from "@cadl-lang/compiler";
@@ -614,4 +613,8 @@ export function isAutoRoute(
   return false;
 }
 
-setDecoratorNamespace("Cadl.Http", $route, $routeReset, $autoRoute);
+setNamespaceForFile("Cadl.Http");
+
+function setNamespaceForFile(namespace: string) {
+  console.log("Caller", setNamespaceForFile.caller);
+}

--- a/packages/rest/src/testing/index.ts
+++ b/packages/rest/src/testing/index.ts
@@ -10,7 +10,7 @@ export const RestTestLibrary: CadlTestLibrary = {
     { realDir: "lib", pattern: "*.cadl", virtualPath: "./node_modules/@cadl-lang/rest/lib" },
     {
       realDir: "dist/src",
-      pattern: "*.js",
+      pattern: "**/*.js",
       virtualPath: "./node_modules/@cadl-lang/rest/dist/src",
     },
   ],

--- a/packages/rest/src/validate.ts
+++ b/packages/rest/src/validate.ts
@@ -1,5 +1,5 @@
 import { Program } from "@cadl-lang/compiler";
-import { getAllRoutes } from "./route.js";
+import { getAllRoutes } from "./http/route.js";
 
 export function $onValidate(program: Program) {
   const [, diagnostics] = getAllRoutes(program);

--- a/packages/rest/test/test-host.ts
+++ b/packages/rest/test/test-host.ts
@@ -6,13 +6,13 @@ import {
   expectDiagnosticEmpty,
   TestHost,
 } from "@cadl-lang/compiler/testing";
-import { HttpVerb } from "../src/http.js";
+import { HttpVerb } from "../src/http/decorators.js";
 import {
   getAllRoutes,
   HttpOperationParameter,
   OperationDetails,
   RouteOptions,
-} from "../src/route.js";
+} from "../src/http/route.js";
 import { RestTestLibrary } from "../src/testing/index.js";
 
 export async function createRestTestHost(): Promise<TestHost> {

--- a/packages/rest/test/test-http-decorators.ts
+++ b/packages/rest/test/test-http-decorators.ts
@@ -11,7 +11,7 @@ import {
   isPathParam,
   isQueryParam,
   isStatusCode,
-} from "../src/http.js";
+} from "../src/http/decorators.js";
 import { createRestTestRunner } from "./test-host.js";
 
 describe("rest: http decorators", () => {

--- a/packages/rest/test/test-plaindata.ts
+++ b/packages/rest/test/test-plaindata.ts
@@ -1,6 +1,6 @@
 import { TestHost } from "@cadl-lang/compiler/testing";
 import { ok, strictEqual } from "assert";
-import { isBody, isHeader, isPathParam, isQueryParam } from "../src/http.js";
+import { isBody, isHeader, isPathParam, isQueryParam } from "../src/http/decorators.js";
 import { createRestTestHost } from "./test-host.js";
 
 describe("rest: plain data", () => {

--- a/packages/samples/polymorphism/polymorphism.cadl
+++ b/packages/samples/polymorphism/polymorphism.cadl
@@ -1,6 +1,7 @@
 import "@cadl-lang/rest";
 
 using Cadl.Http;
+using Cadl.Rest;
 
 @discriminator("kind")
 model Pet {

--- a/packages/samples/use-versioned-lib/library.cadl
+++ b/packages/samples/use-versioned-lib/library.cadl
@@ -1,5 +1,7 @@
 import "@cadl-lang/versioning";
 
+using Cadl.Versioning;
+
 @versioned(Versions)
 namespace Library;
 

--- a/packages/samples/use-versioned-lib/main.cadl
+++ b/packages/samples/use-versioned-lib/main.cadl
@@ -2,6 +2,8 @@ import "@cadl-lang/versioning";
 import "@cadl-lang/rest";
 import "./library.cadl";
 
+using Cadl.Versioning;
+
 // Use version 1.0 of the Library
 @serviceTitle("Pet Store Service")
 @versionedDependency(Library.Versions.v1_0)

--- a/packages/samples/versioning/library.cadl
+++ b/packages/samples/versioning/library.cadl
@@ -1,5 +1,7 @@
 import "@cadl-lang/versioning";
 
+using Cadl.Versioning;
+
 @versioned(Versions)
 namespace Library;
 

--- a/packages/samples/versioning/main.cadl
+++ b/packages/samples/versioning/main.cadl
@@ -2,6 +2,9 @@ import "@cadl-lang/versioning";
 import "@cadl-lang/rest";
 import "./library.cadl";
 
+using Cadl.Versioning;
+using Cadl.Rest;
+
 @versionedDependency([[Versions.v1, Library.Versions.v1_0], [Versions.v2, Library.Versions.v1_1]])
 @serviceTitle("Pet Store Service")
 @versioned(Versions)

--- a/packages/versioning/lib/versioning.cadl
+++ b/packages/versioning/lib/versioning.cadl
@@ -1,6 +1,8 @@
 import "../dist/src/versioning.js";
 import "../dist/src/validate.js";
 
+using Cadl.Versioning;
+
 #suppress "projections-are-experimental"
 projection op#v {
   to(version) {

--- a/packages/versioning/package.json
+++ b/packages/versioning/package.json
@@ -40,7 +40,7 @@
     "clean": "rimraf ./dist ./temp",
     "build": "tsc -p . && npm run lint-cadl-library",
     "watch": "tsc -p . --watch",
-    "lint-cadl-library": "cadl compile . --warn-as-error --import @cadl-lang/library-linter",
+    "lint-cadl-library": "cadl compile . --warn-as-error --import @cadl-lang/library-linter --no-emit",
     "test": "mocha",
     "test-official": "c8 mocha --forbid-only",
     "lint": "eslint . --ext .ts --max-warnings=0",

--- a/packages/versioning/package.json
+++ b/packages/versioning/package.json
@@ -40,7 +40,7 @@
     "clean": "rimraf ./dist ./temp",
     "build": "tsc -p . && npm run lint-cadl-library",
     "watch": "tsc -p . --watch",
-    "lint-cadl-library": "cadl compile . --import @cadl-lang/library-linter",
+    "lint-cadl-library": "cadl compile . --warn-as-error --import @cadl-lang/library-linter",
     "test": "mocha",
     "test-official": "c8 mocha --forbid-only",
     "lint": "eslint . --ext .ts --max-warnings=0",

--- a/packages/versioning/src/versioning.ts
+++ b/packages/versioning/src/versioning.ts
@@ -19,6 +19,8 @@ const versionDependencyKey = Symbol("versionDependency");
 const renamedFromKey = Symbol("renamedFrom");
 const madeOptionalKey = Symbol("madeOptional");
 
+export const namespace = "Cadl.Versioning";
+
 function checkIsVersion(
   program: Program,
   enumMember: EnumMemberType,
@@ -34,6 +36,7 @@ function checkIsVersion(
   }
   return version;
 }
+
 export function $added(context: DecoratorContext, t: Type, v: EnumMemberType) {
   const { program } = context;
 

--- a/packages/versioning/test/test-incompatible-versioning.ts
+++ b/packages/versioning/test/test-incompatible-versioning.ts
@@ -16,6 +16,8 @@ describe("versioning: validate incompatible references", () => {
       (code) => `
       import "@cadl-lang/versioning";
 
+      using Cadl.Versioning;
+      
       @versioned(Versions)
       namespace TestService {
         enum Versions {v1, v2, v3, v4}
@@ -328,14 +330,18 @@ describe("versioning: validate incompatible references", () => {
 
     beforeEach(async () => {
       const host = await createVersioningTestHost();
-      runner = createTestWrapper(host, (code) => code);
+      runner = createTestWrapper(
+        host,
+        (code) => `
+        import "@cadl-lang/versioning";
+        using Cadl.Versioning;
+        ${code}`
+      );
     });
 
     it("emit diagnostic when referencing incompatible version via version dependency", async () => {
       // Here Foo was added in v2 which makes it only available in 1 & 2.
       const diagnostics = await runner.diagnose(`
-        import "@cadl-lang/versioning";
-
         @versioned(Versions)
         namespace VersionedLib {
           enum Versions {l1, l2}
@@ -367,8 +373,6 @@ describe("versioning: validate incompatible references", () => {
     it("doesn't emit diagnostic if all version use the same one", async () => {
       // Here Foo was added in v2 which makes it only available in 1 & 2.
       const diagnostics = await runner.diagnose(`
-        import "@cadl-lang/versioning";
-
         @versioned(Versions)
         namespace VersionedLib {
           enum Versions {l1, l2}
@@ -394,8 +398,6 @@ describe("versioning: validate incompatible references", () => {
     it("emit diagnostic when using item not available in selected version of library", async () => {
       // Here Foo was added in v2 but version 1 was selected.
       const diagnostics = await runner.diagnose(`
-        import "@cadl-lang/versioning";
-
         @versioned(Versions)
         namespace VersionedLib {
           enum Versions {l1, l2}

--- a/packages/versioning/test/test-versioned-dependencies.ts
+++ b/packages/versioning/test/test-versioned-dependencies.ts
@@ -20,6 +20,8 @@ describe("versioning: reference versioned library", () => {
       (code) => `
       import "@cadl-lang/versioning";
 
+      using Cadl.Versioning;
+
       @versioned(Versions)
       namespace VersionedLib {
         enum Versions {l1, l2}
@@ -241,6 +243,7 @@ describe("versioning: dependencies", () => {
       host,
       (code) => `
       import "@cadl-lang/versioning";
+      using Cadl.Versioning;
       ${code}`
     );
   });

--- a/packages/versioning/test/testVersioning.ts
+++ b/packages/versioning/test/testVersioning.ts
@@ -24,7 +24,10 @@ describe("cadl: versioning", () => {
 
   beforeEach(async () => {
     const host = await createVersioningTestHost();
-    runner = createTestWrapper(host, (code) => `import "@cadl-lang/versioning";\n${code}`);
+    runner = createTestWrapper(
+      host,
+      (code) => `import "@cadl-lang/versioning";using Cadl.Versioning;\n${code}`
+    );
   });
 
   describe("version compare", () => {

--- a/packages/versioning/test/testVersioning.ts
+++ b/packages/versioning/test/testVersioning.ts
@@ -402,7 +402,6 @@ describe("cadl: versioning", () => {
 
     async function versionedUnion(versions: string[], union: string) {
       const { Test } = (await runner.compile(`
-      import "@cadl-lang/versioning";
       @versioned(Versions)
       namespace MyService;
 


### PR DESCRIPTION
Had to reoargnize the http library to be able to use `export const namespace =` otherwise every single function needs to be passed to `setCadlNamespace`
Change in rest library:
- All the http layer is now in `http` subfolder and can be accessed via `@cadl-lang/rest/http` instead of using the `http` object 
- `@discriminator` was not in a namespace moved to `Cadl.Rest`