### PR TITLE
Require Visual Studio 2022

### DIFF
--- a/packages/internal-build-utils/src/constants.ts
+++ b/packages/internal-build-utils/src/constants.ts
@@ -1,4 +1,4 @@
-export const vsMinimumVersion = "16.9";
+export const vsMinimumVersion = "17.0";
 
 export const MinimumDotnetVersion = {
   major: 6,


### PR DESCRIPTION
We need a C# 10+ compiler now to build the extension because we used at least one new language feature: file-scoped namespace. 