### PR TITLE
Fixes for a few low-cost issues

### DIFF
--- a/common/changes/@cadl-lang/compiler/small-bug-fixes_2022-06-23-11-41.json
+++ b/common/changes/@cadl-lang/compiler/small-bug-fixes_2022-06-23-11-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Improved the error message shown when an `onEmit` function is not found in the requested emitter package",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/rest/small-bug-fixes_2022-06-23-11-42.json
+++ b/common/changes/@cadl-lang/rest/small-bug-fixes_2022-06-23-11-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Make string literal \"Content-Type\" header check case-insensitive",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -437,7 +437,7 @@ const diagnostics = {
   "emitter-not-found": {
     severity: "error",
     messages: {
-      default: paramMessage`Cannot find emitter ${"emitterPackage"}`,
+      default: paramMessage`Requested emitter package ${"emitterPackage"} does not provide an "onEmit" function.`,
     },
   },
 

--- a/packages/playground/src/app.tsx
+++ b/packages/playground/src/app.tsx
@@ -68,6 +68,11 @@ export const App: FunctionComponent = () => {
     window.open(url, "_blank");
   }, [saveCode, cadlModel]);
 
+  const cadlDocs = useCallback(async () => {
+    const url = `https://github.com/microsoft/cadl/blob/main/docs/tutorial.md`;
+    window.open(url, "_blank");
+  }, [cadlModel]);
+
   async function emptyOutputDir() {
     // empty output directory
     const dirs = await host.readDir("./cadl-output");
@@ -156,6 +161,9 @@ export const App: FunctionComponent = () => {
           </label>
           <label>
             <button onClick={newIssue as any}>Open Issue</button>
+          </label>
+          <label>
+            <button onClick={cadlDocs as any}>Show Cadl Tutorial</button>
           </label>
         </div>
         <div id="editor">

--- a/packages/rest/src/http/responses.ts
+++ b/packages/rest/src/http/responses.ts
@@ -206,8 +206,11 @@ function getResponseContentTypes(
       contentTypes.push(...getResponseContentTypes(program, diagnostics, responseModel.baseModel));
     }
     for (const prop of responseModel.properties.values()) {
-      if (isHeader(program, prop) && getHeaderFieldName(program, prop) === "content-type") {
-        contentTypes.push(...diagnostics.pipe(getContentTypes(prop)));
+      if (isHeader(program, prop)) {
+        const headerName = getHeaderFieldName(program, prop);
+        if (headerName && headerName.toLowerCase() === "content-type") {
+          contentTypes.push(...diagnostics.pipe(getContentTypes(prop)));
+        }
       }
     }
   }


### PR DESCRIPTION
Had some spare time so I fixed a few small bugs:

- Fixed #651 by clarifying the error message that is displayed when you use `--emit` with a Cadl library that doesn't export an `onEmit` function
- Fixed #607 by making the `Content-Type` header property name check case-insensitive
- Fixed #599 by adding a "Show Cadl Tutorial" button on the playground UI which launches the [Cadl tutorial page](https://github.com/microsoft/cadl/blob/main/docs/tutorial.md) in another window (let me know if we have a better link for this)

Here's what the button looks like:

<img width="429" alt="image" src="https://user-images.githubusercontent.com/79405/175293899-9d72ff6f-60c6-4e1e-bdc2-8318b3c9d4f4.png">
