### PR TITLE
Added Directory.Build.props to packages folder

### DIFF
--- a/packages/Directory.Build.props
+++ b/packages/Directory.Build.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <DefaultItemExcludesInProjectFolder>**\node_modules\**;$(DefaultItemExcludesInProjectFolder)</DefaultItemExcludesInProjectFolder>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Having `DefaultItemExcludesInProjectFolder` helps to open this repo in VS in the View Folder mode so it won't hang and go totally unresponsive.

Related to https://github.com/Azure/cadl-azure/pull/1606