### PR TITLE
Add server to tuto and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
+@server("https://example.com", "Single server endpoint")
 @route("/example")
 namespace Example {
   @get

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -708,6 +708,7 @@ A definition for a service is the namespace that contains all the operations for
 
 - @serviceTitle - the title of the service
 - @serviceVersion - the version of the service. Can be any string, but later version should lexicographically sort after earlier versions
+- @server - the host of the service. Can accept parameters.
 - @produces - the content types the service may produce
 - @consumes - the content types that may be sent to the service
 
@@ -716,11 +717,21 @@ Here's an example that uses these to define a Pet Store service:
 ```cadl
 @serviceTitle("Pet Store Service")
 @serviceVersion("2021-03-25")
+@server("https://example.com", "Single server endpoint")
 @doc("This is a sample server Petstore server.")
 @Cadl.Rest.produces("application/json", "image/png")
 @Cadl.Rest.consumes("application/json")
 namespace PetStore;
 
+```
+
+The `server` keyword can take a third parameter with parameters as necessary:
+
+```cadl
+@server("https://{region}.foo.com", "Regional endpoint", {
+  @doc("Region name")
+  region?: string = "westus",
+})
 ```
 
 #### Resources & routes


### PR DESCRIPTION
Adding the `server` doc to the main repo, using @xirzec content from [this playground](https://cadlplayground.z22.web.core.windows.net/prs/581/?c=aW1wb3J0ICJAY2FkbC1sYW5nL3Jlc3QiOwoKQHNlcnZpY2VUaXRsZSgiV2lkZ2V0IFPGFSIpxiBlcigiaHR0cHM6Ly9leGFtcGxlLmNvbSIsICJTaW5nbGUgxiYgZW5kcG9pbnTUOXtyZWdpb259LmZvb8g%2BUsUTYWzKOSwgewogIEBkb2Moxx4gbmFt5ACKICDGQT86IHN0cmluZyA9ICJ3ZXN0dXMiLAp9KQrEKHNwYWNlIERlbW%2FnAMM7Cgp1c8QtQ2FkbC5IdHRwOwoKb3AgdGVzdCgpyEs7) and @timotheeguerin guidance on where to update