### PR TITLE
Unify options: Rename emitter options to be `kebab-case`

### DIFF
--- a/common/changes/@cadl-lang/openapi3/unify-options_2022-07-06-20-27.json
+++ b/common/changes/@cadl-lang/openapi3/unify-options_2022-07-06-20-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Rename emitter options to be `kebab-case`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -676,7 +676,7 @@ emitters:
 # For example
 emitters:
  "@cadl-lang/openapi3":
-    outputFile: my-custom-file.json
+    output-file: my-custom-file.json
 ```
 
 - Via cli
@@ -685,7 +685,7 @@ emitters:
 --option "<emitterName>.<optionName>=<value>"
 
 # For example
---option "@cadl-lang/openapi3.outputFile=my-custom-file.json"
+--option "@cadl-lang/openapi3.output-file=my-custom-file.json"
 ```
 
 #### Creating libraries

--- a/packages/openapi3/README.md
+++ b/packages/openapi3/README.md
@@ -71,10 +71,10 @@ or via the command line with
 --option "@cadl-lang/openapi3.<optionName>=<value>"
 
 # For example
---option "@cadl-lang/openapi3.outputFile=my-custom-openapi.json"
+--option "@cadl-lang/openapi3.output-file=my-custom-openapi.json"
 ```
 
-### `outputFile`
+### `output-file`
 
 Configure the name of the swagger output file relative to the compiler `output-path`.
 

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -1,14 +1,14 @@
 import { createCadlLibrary, JSONSchemaType, paramMessage } from "@cadl-lang/compiler";
 
 export interface OpenAPIEmitterOptions {
-  outputFile?: string;
+  "output-file"?: string;
 }
 
 const EmiterOptionsSchema: JSONSchemaType<OpenAPIEmitterOptions> = {
   type: "object",
   additionalProperties: false,
   properties: {
-    outputFile: { type: "string", nullable: true },
+    "output-file": { type: "string", nullable: true },
   },
   required: [],
 };

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -77,7 +77,7 @@ import {
 } from "./types.js";
 
 const defaultOptions = {
-  outputFile: "openapi.json",
+  "output-file": "openapi.json",
 };
 
 export async function $onEmit(p: Program, emitterOptions?: EmitOptionsFor<OpenAPILibrary>) {
@@ -85,7 +85,7 @@ export async function $onEmit(p: Program, emitterOptions?: EmitOptionsFor<OpenAP
   const options: OpenAPIEmitterOptions = {
     outputFile: resolvePath(
       p.compilerOptions.outputPath ?? "./cadl-output",
-      resolvedOptions.outputFile
+      resolvedOptions["output-file"]
     ),
   };
 

--- a/packages/openapi3/test/test-host.ts
+++ b/packages/openapi3/test/test-host.ts
@@ -40,7 +40,7 @@ export async function openApiFor(code: string, versions?: string[]) {
   );
   await host.compile("./main.cadl", {
     noEmit: false,
-    emitters: { "@cadl-lang/openapi3": { outputFile: outPath } },
+    emitters: { "@cadl-lang/openapi3": { "output-file": outPath } },
   });
 
   if (!versions) {


### PR DESCRIPTION
fix  #648