### PR TITLE
Fix parsing error locations for imports and blockless namespaces

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-import-error-location_2022-07-12-21-48.json
+++ b/common/changes/@cadl-lang/compiler/fix-import-error-location_2022-07-12-21-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix parsing error locations for imports and blockless namespaces",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -342,15 +342,15 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
 
       if (isBlocklessNamespace(item)) {
         if (seenBlocklessNs) {
-          error({ code: "multiple-blockless-namespace" });
+          error({ code: "multiple-blockless-namespace", target: item });
         }
         if (seenDecl) {
-          error({ code: "blockless-namespace-first" });
+          error({ code: "blockless-namespace-first", target: item });
         }
         seenBlocklessNs = true;
       } else if (item.kind === SyntaxKind.ImportStatement) {
         if (seenDecl || seenBlocklessNs || seenUsing) {
-          error({ code: "import-first" });
+          error({ code: "import-first", target: item });
         }
       } else if (item.kind === SyntaxKind.UsingStatement) {
         seenUsing = true;
@@ -377,8 +377,8 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
       switch (tok) {
         case Token.ImportKeyword:
           reportInvalidDecorators(decorators, "import statement");
-          error({ code: "import-first", messageId: "topLevel" });
           item = parseImportStatement();
+          error({ code: "import-first", messageId: "topLevel", target: item });
           break;
         case Token.ModelKeyword:
           item = parseModelStatement(pos, decorators);
@@ -387,7 +387,7 @@ export function parse(code: string | SourceFile, options: ParseOptions = {}): Ca
           const ns = parseNamespaceStatement(pos, decorators);
 
           if (!Array.isArray(ns.statements)) {
-            error({ code: "blockless-namespace-first", messageId: "topLevel" });
+            error({ code: "blockless-namespace-first", messageId: "topLevel", target: ns });
           }
           item = ns;
           break;

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -3,16 +3,17 @@ import { CharCode } from "../core/charcode.js";
 import { formatDiagnostic, logVerboseTestOutput } from "../core/diagnostics.js";
 import { hasParseError, parse, visitChildren } from "../core/parser.js";
 import { CadlScriptNode, Node, NodeFlags, SourceFile, SyntaxKind } from "../core/types.js";
+import { DiagnosticMatch, expectDiagnostics } from "../testing/expect.js";
 
 describe("compiler: syntax", () => {
   describe("import statements", () => {
     parseEach(['import "x";']);
 
     parseErrorEach([
-      ['namespace Foo { import "x"; }', [/Imports must be top-level/]],
-      ['namespace Foo { } import "x";', [/Imports must come prior/]],
-      ['model Foo { } import "x";', [/Imports must come prior/]],
-      ['using Bar; import "x";', [/Imports must come prior/]],
+      ['namespace Foo { import "x"; }', [{ message: /Imports must be top-level/, pos: 16 }]],
+      ['namespace Foo { } import "x";', [{ message: /Imports must come prior/, pos: 18 }]],
+      ['model Foo { } import "x";', [{ message: /Imports must come prior/, pos: 14 }]],
+      ['using Bar; import "x";', [{ message: /Imports must come prior/, pos: 11 }]],
     ]);
   });
 
@@ -222,10 +223,22 @@ describe("compiler: syntax", () => {
     ]);
 
     parseErrorEach([
-      ["namespace Foo { namespace Store; }", [/Blockless namespace can only be top-level/]],
-      ["namespace Store; namespace Store2;", [/Cannot use multiple blockless namespaces/]],
-      ["model Foo { }; namespace Store;", [/Blockless namespaces can't follow other/]],
-      ["namespace Foo { }; namespace Store;", [/Blockless namespaces can't follow other/]],
+      [
+        "namespace Foo { namespace Store; }",
+        [{ message: /Blockless namespace can only be top-level/, pos: 16 }],
+      ],
+      [
+        "namespace Store; namespace Store2;",
+        [{ message: /Cannot use multiple blockless namespaces/, pos: 17 }],
+      ],
+      [
+        "model Foo { }; namespace Store;",
+        [{ message: /Blockless namespaces can't follow other/, pos: 15 }],
+      ],
+      [
+        "namespace Foo { }; namespace Store;",
+        [{ message: /Blockless namespaces can't follow other/, pos: 19 }],
+      ],
     ]);
   });
 
@@ -704,8 +717,8 @@ function checkPositioning(node: Node, file: SourceFile) {
  * }
  */
 function parseErrorEach(
-  cases: [string, RegExp[], Callback?][],
-  options: { strict?: boolean } = {}
+  cases: [string, (RegExp | DiagnosticMatch)[], Callback?][],
+  options = { strict: false }
 ) {
   for (const [code, matches, callback] of cases) {
     it(`doesn't parse '${shorten(code)}'`, () => {
@@ -733,10 +746,12 @@ function parseErrorEach(
           "More diagnostics reported than expected."
         );
       }
-      let i = 0;
-      for (const match of matches) {
-        assert.match(astNode.parseDiagnostics[i++].message, match);
-      }
+
+      const expected = matches.map<DiagnosticMatch>((m) =>
+        m instanceof RegExp ? { message: m } : m
+      );
+      expectDiagnostics(astNode.parseDiagnostics, expected, options);
+
       assert(
         hasParseError(astNode),
         "node claims to have no parse errors, but above were reported."

--- a/packages/compiler/testing/expect.ts
+++ b/packages/compiler/testing/expect.ts
@@ -23,7 +23,7 @@ export interface DiagnosticMatch {
   /**
    * Match the code.
    */
-  code: string;
+  code?: string;
 
   /**
    * Match the message.
@@ -57,11 +57,14 @@ export interface DiagnosticMatch {
  */
 export function expectDiagnostics(
   diagnostics: readonly Diagnostic[],
-  match: DiagnosticMatch | DiagnosticMatch[]
+  match: DiagnosticMatch | DiagnosticMatch[],
+  options = {
+    strict: true,
+  }
 ) {
   const array = isArray(match) ? match : [match];
 
-  if (array.length !== diagnostics.length) {
+  if (options.strict && array.length !== diagnostics.length) {
     assert.fail(
       `Expected ${array.length} diagnostics but found ${diagnostics.length}:\n ${formatDiagnostics(
         diagnostics
@@ -73,11 +76,13 @@ export function expectDiagnostics(
     const expectation = array[i];
     const sep = "-".repeat(100);
     const message = `Diagnostics found:\n${sep}\n${formatDiagnostics(diagnostics)}\n${sep}`;
-    strictEqual(
-      diagnostic.code,
-      expectation.code,
-      `Diagnostic at index ${i} has non matching code.\n${message}`
-    );
+    if (expectation.code !== undefined) {
+      strictEqual(
+        diagnostic.code,
+        expectation.code,
+        `Diagnostic at index ${i} has non matching code.\n${message}`
+      );
+    }
 
     if (expectation.message !== undefined) {
       matchStrOrRegex(


### PR DESCRIPTION
The parser's error function defaults to using the location of the current token as the error location, but here we had moved to the beginning of the next statement before we decided the previous statement was an error. The fix is to pass an explicit target.

I also took the opportunity to make parser.test.ts use expectDiagnostics.

Fix #706 