### PR TITLE
Clone decorator lists correctly, add `DefaultKeyVisibility` model, fix `rest` op signatures

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-clone-type_2022-07-14-13-05.json
+++ b/common/changes/@cadl-lang/compiler/fix-clone-type_2022-07-14-13-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Improve `cloneType` implementation to duplicate decorator lists correctly",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/compiler/fix-clone-type_2022-07-19-15-33.json
+++ b/common/changes/@cadl-lang/compiler/fix-clone-type_2022-07-19-15-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add DefaultKeyVisibility<T, Visibility> and @withDefaultKeyVisibility to assign a default visibility value to model @key properties in specific operation signatures",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/rest/fix-clone-type_2022-07-14-13-05.json
+++ b/common/changes/@cadl-lang/rest/fix-clone-type_2022-07-14-13-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Improve `cloneKeyProperties` implementation so that original model type is not affected",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/rest/fix-clone-type_2022-07-19-15-33.json
+++ b/common/changes/@cadl-lang/rest/fix-clone-type_2022-07-19-15-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Update resource operation interfaces to configure Create and Update model properties correctly",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -117,7 +117,7 @@ export interface Checker {
   getLiteralType(node: LiteralNode): LiteralType;
   getTypeName(type: Type, options?: TypeNameOptions): string;
   getNamespaceString(type: NamespaceType | undefined, options?: TypeNameOptions): string;
-  cloneType<T extends Type>(type: T): T;
+  cloneType<T extends Type>(type: T, additionalProps?: { [P in keyof T]?: T[P] }): T;
   evalProjection(node: ProjectionNode, target: Type, args: Type[]): Type;
   project(
     target: Type,
@@ -2779,12 +2779,17 @@ export function createChecker(program: Program): Checker {
    * recursively by the caller.
    */
   function cloneType<T extends Type>(type: T, additionalProps: { [P in keyof T]?: T[P] } = {}): T {
+    // Create a new decorator list with the same decorators so that edits to the
+    // new decorators list doesn't affect the cloned type
+    const decorators = "decorators" in type ? [...type.decorators] : undefined;
+
     // TODO: this needs to handle other types
     let clone;
     switch (type.kind) {
       case "Model":
         clone = finishType({
           ...type,
+          decorators,
           properties: Object.prototype.hasOwnProperty.call(additionalProps, "properties")
             ? undefined
             : new Map(
@@ -2796,6 +2801,7 @@ export function createChecker(program: Program): Checker {
       case "Union":
         clone = finishType({
           ...type,
+          decorators,
           variants: new Map<string | symbol, UnionTypeVariant>(
             Array.from(type.variants.entries()).map(([key, prop]) => [
               key,
@@ -2811,6 +2817,7 @@ export function createChecker(program: Program): Checker {
       case "Interface":
         clone = finishType({
           ...type,
+          decorators,
           operations: new Map(type.operations.entries()),
           ...additionalProps,
         });
@@ -2818,6 +2825,7 @@ export function createChecker(program: Program): Checker {
       case "Enum":
         clone = finishType({
           ...type,
+          decorators,
           members: type.members.map((v) => cloneType(v)),
           ...additionalProps,
         });
@@ -2825,6 +2833,7 @@ export function createChecker(program: Program): Checker {
       default:
         clone = finishType({
           ...type,
+          ...(decorators ? { decorators } : {}),
           ...additionalProps,
         });
     }

--- a/packages/compiler/lib/lib.cadl
+++ b/packages/compiler/lib/lib.cadl
@@ -102,3 +102,9 @@ model OmitProperties<T, TStringOrTuple> {
 model OmitDefaults<T> {
   ...T;
 }
+
+@doc("The template for setting the default visibility of key properties.")
+@withDefaultKeyVisibility(Visibility)
+model DefaultKeyVisibility<T, Visibility> {
+  ...T;
+}

--- a/packages/compiler/test/checker/clone-type.test.ts
+++ b/packages/compiler/test/checker/clone-type.test.ts
@@ -1,6 +1,6 @@
-import { deepStrictEqual, ok } from "assert";
+import { deepStrictEqual, ok, strictEqual } from "assert";
 import { Program } from "../../core/program.js";
-import { Type } from "../../core/types.js";
+import { DecoratorContext, Type } from "../../core/types.js";
 import { createTestHost, TestHost } from "../../testing/index.js";
 
 describe("compiler: type cloning", () => {
@@ -39,6 +39,19 @@ describe("compiler: type cloning", () => {
       const clone = testHost.program.checker.cloneType(test);
       ok(blues.has(clone!), "the clone is blue");
       deepStrictEqual(test, clone!);
+
+      // Ensure that the cloned decorators list isn't reused directly
+      if ("decorators" in test && "decorators" in clone) {
+        clone.decorators.push({
+          decorator: (_ctx: DecoratorContext, _type: Type) => {
+            // Decorator not executed
+          },
+          args: [],
+        });
+
+        strictEqual(test.decorators.length, 2);
+        strictEqual(clone.decorators.length, 3);
+      }
     });
   }
 });

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -48,15 +48,21 @@ model ResourceCreatedResponse<T> {
   @body body: T;
 }
 
+@friendlyName("{name}Update", TResource)
+model ResourceCreateOrUpdateModel<TResource> is OptionalProperties<UpdateableProperties<DefaultKeyVisibility<TResource, "read">>> {}
+
 interface ResourceCreateOrUpdate<TResource, TError> {
   @autoRoute
   @doc("Creates or update a instance of the resource.")
   @createsOrUpdatesResource(TResource)
   createOrUpdate(
     ...ResourceParameters<TResource>,
-    @body resource: TResource
+    @body resource: ResourceCreateOrUpdateModel<TResource>
   ): TResource | ResourceCreatedResponse<TResource> | TError;
 }
+
+@friendlyName("{name}Create", TResource)
+model ResourceCreateModel<TResource> is UpdateableProperties<DefaultKeyVisibility<TResource, "read">> {}
 
 interface ResourceCreate<TResource, TError> {
   @autoRoute
@@ -64,7 +70,7 @@ interface ResourceCreate<TResource, TError> {
   @createsResource(TResource)
   create(
     ...ResourceCollectionParameters<TResource>,
-    @body resource: TResource
+    @body resource: ResourceCreateModel<TResource>
   ): TResource | ResourceCreatedResponse<TResource> | TError;
 }
 
@@ -76,7 +82,7 @@ interface ResourceUpdate<TResource, TError> {
   @updatesResource(TResource)
   update(
     ...ResourceParameters<TResource>,
-    @body properties: OptionalProperties<UpdateableProperties<TResource>>
+    @body properties: ResourceCreateOrUpdateModel<TResource>
   ): TResource | TError;
 }
 
@@ -150,7 +156,9 @@ interface SingletonResourceUpdate<TSingleton, TResource, TError> {
   @updatesResource(TSingleton)
   Update(
     ...ResourceParameters<TResource>,
-    @body properties: OptionalProperties<UpdateableProperties<TSingleton>>
+
+    @body
+    properties: ResourceCreateOrUpdateModel<TSingleton>
   ): TSingleton | TError;
 }
 
@@ -174,7 +182,7 @@ interface ExtensionResourceCreateOrUpdate<TExtension, TResource, TError> {
   CreateOrUpdate(
     ...ResourceParameters<TResource>,
     ...ResourceParameters<TExtension>,
-    @body resource: TExtension
+    @body resource: ResourceCreateOrUpdateModel<TExtension>
   ): TExtension | ResourceCreatedResponse<TExtension> | TError;
 }
 
@@ -184,7 +192,7 @@ interface ExtensionResourceCreate<TExtension, TResource, TError> {
   @createsResource(TExtension)
   Create(
     ...ResourceParameters<TResource>,
-    @body resource: TResource
+    @body resource: ResourceCreateModel<TExtension>
   ): TExtension | ResourceCreatedResponse<TExtension> | TError;
 }
 
@@ -195,7 +203,9 @@ interface ExtensionResourceUpdate<TExtension, TResource, TError> {
   Update(
     ...ResourceParameters<TResource>,
     ...ResourceParameters<TExtension>,
-    @body properties: OptionalProperties<UpdateableProperties<TExtension>>
+
+    @body
+    properties: ResourceCreateOrUpdateModel<TExtension>
   ): TExtension | TError;
 }
 

--- a/packages/rest/src/resource.ts
+++ b/packages/rest/src/resource.ts
@@ -95,10 +95,8 @@ function cloneKeyProperties(context: DecoratorContext, target: ModelType, resour
   if (resourceKey) {
     const { keyProperty } = resourceKey;
     const keyName = getKeyName(program, keyProperty);
-
-    const newProp = program.checker.cloneType(keyProperty);
-    newProp.name = keyName;
-    newProp.decorators.push(
+    const decorators = [
+      ...keyProperty.decorators,
       {
         decorator: $path,
         args: [],
@@ -106,9 +104,9 @@ function cloneKeyProperties(context: DecoratorContext, target: ModelType, resour
       {
         decorator: $resourceTypeForKeyParam,
         args: [{ node: target.node, value: resourceType }],
-      }
-    );
-    context.call($path, newProp, undefined as any);
+      },
+    ];
+    const newProp = program.checker.cloneType(keyProperty, { name: keyName, decorators });
 
     target.properties.set(keyName, newProp);
   }

--- a/packages/rest/src/resource.ts
+++ b/packages/rest/src/resource.ts
@@ -1,4 +1,5 @@
 import {
+  $visibility,
   DecoratorContext,
   getKeyName,
   isErrorType,
@@ -95,8 +96,11 @@ function cloneKeyProperties(context: DecoratorContext, target: ModelType, resour
   if (resourceKey) {
     const { keyProperty } = resourceKey;
     const keyName = getKeyName(program, keyProperty);
+
+    // Filter out the @visibility decorator because it might affect metadata
+    // filtering
     const decorators = [
-      ...keyProperty.decorators,
+      ...keyProperty.decorators.filter((d) => d.decorator !== $visibility),
       {
         decorator: $path,
         args: [],
@@ -106,8 +110,8 @@ function cloneKeyProperties(context: DecoratorContext, target: ModelType, resour
         args: [{ node: target.node, value: resourceType }],
       },
     ];
-    const newProp = program.checker.cloneType(keyProperty, { name: keyName, decorators });
 
+    const newProp = program.checker.cloneType(keyProperty, { name: keyName, decorators });
     target.properties.set(keyName, newProp);
   }
 }

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -74,6 +74,10 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
                   "name": {
                     "type": "string"
                   },
@@ -693,6 +697,10 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "int64"
+                  },
                   "name": {
                     "type": "string"
                   },

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -72,31 +72,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "tag": {
-                    "type": "string"
-                  },
-                  "age": {
-                    "type": "integer",
-                    "format": "int32",
-                    "minimum": 0,
-                    "maximum": 20
-                  },
-                  "ownerId": {
-                    "type": "integer",
-                    "format": "int64"
-                  }
-                },
-                "description": "The template for adding optional properties.",
-                "x-cadl-name": "OptionalProperties<UpdateableProperties<Pet>>"
+                "$ref": "#/components/schemas/PetUpdate"
               }
             }
           }
@@ -168,7 +144,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Pet"
+                "$ref": "#/components/schemas/PetCreate"
               }
             }
           }
@@ -250,7 +226,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Checkup"
+                "$ref": "#/components/schemas/CheckupUpdate"
               }
             }
           }
@@ -356,22 +332,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "provider": {
-                    "type": "string"
-                  },
-                  "premium": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "deductible": {
-                    "type": "integer",
-                    "format": "int32"
-                  }
-                },
-                "description": "The template for adding optional properties.",
-                "x-cadl-name": "OptionalProperties<UpdateableProperties<Insurance>>"
+                "$ref": "#/components/schemas/InsuranceUpdate"
               }
             }
           }
@@ -526,22 +487,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "provider": {
-                    "type": "string"
-                  },
-                  "premium": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "deductible": {
-                    "type": "integer",
-                    "format": "int32"
-                  }
-                },
-                "description": "The template for adding optional properties.",
-                "x-cadl-name": "OptionalProperties<UpdateableProperties<Insurance>>"
+                "$ref": "#/components/schemas/InsuranceUpdate"
               }
             }
           }
@@ -593,7 +539,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Checkup"
+                "$ref": "#/components/schemas/CheckupUpdate"
               }
             }
           }
@@ -695,22 +641,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "integer",
-                    "format": "int64"
-                  },
-                  "name": {
-                    "type": "string"
-                  },
-                  "age": {
-                    "type": "integer",
-                    "format": "int32"
-                  }
-                },
-                "description": "The template for adding optional properties.",
-                "x-cadl-name": "OptionalProperties<UpdateableProperties<Owner>>"
+                "$ref": "#/components/schemas/OwnerUpdate"
               }
             }
           }
@@ -782,7 +713,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Owner"
+                "$ref": "#/components/schemas/OwnerCreate"
               }
             }
           }
@@ -864,7 +795,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Checkup"
+                "$ref": "#/components/schemas/CheckupUpdate"
               }
             }
           }
@@ -970,22 +901,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "provider": {
-                    "type": "string"
-                  },
-                  "premium": {
-                    "type": "integer",
-                    "format": "int32"
-                  },
-                  "deductible": {
-                    "type": "integer",
-                    "format": "int32"
-                  }
-                },
-                "description": "The template for adding optional properties.",
-                "x-cadl-name": "OptionalProperties<UpdateableProperties<Insurance>>"
+                "$ref": "#/components/schemas/InsuranceUpdate"
               }
             }
           }
@@ -1080,6 +996,55 @@
           "message"
         ]
       },
+      "PetUpdate": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 20
+          },
+          "ownerId": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "description": "The template for adding optional properties."
+      },
+      "PetCreate": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0,
+            "maximum": 20
+          },
+          "ownerId": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "description": "The template for adding updateable properties.",
+        "required": [
+          "name",
+          "age",
+          "ownerId"
+        ]
+      },
       "Rest.Resource.Page_Pet": {
         "type": "object",
         "properties": {
@@ -1100,6 +1065,18 @@
         "required": [
           "value"
         ]
+      },
+      "CheckupUpdate": {
+        "type": "object",
+        "properties": {
+          "vetName": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          }
+        },
+        "description": "The template for adding optional properties."
       },
       "Checkup": {
         "type": "object",
@@ -1163,6 +1140,23 @@
           "deductible"
         ]
       },
+      "InsuranceUpdate": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string"
+          },
+          "premium": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "deductible": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "description": "The template for adding optional properties."
+      },
       "Toy": {
         "type": "object",
         "properties": {
@@ -1222,6 +1216,36 @@
         },
         "required": [
           "id",
+          "name",
+          "age"
+        ]
+      },
+      "OwnerUpdate": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "description": "The template for adding optional properties."
+      },
+      "OwnerCreate": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "description": "The template for adding updateable properties.",
+        "required": [
           "name",
           "age"
         ]


### PR DESCRIPTION
This PR fixes #693 which reports that the `cloneType` function does not make a new, unique `decorators` array when cloning a type.  The implication of this bug is that any changes to the "new" `decorators` array will be propagated back to the original type.

The fix is to create a new array to copy over the decorator list so that any changes to that list are only applied to the cloned type.  I've also added some test logic to verify that this holds true.

I also improved the code of the `cloneKeyProperties` function in the `rest` library to use the `additionalProperties` parameter of `cloneType` and duplicate the original property decorators correctly.  This caused a small (and expected) change in the output of the PetStore REST spec.  I'll need to go update the resource operation signatures to omit the key property wherever it is semantically necessary.