### PR TITLE
Add better operation Id resolving

### DIFF
--- a/common/changes/@cadl-lang/compiler/operation-id-better_2022-07-14-16-51.json
+++ b/common/changes/@cadl-lang/compiler/operation-id-better_2022-07-14-16-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Added ability for decorator validator to accept any type",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi/operation-id-better_2022-07-14-16-51.json
+++ b/common/changes/@cadl-lang/openapi/operation-id-better_2022-07-14-16-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "Added helper to resolve operation id",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/openapi3/operation-id-better_2022-07-14-16-51.json
+++ b/common/changes/@cadl-lang/openapi3/operation-id-better_2022-07-14-16-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Uptake new `resolveOperationId` helper from openapi library improving the logic",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/operation-id-better_2022-07-14-17-06.json
+++ b/common/changes/@cadl-lang/rest/operation-id-better_2022-07-14-17-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Remove `groupName` from `OperationDetails`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/compiler/core/decorator-utils.ts
+++ b/packages/compiler/core/decorator-utils.ts
@@ -14,8 +14,9 @@ import {
 export type CadlValue = Type | string | number | boolean;
 
 // prettier-ignore
-export type InferredCadlValue<K extends Type["kind"]> = 
-  K extends (infer T extends Type["kind"])[] ? InferredCadlValue<T>
+export type InferredCadlValue<K extends TypeKind> = 
+  K extends "Any" ? CadlValue
+  : K extends (infer T extends Type["kind"])[] ? InferredCadlValue<T>
   : K extends "String" ? string 
   : K extends "Number" ? number 
   : K extends "Boolean" ? boolean 
@@ -29,12 +30,12 @@ export type InferredCadlValue<K extends Type["kind"]> =
  * @param decoratorName
  * @returns
  */
-export function validateDecoratorTarget<K extends Type["kind"]>(
+export function validateDecoratorTarget<K extends TypeKind>(
   context: DecoratorContext,
   target: Type,
   decoratorName: string,
   expectedType: K | readonly K[]
-): target is Type & { kind: K } {
+): target is K extends "Any" ? Type : Type & { kind: K } {
   const isCorrectType = isCadlValueTypeOf(target, expectedType);
   if (!isCorrectType) {
     reportDiagnostic(context.program, {
@@ -86,7 +87,7 @@ export function validateDecoratorTargetIntrinsic(
  * @param expectedType One or multiple allowed cadl types.
  * @returns boolean if the target is of one of the allowed types.
  */
-export function isCadlValueTypeOf<K extends Type["kind"]>(
+export function isCadlValueTypeOf<K extends TypeKind>(
   target: CadlValue,
   expectedType: K | readonly K[]
 ): target is InferredCadlValue<K> {
@@ -96,8 +97,8 @@ export function isCadlValueTypeOf<K extends Type["kind"]>(
   }
 
   return typeof expectedType === "string"
-    ? kind === expectedType
-    : expectedType.includes(kind as any);
+    ? expectedType === "Any" || kind === expectedType
+    : expectedType.includes("Any" as any) || expectedType.includes(kind as any);
 }
 
 function getTypeKind(target: CadlValue): Type["kind"] | undefined {
@@ -146,9 +147,9 @@ export function validateDecoratorParamType<K extends Type["kind"]>(
 }
 
 export interface DecoratorDefinition<
-  T extends Type["kind"],
-  P extends readonly DecoratorParamDefinition<Type["kind"]>[],
-  S extends DecoratorParamDefinition<Type["kind"]> | undefined = undefined
+  T extends TypeKind,
+  P extends readonly DecoratorParamDefinition<TypeKind>[],
+  S extends DecoratorParamDefinition<TypeKind> | undefined = undefined
 > {
   /**
    * Name of the decorator.
@@ -171,7 +172,7 @@ export interface DecoratorDefinition<
   readonly spreadArgs?: S;
 }
 
-export interface DecoratorParamDefinition<K extends Type["kind"]> {
+export interface DecoratorParamDefinition<K extends TypeKind> {
   /**
    * Kind of the parameter
    */
@@ -184,32 +185,32 @@ export interface DecoratorParamDefinition<K extends Type["kind"]> {
 }
 
 type InferParameters<
-  P extends readonly DecoratorParamDefinition<Type["kind"]>[],
-  S extends DecoratorParamDefinition<Type["kind"]> | undefined
+  P extends readonly DecoratorParamDefinition<TypeKind>[],
+  S extends DecoratorParamDefinition<TypeKind> | undefined
 > = S extends undefined
   ? InferPosParameters<P>
   : [...InferPosParameters<P>, ...InferSpreadParameter<S>];
 
-type InferSpreadParameter<S extends DecoratorParamDefinition<Type["kind"]> | undefined> =
+type InferSpreadParameter<S extends DecoratorParamDefinition<TypeKind> | undefined> =
   S extends DecoratorParamDefinition<Type["kind"]> ? InferParameter<S>[] : never;
 
-type InferPosParameters<P extends readonly DecoratorParamDefinition<Type["kind"]>[]> = {
+type InferPosParameters<P extends readonly DecoratorParamDefinition<TypeKind>[]> = {
   [K in keyof P]: InferParameter<P[K]>;
 };
 
-type InferParameter<P extends DecoratorParamDefinition<Type["kind"]>> = P["optional"] extends true
+type InferParameter<P extends DecoratorParamDefinition<TypeKind>> = P["optional"] extends true
   ? InferParameterKind<P["kind"]> | undefined
   : InferParameterKind<P["kind"]>;
 
 // prettier-ignore
-type InferParameterKind<P extends Type["kind"] | readonly Type["kind"][]> =
-  P extends readonly (infer T extends Type["kind"])[] ? InferredCadlValue<T> 
-  : P extends Type["kind"] ? InferredCadlValue<P> : never
+type InferParameterKind<P extends TypeKind | readonly TypeKind[]> =
+  P extends readonly (infer T extends TypeKind)[] ? InferredCadlValue<T> 
+  : P extends TypeKind ? InferredCadlValue<P> : never
 
 export interface DecoratorValidator<
-  T extends Type["kind"],
-  P extends readonly DecoratorParamDefinition<Type["kind"]>[],
-  S extends DecoratorParamDefinition<Type["kind"]> | undefined = undefined
+  T extends TypeKind,
+  P extends readonly DecoratorParamDefinition<TypeKind>[],
+  S extends DecoratorParamDefinition<TypeKind> | undefined = undefined
 > {
   validate(
     context: DecoratorContext,
@@ -218,10 +219,12 @@ export interface DecoratorValidator<
   ): boolean;
 }
 
+export type TypeKind = Type["kind"] | "Any";
+
 export function createDecoratorDefinition<
-  T extends Type["kind"],
-  P extends readonly DecoratorParamDefinition<Type["kind"]>[],
-  S extends DecoratorParamDefinition<Type["kind"]> | undefined
+  T extends TypeKind,
+  P extends readonly DecoratorParamDefinition<TypeKind>[],
+  S extends DecoratorParamDefinition<TypeKind> | undefined
 >(definition: DecoratorDefinition<T, P, S>): DecoratorValidator<T, P, S> {
   const minParams = definition.args.filter((x) => !x.optional).length;
   const maxParams = definition.spreadArgs ? undefined : definition.args.length;

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -1,43 +1,58 @@
 import {
   cadlTypeToJson,
   CadlValue,
+  createDecoratorDefinition,
   DecoratorContext,
+  ModelType,
+  OperationType,
   Program,
   Type,
-  validateDecoratorParamType,
-  validateDecoratorTarget,
 } from "@cadl-lang/compiler";
 import { http } from "@cadl-lang/rest";
 import { reportDiagnostic } from "./lib.js";
+import { ExtensionKey } from "./types.js";
 
 export const namespace = "OpenAPI";
 
-export function $notinnamespace(context: DecoratorContext, entity: Type, opId: string) {}
-
 const operationIdsKey = Symbol("operationIds");
-export function $operationId(context: DecoratorContext, entity: Type, opId: string) {
-  if (
-    !validateDecoratorTarget(context, entity, "@operationId", "Operation") ||
-    !validateDecoratorParamType(context.program, entity, opId, "String")
-  ) {
+const operationIdDecorator = createDecoratorDefinition({
+  name: "@operationId",
+  target: "Operation",
+  args: [{ kind: "String" }],
+} as const);
+/**
+ * Set a sepecific operation ID.
+ * @param context Decorator Context
+ * @param entity Decorator target
+ * @param opId Operation ID.
+ */
+export function $operationId(context: DecoratorContext, entity: OperationType, opId: string) {
+  if (!operationIdDecorator.validate(context, entity, [opId])) {
     return;
   }
   context.program.stateMap(operationIdsKey).set(entity, opId);
 }
 
-export function getOperationId(program: Program, entity: Type): string | undefined {
+/**
+ * @returns operationId set via the @operationId decorator or `undefined`
+ */
+export function getOperationId(program: Program, entity: OperationType): string | undefined {
   return program.stateMap(operationIdsKey).get(entity);
 }
 
-export type ExtensionKey = `x-${string}`;
 const openApiExtensionKey = Symbol("openApiExtension");
+const extensionDecorator = createDecoratorDefinition({
+  name: "@extension",
+  target: "Any",
+  args: [{ kind: "String" }, { kind: "Any" }],
+} as const);
 export function $extension(
   context: DecoratorContext,
   entity: Type,
   extensionName: string,
   value: CadlValue
 ) {
-  if (!validateDecoratorParamType(context.program, entity, extensionName, "String")) {
+  if (!extensionDecorator.validate(context, entity, [extensionName, value])) {
     return;
   }
 
@@ -77,17 +92,31 @@ function isOpenAPIExtensionKey(key: string): key is ExtensionKey {
   return key.startsWith("x-");
 }
 
-// The @defaultResponse decorator can be applied to a model. When that model is used
-// as the return type of an operation, this return type will be the default response.
+const defaultResponseDecorator = createDecoratorDefinition({
+  name: "@defaultResponse",
+  target: "Model",
+  args: [],
+} as const);
+/**
+ * The @defaultResponse decorator can be applied to a model. When that model is used
+ * as the return type of an operation, this return type will be the default response.
+ *
+ */
 const defaultResponseKey = Symbol("defaultResponse");
-export function $defaultResponse(context: DecoratorContext, entity: Type) {
-  if (!validateDecoratorTarget(context, entity, "@defaultResponse", "Model")) {
+export function $defaultResponse(context: DecoratorContext, entity: ModelType) {
+  if (!defaultResponseDecorator.validate(context, entity, [])) {
     return;
   }
   http.setStatusCode(context.program, entity, ["*"]);
   context.program.stateSet(defaultResponseKey).add(entity);
 }
 
+/**
+ * Check if the given model has been mark as a default response.
+ * @param program Cadl Program
+ * @param entity Model to check.
+ * @returns boolean.
+ */
 export function isDefaultResponse(program: Program, entity: Type): boolean {
   return program.stateSet(defaultResponseKey).has(entity);
 }
@@ -98,6 +127,11 @@ export interface ExternalDocs {
 }
 const externalDocsKey = Symbol("externalDocs");
 
+const externalDocsDecorator = createDecoratorDefinition({
+  name: "@externalDocs",
+  target: "Any",
+  args: [{ kind: "String" }, { kind: "String", optional: true }],
+} as const);
 /**
  * Allows referencing an external resource for extended documentation.
  * @param url The URL for the target documentation. Value MUST be in the format of a URL.
@@ -109,10 +143,7 @@ export function $externalDocs(
   url: string,
   description?: string
 ) {
-  if (!validateDecoratorParamType(context.program, target, url, "String")) {
-    return;
-  }
-  if (description && !validateDecoratorParamType(context.program, target, description, "String")) {
+  if (!externalDocsDecorator.validate(context, target, [url, description])) {
     return;
   }
   const doc: ExternalDocs = { url };

--- a/packages/openapi/src/helpers.ts
+++ b/packages/openapi/src/helpers.ts
@@ -1,11 +1,14 @@
 import {
   getFriendlyName as getAssignedFriendlyName,
+  getServiceNamespace,
   ModelType,
   ModelTypeProperty,
+  OperationType,
   Program,
   Type,
   TypeNameOptions,
 } from "@cadl-lang/compiler";
+import { getOperationId } from "./decorators.js";
 import { reportDiagnostic } from "./lib.js";
 
 /**
@@ -143,4 +146,35 @@ function getDefaultFriendlyName(
   const model = (ns ? ns + "." : "") + type.name;
   const args = type.templateArguments.map((arg) => getTypeName(program, arg, options));
   return `${model}_${args.join("_")}`;
+}
+
+/**
+ * Resolve the OpenAPI operation ID for the given operation using the following logic:
+ * - If @operationId was specified use that value
+ * - If operation is defined at the root or under the service namespace return <operation.name>
+ * - Otherwise(operation is under another namespace or interface) return <namespace/interface.name>_<opration.name>
+ *
+ * @param program Cadl Program
+ * @param operation Operation
+ * @returns Operation ID in this format <name> or <group>_<name>
+ */
+export function resolveOperationId(program: Program, operation: OperationType) {
+  const explicitOperationId = getOperationId(program, operation);
+  if (explicitOperationId) {
+    return explicitOperationId;
+  }
+
+  if (operation.interface) {
+    return `${operation.interface.name}_${operation.name}`;
+  }
+  const namespace = operation.namespace;
+  if (
+    namespace === undefined ||
+    namespace === program.checker.getGlobalNamespaceType() ||
+    namespace === getServiceNamespace(program)
+  ) {
+    return operation.name;
+  }
+
+  return `${namespace.name}_${operation.name}`;
 }

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./decorators.js";
 export * from "./helpers.js";
+export * from "./types.js";

--- a/packages/openapi/src/types.ts
+++ b/packages/openapi/src/types.ts
@@ -1,0 +1,1 @@
+export type ExtensionKey = `x-${string}`;

--- a/packages/openapi/test/helpers.test.ts
+++ b/packages/openapi/test/helpers.test.ts
@@ -1,0 +1,54 @@
+import { OperationType } from "@cadl-lang/compiler";
+import { BasicTestRunner, createTestRunner } from "@cadl-lang/compiler/testing";
+import { strictEqual } from "assert";
+import { resolveOperationId } from "../src/helpers.js";
+
+describe("OpenAPI3 Helpers", () => {
+  let runner: BasicTestRunner;
+
+  beforeEach(async () => {
+    runner = await createTestRunner();
+  });
+  describe("resolveOperationId", () => {
+    async function testResolveOperationId(code: string) {
+      const { foo } = (await runner.compile(code)) as { foo: OperationType };
+      return resolveOperationId(runner.program, foo);
+    }
+
+    it("return operation name if operation is defined at the root", async () => {
+      const id = await testResolveOperationId(`@test op foo(): string;`);
+      strictEqual(id, "foo");
+    });
+
+    it("return operation name if operation is defined under service namespace", async () => {
+      const id = await testResolveOperationId(`
+        @serviceTitle("Abc")
+        namespace MyService;
+
+        @test op foo(): string;
+      `);
+      strictEqual(id, "foo");
+    });
+
+    it("return group name and operaiton name if operation is defined under interface", async () => {
+      const id = await testResolveOperationId(`
+        interface Bar {
+          @test op foo(): string;
+        }
+      `);
+      strictEqual(id, "Bar_foo");
+    });
+
+    it("return group name and operation name if operation is defined under namespace that is not the service namespace", async () => {
+      const id = await testResolveOperationId(`
+        @serviceTitle("Abc")
+        namespace MyService;
+
+        namespace Bar {
+          @test op foo(): string;
+        }
+      `);
+      strictEqual(id, "Bar_foo");
+    });
+  });
+});

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -43,9 +43,9 @@ import {
 import {
   getExtensions,
   getExternalDocs,
-  getOperationId,
   getParameterKey,
   getTypeName,
+  resolveOperationId,
   shouldInline,
 } from "@cadl-lang/openapi";
 import { Discriminator, getDiscriminator, http } from "@cadl-lang/rest";
@@ -381,13 +381,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
       }
     }
 
-    const operationId = getOperationId(program, op);
-    if (operationId) {
-      currentEndpoint.operationId = operationId;
-    } else {
-      // Synthesize an operation ID
-      currentEndpoint.operationId = (groupName.length > 0 ? `${groupName}_` : "") + op.name;
-    }
+    currentEndpoint.operationId = resolveOperationId(program, op);
     applyExternalDocs(op, currentEndpoint);
 
     // Set up basic endpoint fields

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -354,7 +354,7 @@ function createOAPIEmitter(program: Program, options: OpenAPIEmitterOptions) {
   }
 
   function emitOperation(operation: OperationDetails): void {
-    const { path: fullPath, operation: op, groupName, verb, parameters } = operation;
+    const { path: fullPath, operation: op, verb, parameters } = operation;
 
     // If path contains a query string, issue msg and don't emit this endpoint
     if (fullPath.indexOf("?") > 0) {

--- a/packages/openapi3/src/types.ts
+++ b/packages/openapi3/src/types.ts
@@ -1,4 +1,4 @@
-export type ExtensionKey = `x-${string}`;
+import { ExtensionKey } from "@cadl-lang/openapi";
 
 export type Extensions = {
   [key in ExtensionKey]?: any;

--- a/packages/rest/src/http/route.ts
+++ b/packages/rest/src/http/route.ts
@@ -64,7 +64,6 @@ export interface OperationDetails {
   path: string;
   pathFragment?: string;
   verb: HttpVerb;
-  groupName: string;
   container: OperationContainer;
   parameters: HttpOperationParameters;
   responses: HttpOperationResponse[];
@@ -455,7 +454,6 @@ function buildRoutes(
       pathFragment: route.pathFragment,
       verb,
       container,
-      groupName: container.name,
       parameters: route.parameters,
       operation: op,
       responses,

--- a/packages/samples/test/output/use-versioned-lib/openapi.json
+++ b/packages/samples/test/output/use-versioned-lib/openapi.json
@@ -8,7 +8,7 @@
   "paths": {
     "/": {
       "get": {
-        "operationId": "VersionedApi_read",
+        "operationId": "read",
         "parameters": [],
         "responses": {
           "200": {


### PR DESCRIPTION
fix  #689

## Changes
Stay the same: `foo`
```cadl
op foo():  string; 
```

Before: `MyService_foo`, now `foo`
```cadl
@serviceTitle("MyService")
namespace MyService;

op test(): string; 
```

Stay the same: `Bar_foo`
```cadl
@serviceTitle("MyService")
namespace MyService;

interface Bar {
   op test(): string; 
}
```

Stay the same: `Bar_foo`
```cadl
@serviceTitle("MyService")
namespace MyService;

namespace Bar {
   op test(): string; 
}
```