### PR TITLE
Implement `routeReset` decorator and operation route overrides

### DIFF
--- a/common/changes/@cadl-lang/rest/route-overrides_2022-07-20-11-44.json
+++ b/common/changes/@cadl-lang/rest/route-overrides_2022-07-20-11-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add @routeReset decorator to enable operations and containers to override the route prefix of any parent container",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/rest/route-overrides_2022-07-20-11-45.json
+++ b/common/changes/@cadl-lang/rest/route-overrides_2022-07-20-11-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "@route decorator can now override @autoRoute generated route",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}


### PR DESCRIPTION
This change fixes #685 by completing the implementation of the `@routeReset` decorator that I added way back when the new routing logic was created.  This decorator resets the list of parent container prefix routes that are used to compute the full route for an operation.  

This means that an operation at any namespace/interface depth can now place itself in arbitrary locations of the route hierarchy.

I've also made it possible for the `@route` decorator to override the `@autoRoute` decorator when using operation signatures.  In the case where a spec author wants to have explicit control over the route of a particular operation signature, this will now be possible by simply using `@route` or `@routeReset`.

Check out my changes to the routing unit tests to see examples of what you can do.

/cc @lmazuel 