### PR TITLE
Ensure that all @path params from @key properties are required

### DIFF
--- a/common/changes/@cadl-lang/rest/key-path-param-required_2022-07-20-12-34.json
+++ b/common/changes/@cadl-lang/rest/key-path-param-required_2022-07-20-12-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Ensure that all @key properties turned into @path parameters by KeysOf<T> are required even if the original is optional",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/src/resource.ts
+++ b/packages/rest/src/resource.ts
@@ -111,7 +111,15 @@ function cloneKeyProperties(context: DecoratorContext, target: ModelType, resour
       },
     ];
 
-    const newProp = program.checker.cloneType(keyProperty, { name: keyName, decorators });
+    // Clone the key property and ensure that an optional key property doesn't
+    // become an optional path parameter
+    const newProp = program.checker.cloneType(keyProperty, {
+      name: keyName,
+      decorators,
+      optional: false,
+    });
+
+    // Add the key property to the target type
     target.properties.set(keyName, newProp);
   }
 }

--- a/packages/rest/test/routes.test.ts
+++ b/packages/rest/test/routes.test.ts
@@ -219,6 +219,32 @@ describe("rest: routes", () => {
     ]);
   });
 
+  it("models with non-required key property will produce required path parameter for key", async () => {
+    const [routes, diagnostics] = await compileOperations(`
+      using Cadl.Rest.Resource;
+
+      namespace Things {
+        model Thing {
+          @key
+          @segment("things")
+          thingId?: string;
+        }
+
+        @autoRoute
+        @get op GetThingWithParams(...KeysOf<Thing>): string;
+      }
+      `);
+
+    deepStrictEqual(routes, [
+      {
+        verb: "get",
+        path: "/things/{thingId}",
+        params: { body: undefined, params: [{ name: "thingId", type: "path" }] },
+      },
+    ]);
+    expectDiagnosticEmpty(diagnostics);
+  });
+
   it("autoRoute operations filter out path parameters with a string literal type", async () => {
     const routes = await getRoutesFor(
       `


### PR DESCRIPTION
This change fixes an issue exposed by #697 which affects some sample specs we have in `cadl-azure`.  Specifically, the previous PR now emits an error when an operation's `@path` parameter is optional without a default value.  

When using a resource-style library like `@cadl-lang/rest` or `@azure-tools/cadl-azure-core`, a spec author might make the `@key` property optional which causes `KeysOf<T>` to copy over that key property as a new *optional* `@path` parameter for resource operations.

This change forces the new `@path` parameter to always be required since there's no reason (in my opinion) that a key parameter would ever need to be optional.