### PR TITLE
Fix issue in VS Code on Windows where common defs are not found

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-issue-with-check-for-import-by-main-file_2022-07-21-21-43.json
+++ b/common/changes/@cadl-lang/compiler/fix-issue-with-check-for-import-by-main-file_2022-07-21-21-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix issue with multi-file specs in VS Code on Windows where common definitions are not found.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/util.ts
+++ b/packages/compiler/core/util.ts
@@ -6,6 +6,7 @@ import {
   isPathAbsolute,
   isUrl,
   joinPaths,
+  normalizePath,
   resolvePath,
 } from "./path-utils.js";
 import {
@@ -48,8 +49,8 @@ export function deepClone<T>(value: T): T {
   return value;
 }
 
-export async function resolveRealPath(host: CompilerHost, path: string) {
-  return resolvePath(await host.realpath(path));
+export async function getNormalizedRealPath(host: CompilerHost, path: string) {
+  return normalizePath(await host.realpath(path));
 }
 
 export interface FileHandlingOptions {

--- a/packages/compiler/core/util.ts
+++ b/packages/compiler/core/util.ts
@@ -48,6 +48,10 @@ export function deepClone<T>(value: T): T {
   return value;
 }
 
+export async function resolveRealPath(host: CompilerHost, path: string) {
+  return resolvePath(await host.realpath(path));
+}
+
 export interface FileHandlingOptions {
   allowFileNotFound?: boolean;
   diagnosticTarget?: DiagnosticTarget | typeof NoTarget;
@@ -188,5 +192,24 @@ export function getSourceFileKindFromExt(path: string): SourceFileKind | undefin
     return "cadl";
   } else {
     return undefined;
+  }
+}
+
+export function createStringMap<T>(caseInsensitive: boolean): Map<string, T> {
+  return caseInsensitive ? new CaseInsensitiveMap<T>() : new Map<string, T>();
+}
+
+class CaseInsensitiveMap<T> extends Map<string, T> {
+  get(key: string) {
+    return super.get(key.toUpperCase());
+  }
+  set(key: string, value: T) {
+    return super.set(key.toUpperCase(), value);
+  }
+  has(key: string) {
+    return super.has(key.toUpperCase());
+  }
+  delete(key: string) {
+    return super.delete(key.toUpperCase());
   }
 }

--- a/packages/compiler/server/server.ts
+++ b/packages/compiler/server/server.ts
@@ -50,11 +50,11 @@ function main() {
   s.log("Process ID", process.pid);
   s.log("Command Line", process.argv);
 
-  connection.onInitialize((params) => {
+  connection.onInitialize(async (params) => {
     if (params.capabilities.workspace?.workspaceFolders) {
       clientHasWorkspaceFolderCapability = true;
     }
-    return s.initialize(params);
+    return await s.initialize(params);
   });
 
   connection.onInitialized((params) => {

--- a/packages/compiler/server/serverlib.ts
+++ b/packages/compiler/server/serverlib.ts
@@ -1153,6 +1153,7 @@ export function createServer(host: ServerHost): Server {
       getSourceFileKind,
     };
 
+    // NOTE: we use the underlying host as a prototype to allow test code to mutate it.
     const compilerHost = Object.create(base);
     Object.assign(compilerHost, overrides);
     return compilerHost;

--- a/packages/compiler/server/serverlib.ts
+++ b/packages/compiler/server/serverlib.ts
@@ -78,9 +78,9 @@ import {
 import {
   doIO,
   findProjectRoot,
+  getNormalizedRealPath,
   getSourceFileKindFromExt,
   loadFile,
-  resolveRealPath,
 } from "../core/util.js";
 import { getDoc, isDeprecated, isIntrinsic } from "../lib/decorators.js";
 
@@ -302,7 +302,7 @@ export function createServer(host: ServerHost): Server {
           name: "<root>",
           uri: compilerHost.pathToFileURL(params.rootPath),
           path: ensureTrailingDirectorySeparator(
-            await resolveRealPath(compilerHost, params.rootPath)
+            await getNormalizedRealPath(compilerHost, params.rootPath)
           ),
         },
       ];
@@ -1121,7 +1121,7 @@ export function createServer(host: ServerHost): Server {
   }
 
   async function fileURLToRealPath(url: string) {
-    return resolveRealPath(compilerHost, compilerHost.fileURLToPath(url));
+    return getNormalizedRealPath(compilerHost, compilerHost.fileURLToPath(url));
   }
 
   function createFileSystemCache() {
@@ -1152,6 +1152,7 @@ export function createServer(host: ServerHost): Server {
       stat,
       getSourceFileKind,
     };
+
     const compilerHost = Object.create(base);
     Object.assign(compilerHost, overrides);
     return compilerHost;

--- a/packages/compiler/server/serverlib.ts
+++ b/packages/compiler/server/serverlib.ts
@@ -1147,16 +1147,12 @@ export function createServer(host: ServerHost): Server {
 
   function createCompilerHost(): CompilerHost {
     const base = host.compilerHost;
-    const overrides: Partial<CompilerHost> = {
+    return {
+      ...base,
       readFile,
       stat,
       getSourceFileKind,
     };
-
-    // NOTE: we use the underlying host as a prototype to allow test code to mutate it.
-    const compilerHost = Object.create(base);
-    Object.assign(compilerHost, overrides);
-    return compilerHost;
 
     async function readFile(path: string): Promise<ServerSourceFile> {
       // Try open files sent from client over LSP

--- a/packages/compiler/server/serverlib.ts
+++ b/packages/compiler/server/serverlib.ts
@@ -10,6 +10,7 @@ import {
   DiagnosticSeverity,
   DiagnosticTag,
   DidChangeWatchedFilesParams,
+  FileEvent,
   FoldingRange,
   FoldingRangeParams,
   InitializedParams,
@@ -74,7 +75,13 @@ import {
   SyntaxKind,
   Type,
 } from "../core/types.js";
-import { doIO, findProjectRoot, getSourceFileKindFromExt, loadFile } from "../core/util.js";
+import {
+  doIO,
+  findProjectRoot,
+  getSourceFileKindFromExt,
+  loadFile,
+  resolveRealPath,
+} from "../core/util.js";
 import { getDoc, isDeprecated, isIntrinsic } from "../lib/decorators.js";
 
 export interface ServerHost {
@@ -87,9 +94,9 @@ export interface ServerHost {
 export interface Server {
   readonly pendingMessages: readonly string[];
   readonly workspaceFolders: readonly ServerWorkspaceFolder[];
-  initialize(params: InitializeParams): InitializeResult;
+  initialize(params: InitializeParams): Promise<InitializeResult>;
   initialized(params: InitializedParams): void;
-  workspaceFoldersChanged(e: WorkspaceFoldersChangeEvent): void;
+  workspaceFoldersChanged(e: WorkspaceFoldersChangeEvent): Promise<void>;
   watchedFilesChanged(params: DidChangeWatchedFilesParams): void;
   gotoDefinition(params: DefinitionParams): Promise<Location[]>;
   complete(params: CompletionParams): Promise<CompletionList>;
@@ -210,14 +217,8 @@ export function createServer(host: ServerHost): Server {
   // the compiler reads a file that isn't open, we use this cache to avoid
   // hitting the disk. Entries are invalidated when LSP client notifies us of
   // a file change.
-  const fileSystemCache = new Map<string, CachedFile | CachedError>();
-
-  const compilerHost: CompilerHost = {
-    ...host.compilerHost,
-    readFile,
-    stat,
-    getSourceFileKind,
-  };
+  const fileSystemCache = createFileSystemCache();
+  const compilerHost = createCompilerHost();
 
   let workspaceFolders: ServerWorkspaceFolder[] = [];
   let isInitialized = false;
@@ -247,7 +248,7 @@ export function createServer(host: ServerHost): Server {
     log,
   };
 
-  function initialize(params: InitializeParams): InitializeResult {
+  async function initialize(params: InitializeParams): Promise<InitializeResult> {
     const tokenLegend: SemanticTokensLegend = {
       tokenTypes: Object.keys(SemanticTokenKind)
         .filter((x) => Number.isNaN(Number(x)))
@@ -275,11 +276,12 @@ export function createServer(host: ServerHost): Server {
     };
 
     if (params.capabilities.workspace?.workspaceFolders) {
-      workspaceFolders =
-        params.workspaceFolders?.map((w) => ({
+      for (const w of params.workspaceFolders ?? []) {
+        workspaceFolders.push({
           ...w,
-          path: ensureTrailingDirectorySeparator(resolvePath(compilerHost.fileURLToPath(w.uri))),
-        })) ?? [];
+          path: ensureTrailingDirectorySeparator(await fileURLToRealPath(w.uri)),
+        });
+      }
       capabilities.workspace = {
         workspaceFolders: {
           supported: true,
@@ -291,9 +293,7 @@ export function createServer(host: ServerHost): Server {
         {
           name: "<root>",
           uri: params.rootUri,
-          path: ensureTrailingDirectorySeparator(
-            resolvePath(compilerHost.fileURLToPath(params.rootUri))
-          ),
+          path: ensureTrailingDirectorySeparator(await fileURLToRealPath(params.rootUri)),
         },
       ];
     } else if (params.rootPath) {
@@ -301,7 +301,9 @@ export function createServer(host: ServerHost): Server {
         {
           name: "<root>",
           uri: compilerHost.pathToFileURL(params.rootPath),
-          path: ensureTrailingDirectorySeparator(resolvePath(params.rootPath)),
+          path: ensureTrailingDirectorySeparator(
+            await resolveRealPath(compilerHost, params.rootPath)
+          ),
         },
       ];
     }
@@ -315,27 +317,24 @@ export function createServer(host: ServerHost): Server {
     log("Initialization complete.");
   }
 
-  function workspaceFoldersChanged(e: WorkspaceFoldersChangeEvent) {
+  async function workspaceFoldersChanged(e: WorkspaceFoldersChangeEvent) {
     log("Workspace Folders Changed", e);
     const map = new Map(workspaceFolders.map((f) => [f.uri, f]));
     for (const folder of e.removed) {
       map.delete(folder.uri);
     }
     for (const folder of e.added) {
-      map.set(folder.uri, { ...folder, path: compilerHost.fileURLToPath(folder.uri) });
+      map.set(folder.uri, {
+        ...folder,
+        path: ensureTrailingDirectorySeparator(await fileURLToRealPath(folder.uri)),
+      });
     }
     workspaceFolders = Array.from(map.values());
     log("Workspace Folders", workspaceFolders);
   }
 
   function watchedFilesChanged(params: DidChangeWatchedFilesParams) {
-    // remove stale file system cache entries on file change notification
-    for (const each of params.changes) {
-      if (each.uri.startsWith("file:")) {
-        const path = compilerHost.fileURLToPath(each.uri);
-        fileSystemCache.delete(path);
-      }
-    }
+    fileSystemCache.notify(params.changes);
   }
 
   type CompileCallback<T> = (
@@ -357,7 +356,7 @@ export function createServer(host: ServerHost): Server {
     document: TextDocument | TextDocumentIdentifier,
     callback?: CompileCallback<T>
   ): Promise<T | Program | undefined> {
-    const path = getPath(document);
+    const path = await getPath(document);
     const mainFile = await getMainFileForDocument(path);
     const config = await loadCadlConfigForPath(compilerHost, mainFile);
 
@@ -390,7 +389,7 @@ export function createServer(host: ServerHost): Server {
       if (callback) {
         const doc = "version" in document ? document : host.getOpenDocumentByURL(document.uri);
         compilerAssert(doc, "Failed to get document.");
-        const path = getPath(doc);
+        const path = await getPath(doc);
         const script = program.sourceFiles.get(path);
         compilerAssert(script, "Failed to get script.");
         return await callback(program, doc, script);
@@ -416,7 +415,7 @@ export function createServer(host: ServerHost): Server {
   }
 
   async function getFoldingRanges(params: FoldingRangeParams): Promise<FoldingRange[]> {
-    const file = await compilerHost.readFile(getPath(params.textDocument));
+    const file = await compilerHost.readFile(await getPath(params.textDocument));
     const ast = parse(file, { comments: true });
     const ranges: FoldingRange[] = [];
     let rangeStartSingleLines = -1;
@@ -647,7 +646,7 @@ export function createServer(host: ServerHost): Server {
     document: TextDocument,
     completions: CompletionList
   ) {
-    const documentPath = getPath(document);
+    const documentPath = await getPath(document);
     const projectRoot = await findProjectRoot(compilerHost, documentPath);
     if (projectRoot != undefined) {
       const [packagejson] = await loadFile(
@@ -701,7 +700,7 @@ export function createServer(host: ServerHost): Server {
     completions: CompletionList,
     node: StringLiteralNode
   ) {
-    const documentPath = getPath(document);
+    const documentPath = await getPath(document);
     const documentFile = getBaseFileName(documentPath);
     const documentDir = getDirectoryPath(documentPath);
     const nodevalueDir = hasTrailingDirectorySeparator(node.value)
@@ -806,7 +805,7 @@ export function createServer(host: ServerHost): Server {
   async function getSemanticTokens(params: SemanticTokensParams): Promise<SemanticToken[]> {
     const ignore = -1;
     const defer = -2;
-    const file = await compilerHost.readFile(getPath(params.textDocument));
+    const file = await compilerHost.readFile(await getPath(params.textDocument));
     const tokens = mapTokens();
     const ast = parse(file);
     classifyNode(ast);
@@ -930,7 +929,7 @@ export function createServer(host: ServerHost): Server {
   async function buildSemanticTokens(params: SemanticTokensParams): Promise<SemanticTokens> {
     const builder = new SemanticTokensBuilder();
     const tokens = await getSemanticTokens(params);
-    const file = await compilerHost.readFile(getPath(params.textDocument));
+    const file = await compilerHost.readFile(await getPath(params.textDocument));
     const starts = file.getLineStarts();
 
     for (const token of tokens) {
@@ -1047,7 +1046,7 @@ export function createServer(host: ServerHost): Server {
       let mainFile = "main.cadl";
       let pkg: any;
       const pkgPath = joinPaths(dir, "package.json");
-      const cached = fileSystemCache.get(pkgPath)?.data;
+      const cached = (await fileSystemCache.get(pkgPath))?.data;
 
       if (cached) {
         pkg = cached;
@@ -1059,7 +1058,7 @@ export function createServer(host: ServerHost): Server {
           logMainFileSearchDiagnostic,
           options
         );
-        fileSystemCache.get(pkgPath)!.data = pkg ?? {};
+        (await fileSystemCache.get(pkgPath))!.data = pkg ?? {};
       }
 
       if (typeof pkg?.cadlMain === "string") {
@@ -1096,11 +1095,11 @@ export function createServer(host: ServerHost): Server {
     return workspaceFolders.some((f) => path.startsWith(f.path));
   }
 
-  function getPath(document: TextDocument | TextDocumentIdentifier) {
+  async function getPath(document: TextDocument | TextDocumentIdentifier) {
     if (isUntitled(document.uri)) {
       return document.uri;
     }
-    const path = resolvePath(compilerHost.fileURLToPath(document.uri));
+    const path = await fileURLToRealPath(document.uri);
     pathToURLMap.set(path, document.uri);
     return path;
   }
@@ -1121,57 +1120,94 @@ export function createServer(host: ServerHost): Server {
     return url ? host.getOpenDocumentByURL(url) : undefined;
   }
 
-  async function readFile(path: string): Promise<ServerSourceFile> {
-    // Try open files sent from client over LSP
-    const document = getOpenDocument(path);
-    if (document) {
-      return {
-        document,
-        ...createSourceFile(document.getText(), path),
-      };
-    }
+  async function fileURLToRealPath(url: string) {
+    return resolveRealPath(compilerHost, compilerHost.fileURLToPath(url));
+  }
 
-    // Try file system cache
-    const cached = fileSystemCache.get(path);
-    if (cached) {
-      if (cached.type === "error") {
-        throw cached.error;
+  function createFileSystemCache() {
+    const cache = new Map<string, CachedFile | CachedError>();
+    let changes: FileEvent[] = [];
+    return {
+      async get(path: string) {
+        for (const change of changes) {
+          const path = await fileURLToRealPath(change.uri);
+          cache.delete(path);
+        }
+        changes = [];
+        return cache.get(path);
+      },
+      set(path: string, entry: CachedFile | CachedError) {
+        cache.set(path, entry);
+      },
+      notify(changes: FileEvent[]) {
+        changes.push(...changes);
+      },
+    };
+  }
+
+  function createCompilerHost(): CompilerHost {
+    const base = host.compilerHost;
+    const overrides: Partial<CompilerHost> = {
+      readFile,
+      stat,
+      getSourceFileKind,
+    };
+    const compilerHost = Object.create(base);
+    Object.assign(compilerHost, overrides);
+    return compilerHost;
+
+    async function readFile(path: string): Promise<ServerSourceFile> {
+      // Try open files sent from client over LSP
+      const document = getOpenDocument(path);
+      if (document) {
+        return {
+          document,
+          ...createSourceFile(document.getText(), path),
+        };
       }
-      return cached.file;
+
+      // Try file system cache
+      const cached = await fileSystemCache.get(path);
+      if (cached) {
+        if (cached.type === "error") {
+          throw cached.error;
+        }
+        return cached.file;
+      }
+
+      // Hit the disk and cache
+      try {
+        const file = await base.readFile(path);
+        fileSystemCache.set(path, { type: "file", file });
+        return file;
+      } catch (error) {
+        fileSystemCache.set(path, { type: "error", error });
+        throw error;
+      }
     }
 
-    // Hit the disk and cache
-    try {
-      const file = await host.compilerHost.readFile(path);
-      fileSystemCache.set(path, { type: "file", file });
-      return file;
-    } catch (error) {
-      fileSystemCache.set(path, { type: "error", error });
-      throw error;
+    async function stat(path: string): Promise<{ isDirectory(): boolean; isFile(): boolean }> {
+      // if we have an open document for the path or a cache entry, then we know
+      // it's a file and not a directory and needn't hit the disk.
+      if (getOpenDocument(path) || (await fileSystemCache.get(path))?.type === "file") {
+        return {
+          isFile() {
+            return true;
+          },
+          isDirectory() {
+            return false;
+          },
+        };
+      }
+      return await base.stat(path);
     }
-  }
 
-  async function stat(path: string): Promise<{ isDirectory(): boolean; isFile(): boolean }> {
-    // if we have an open document for the path or a cache entry, then we know
-    // it's a file and not a directory and needn't hit the disk.
-    if (getOpenDocument(path) || fileSystemCache.get(path)?.type === "file") {
-      return {
-        isFile() {
-          return true;
-        },
-        isDirectory() {
-          return false;
-        },
-      };
+    function getSourceFileKind(path: string) {
+      const document = getOpenDocument(path);
+      if (document?.languageId === "cadl") {
+        return "cadl";
+      }
+      return getSourceFileKindFromExt(path);
     }
-    return await host.compilerHost.stat(path);
-  }
-
-  function getSourceFileKind(path: string) {
-    const document = getOpenDocument(path);
-    if (document?.languageId === "cadl") {
-      return "cadl";
-    }
-    return getSourceFileKindFromExt(path);
   }
 }

--- a/packages/compiler/test/path-utils.test.ts
+++ b/packages/compiler/test/path-utils.test.ts
@@ -165,13 +165,6 @@ describe("compiler: path utils", () => {
     strictEqual(getBaseFileName("http://server/"), "");
     strictEqual(getBaseFileName("http://server/a"), "a");
     strictEqual(getBaseFileName("http://server/a/"), "a");
-    strictEqual(getBaseFileName("/path/a.ext", ".ext", /*ignoreCase*/ false), "a");
-    strictEqual(getBaseFileName("/path/a.ext", ".EXT", /*ignoreCase*/ true), "a");
-    strictEqual(getBaseFileName("/path/a.ext", "ext", /*ignoreCase*/ false), "a");
-    strictEqual(getBaseFileName("/path/a.b", ".ext", /*ignoreCase*/ false), "a.b");
-    strictEqual(getBaseFileName("/path/a.b", [".b", ".c"], /*ignoreCase*/ false), "a");
-    strictEqual(getBaseFileName("/path/a.c", [".b", ".c"], /*ignoreCase*/ false), "a");
-    strictEqual(getBaseFileName("/path/a.d", [".b", ".c"], /*ignoreCase*/ false), "a.d");
   });
 
   it("getAnyExtensionFromPath", () => {
@@ -180,13 +173,10 @@ describe("compiler: path utils", () => {
     strictEqual(getAnyExtensionFromPath("a.ext"), ".ext");
     strictEqual(getAnyExtensionFromPath("/a.ext"), ".ext");
     strictEqual(getAnyExtensionFromPath("a.ext/"), ".ext");
-    strictEqual(getAnyExtensionFromPath("a.ext", ".ext", /*ignoreCase*/ false), ".ext");
-    strictEqual(getAnyExtensionFromPath("a.ext", ".EXT", /*ignoreCase*/ true), ".ext");
-    strictEqual(getAnyExtensionFromPath("a.ext", "ext", /*ignoreCase*/ false), ".ext");
-    strictEqual(getAnyExtensionFromPath("a.b", ".ext", /*ignoreCase*/ false), "");
-    strictEqual(getAnyExtensionFromPath("a.b", [".b", ".c"], /*ignoreCase*/ false), ".b");
-    strictEqual(getAnyExtensionFromPath("a.c", [".b", ".c"], /*ignoreCase*/ false), ".c");
-    strictEqual(getAnyExtensionFromPath("a.d", [".b", ".c"], /*ignoreCase*/ false), "");
+    strictEqual(getAnyExtensionFromPath(".EXT"), ".ext");
+    strictEqual(getAnyExtensionFromPath("a.EXT"), ".ext");
+    strictEqual(getAnyExtensionFromPath("/a.EXT"), ".ext");
+    strictEqual(getAnyExtensionFromPath("a.EXT/"), ".ext");
   });
 
   it("getPathComponents", () => {

--- a/packages/compiler/test/server/server-file-handling.test.ts
+++ b/packages/compiler/test/server/server-file-handling.test.ts
@@ -3,11 +3,16 @@ import { createTestServerHost } from "../../testing/test-server-host.js";
 
 describe("compiler: server: main file", () => {
   it("finds the main file and finds that main file imports document", async () => {
-    const host = await createTestServerHost({ caseInsensitiveFileSystem: true });
-    // Simulate issue where realpath changes drive letter case different from VS Code.
-    host.compilerHost.realpath = async function (path) {
-      return path.toUpperCase();
-    };
+    const host = await createTestServerHost({
+      // Simulate issue where realpath changes drive letter case different from VS Code.
+      caseInsensitiveFileSystem: true,
+      compilerHostOverrides: {
+        async realpath(path) {
+          return path.toUpperCase();
+        },
+      },
+    });
+
     host.addCadlFile("./main.cadl", 'import "./common.cadl"; import "./subdir/subfile.cadl";');
     host.addCadlFile("./common.cadl", "model Base {}");
     host.addCadlFile("./subdir/empty.cadl", ""); // to force virtual file system to create directory

--- a/packages/compiler/test/server/server-file-handling.test.ts
+++ b/packages/compiler/test/server/server-file-handling.test.ts
@@ -2,8 +2,12 @@ import { deepStrictEqual } from "assert";
 import { createTestServerHost } from "../../testing/test-server-host.js";
 
 describe("compiler: server: main file", () => {
-  it("finds the main file", async () => {
-    const host = await createTestServerHost();
+  it("finds the main file and finds that main file imports document", async () => {
+    const host = await createTestServerHost({ caseInsensitiveFileSystem: true });
+    // Simulate issue where realpath changes drive letter case different from VS Code.
+    host.compilerHost.realpath = async function (path) {
+      return path.toUpperCase();
+    };
     host.addCadlFile("./main.cadl", 'import "./common.cadl"; import "./subdir/subfile.cadl";');
     host.addCadlFile("./common.cadl", "model Base {}");
     host.addCadlFile("./subdir/empty.cadl", ""); // to force virtual file system to create directory

--- a/packages/compiler/testing/test-host.ts
+++ b/packages/compiler/testing/test-host.ts
@@ -20,6 +20,12 @@ import {
   TestHostError,
 } from "./types.js";
 
+export interface TestHostOptions {
+  caseInsensitiveFileSystem?: boolean;
+  excludeTestLib?: boolean;
+  compilerHostOverrides?: Partial<CompilerHost>;
+}
+
 export function resolveVirtualPath(path: string, ...paths: string[]) {
   // NB: We should always resolve an absolute path, and there is no absolute
   // path that works across OSes. This ensures that we can still rely on API
@@ -30,8 +36,14 @@ export function resolveVirtualPath(path: string, ...paths: string[]) {
 
 function createTestCompilerHost(
   virtualFs: Map<string, string>,
-  jsImports: Map<string, Record<string, any>>
+  jsImports: Map<string, Record<string, any>>,
+  options?: TestHostOptions
 ): CompilerHost {
+  const libDirs = [resolveVirtualPath(".cadl/lib")];
+  if (!options?.excludeTestLib) {
+    libDirs.push(resolveVirtualPath(".cadl/test-lib"));
+  }
+
   return {
     async readUrl(url: string) {
       const contents = virtualFs.get(url);
@@ -81,7 +93,7 @@ function createTestCompilerHost(
     },
 
     getLibDirs() {
-      return [resolveVirtualPath(".cadl/lib"), resolveVirtualPath(".cadl/test-lib")];
+      return libDirs;
     },
 
     getExecutionRoot() {
@@ -139,14 +151,16 @@ function createTestCompilerHost(
     pathToFileURL(path: string) {
       return pathToFileURL(path).href;
     },
+
+    ...options?.compilerHostOverrides,
   };
 }
 
-export async function createTestFileSystem(caseInsensitive = false): Promise<TestFileSystem> {
-  const virtualFs = createStringMap<string>(caseInsensitive);
-  const jsImports = createStringMap<Promise<any>>(caseInsensitive);
+export async function createTestFileSystem(options?: TestHostOptions): Promise<TestFileSystem> {
+  const virtualFs = createStringMap<string>(!!options?.caseInsensitiveFileSystem);
+  const jsImports = createStringMap<Promise<any>>(!!options?.caseInsensitiveFileSystem);
 
-  const compilerHost = createTestCompilerHost(virtualFs, jsImports);
+  const compilerHost = createTestCompilerHost(virtualFs, jsImports, options);
   return {
     addCadlFile,
     addJsFile,

--- a/packages/compiler/testing/test-host.ts
+++ b/packages/compiler/testing/test-host.ts
@@ -9,7 +9,7 @@ import { CompilerOptions } from "../core/options.js";
 import { getAnyExtensionFromPath, resolvePath } from "../core/path-utils.js";
 import { createProgram, Program } from "../core/program.js";
 import { CompilerHost, Diagnostic, Type } from "../core/types.js";
-import { getSourceFileKindFromExt } from "../core/util.js";
+import { createStringMap, getSourceFileKindFromExt } from "../core/util.js";
 import { expectDiagnosticEmpty } from "./expect.js";
 import { BasicTestRunner, createTestWrapper } from "./test-utils.js";
 import {
@@ -142,9 +142,9 @@ function createTestCompilerHost(
   };
 }
 
-export async function createTestFileSystem(): Promise<TestFileSystem> {
-  const virtualFs = new Map<string, string>();
-  const jsImports = new Map<string, Promise<any>>();
+export async function createTestFileSystem(caseInsensitive = false): Promise<TestFileSystem> {
+  const virtualFs = createStringMap<string>(caseInsensitive);
+  const jsImports = createStringMap<Promise<any>>(caseInsensitive);
 
   const compilerHost = createTestCompilerHost(virtualFs, jsImports);
   return {

--- a/packages/playground/src/services.ts
+++ b/packages/playground/src/services.ts
@@ -23,7 +23,7 @@ export async function attachServices(host: BrowserHost) {
 
   const { createServer } = await importCadlCompiler();
   const serverLib = createServer(serverHost);
-  const lsConfig = serverLib.initialize({
+  const lsConfig = await serverLib.initialize({
     capabilities: {},
     processId: 1,
     workspaceFolders: [],


### PR DESCRIPTION
```
The issue impacts multi-file specs where common definitions are pulled in
from main.cadl but then not seen when editing another file that relies on
that. We started calling realpath in the compiler on relative path imports,
which led to a mismatch between VS Code's lower-case normalized drive letter
and realpath's canonical upper-case drive letter.

This made the language server think that main.cadl did not import the
current file and decide that it should analyze the current file as its own
entry point.

The fix is to also use realpath in the language server whenever we receive a
path or file URL from the client.
```

Fix #751