### PR TITLE
Fix: Cannot project nested namespace with decorator using types from another namespace 

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-projector-namespace-evaluation_2022-07-25-16-33.json
+++ b/common/changes/@cadl-lang/compiler/fix-projector-namespace-evaluation_2022-07-25-16-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix: Issue with Nested namespace in projection causing versioning library to fail when Service is using nested namespace",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/versioning/fix-projector-namespace-evaluation_2022-07-25-16-33.json
+++ b/common/changes/@cadl-lang/versioning/fix-projector-namespace-evaluation_2022-07-25-16-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/packages/compiler/core/projector.ts
+++ b/packages/compiler/core/projector.ts
@@ -61,7 +61,7 @@ export function createProjector(
     projectType,
   };
   const projectedNamespaces: NamespaceType[] = [];
-  let projectingNamespace = false;
+  let projectingNamespaces = false;
 
   program.currentProjector = projector;
 
@@ -71,10 +71,10 @@ export function createProjector(
       : program.checker.getGlobalNamespaceType()
     : program.checker.getGlobalNamespaceType();
 
-  projectingNamespace = true;
+  projectingNamespaces = true;
   // project all the namespaces first
   projector.projectedGlobalNamespace = projectNamespace(targetGlobalNs) as NamespaceType;
-  projectingNamespace = false;
+  projectingNamespaces = false;
 
   // then project all the types
   for (const ns of projectedNamespaces) {
@@ -98,7 +98,7 @@ export function createProjector(
     switch (type.kind) {
       case "Namespace":
         compilerAssert(
-          projectingNamespace,
+          projectingNamespaces,
           `Namespace ${type.name} should have already been projected.`
         );
         projected = projectNamespace(type);

--- a/packages/compiler/core/projector.ts
+++ b/packages/compiler/core/projector.ts
@@ -61,6 +61,7 @@ export function createProjector(
     projectType,
   };
   const projectedNamespaces: NamespaceType[] = [];
+  let projectingNamespace = false;
 
   program.currentProjector = projector;
 
@@ -70,8 +71,10 @@ export function createProjector(
       : program.checker.getGlobalNamespaceType()
     : program.checker.getGlobalNamespaceType();
 
+  projectingNamespace = true;
   // project all the namespaces first
   projector.projectedGlobalNamespace = projectNamespace(targetGlobalNs) as NamespaceType;
+  projectingNamespace = false;
 
   // then project all the types
   for (const ns of projectedNamespaces) {
@@ -94,6 +97,10 @@ export function createProjector(
     let projected;
     switch (type.kind) {
       case "Namespace":
+        compilerAssert(
+          projectingNamespace,
+          `Namespace ${type.name} should have already been projected.`
+        );
         projected = projectNamespace(type);
         break;
       case "Model":

--- a/packages/compiler/core/projector.ts
+++ b/packages/compiler/core/projector.ts
@@ -94,7 +94,7 @@ export function createProjector(
     let projected;
     switch (type.kind) {
       case "Namespace":
-        compilerAssert(false, "Namespace should have already been projected.");
+        projected = projectNamespace(type);
         break;
       case "Model":
         projected = projectModel(type);
@@ -133,6 +133,10 @@ export function createProjector(
   }
 
   function projectNamespace(ns: NamespaceType): Type {
+    const alreadyProjected = projectedTypes.get(ns);
+    if (alreadyProjected) {
+      return alreadyProjected;
+    }
     const childNamespaces = new Map<string, NamespaceType>();
     const childModels = new Map<string, ModelType>();
     const childOperations = new Map<string, OperationType>();

--- a/packages/compiler/test/checker/projection.test.ts
+++ b/packages/compiler/test/checker/projection.test.ts
@@ -53,6 +53,25 @@ describe("cadl: projections", () => {
     );
   });
 
+  it("projects nested namespaces with decorator refering to another namespace", async () => {
+    testHost.addJsFile("./ref.js", {
+      $ref: () => null,
+    });
+    const code = `
+    import "./ref.js";
+     @ref(Other.MyModel)
+     namespace MyOrg.MyService {
+      @test model Foo {}
+     }
+
+     namespace Other {
+      model MyModel {}
+     }
+     `;
+    const result = (await testProjection(code, [projection("v", 1)])) as ModelType;
+    strictEqual(result.namespace?.namespace?.name, "MyOrg");
+  });
+
   it("takes parameters", async () => {
     const code = `
       @test model Foo {

--- a/packages/versioning/test/versioned-dependencies.test.ts
+++ b/packages/versioning/test/versioned-dependencies.test.ts
@@ -311,6 +311,28 @@ describe("versioning: dependencies", () => {
     const SpreadInstance2 = (v2.projectedTypes.get(Test) as any).baseModel;
     assertHasProperties(SpreadInstance2, ["t", "a", "b"]);
   });
+
+  // Test for https://github.com/microsoft/cadl/issues/760
+  it("have a nested service namespace", async () => {
+    const { MyService } = (await runner.compile(`
+        @serviceTitle("Test")
+        @versionedDependency(Lib.Versions.v1)
+        @test("MyService")
+        namespace MyOrg.MyService {
+
+        }
+
+        @versioned(Versions)
+        namespace Lib {
+          enum Versions {
+            v1: "v1",
+          }
+        }
+      `)) as { MyService: NamespaceType };
+
+    const [v1] = runProjections(runner.program, MyService);
+    ok(v1.projectedTypes.get(MyService));
+  });
 });
 
 function runProjections(program: Program, rootNs: NamespaceType) {


### PR DESCRIPTION
fix #760