### PR TITLE
Feature: Default support for property with enum type

### DIFF
--- a/common/changes/@cadl-lang/openapi3/feature-enum-defaults_2022-07-25-17-39.json
+++ b/common/changes/@cadl-lang/openapi3/feature-enum-defaults_2022-07-25-17-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Added support for default value for properties with enum type.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -74,6 +74,7 @@ import {
   OpenAPI3Parameter,
   OpenAPI3ParameterType,
   OpenAPI3Schema,
+  OpenAPI3SchemaProperty,
   OpenAPI3Server,
   OpenAPI3ServerVariable,
 } from "./types.js";
@@ -877,6 +878,8 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
         return type.value;
       case "Tuple":
         return type.values.map(getDefaultValue);
+      case "EnumMember":
+        return type.value ?? type.name;
       default:
         reportDiagnostic(program, {
           code: "invalid-default",
@@ -935,7 +938,6 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
         continue;
       }
 
-      const description = getDoc(program, prop);
       if (!prop.optional) {
         if (!modelSchema.required) {
           modelSchema.required = [];
@@ -943,27 +945,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
         modelSchema.required.push(name);
       }
 
-      // Apply decorators on the property to the type's schema
-      const property: any = (modelSchema.properties[name] = applyIntrinsicDecorators(
-        prop,
-        getSchemaOrRef(prop.type)
-      ));
-      if (description) {
-        property.description = description;
-      }
-
-      if (prop.default) {
-        property.default = getDefaultValue(prop.default);
-      }
-
-      // Should the property be marked as readOnly?
-      const vis = getVisibility(program, prop);
-      if (vis && vis.includes("read") && vis.length == 1) {
-        property.readOnly = true;
-      }
-
-      // Attach any additional OpenAPI extensions
-      attachExtensions(program, prop, modelSchema.properties[name]);
+      modelSchema.properties[name] = resolveProperty(prop);
     }
 
     // Special case: if a model type extends a single *templated* base type and
@@ -991,6 +973,42 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     // Attach any OpenAPI extensions
     attachExtensions(program, model, modelSchema);
     return modelSchema;
+  }
+
+  function resolveProperty(prop: ModelTypeProperty): OpenAPI3SchemaProperty {
+    const description = getDoc(program, prop);
+
+    const schema = getSchemaOrRef(prop.type);
+    // Apply decorators on the property to the type's schema
+    const additionalProps: Partial<OpenAPI3Schema> = applyIntrinsicDecorators(prop, {});
+    if (description) {
+      additionalProps.description = description;
+    }
+
+    if (prop.default) {
+      additionalProps.default = getDefaultValue(prop.default);
+    }
+
+    // Should the property be marked as readOnly?
+    const vis = getVisibility(program, prop);
+    if (vis && vis.includes("read") && vis.length == 1) {
+      additionalProps.readOnly = true;
+    }
+
+    // Attach any additional OpenAPI extensions
+    attachExtensions(program, prop, additionalProps);
+    if ("$ref" in schema) {
+      if (Object.keys(additionalProps).length === 0) {
+        return schema;
+      } else {
+        return {
+          allOf: [schema],
+          ...additionalProps,
+        };
+      }
+    } else {
+      return { ...schema, ...additionalProps };
+    }
   }
 
   function attachExtensions(program: Program, type: Type, emitObject: any) {

--- a/packages/openapi3/src/types.ts
+++ b/packages/openapi3/src/types.ts
@@ -503,6 +503,11 @@ export type OpenAPI3Schema = Extensions & {
   /** Allows sending a null value for the defined schema. Default value is false. */
   nullable?: boolean;
 
+  /**
+   * Property is readonly.
+   */
+  readOnly?: boolean;
+
   /** Adds support for polymorphism. The discriminator is an object name that is used to differentiate between other schemas which may satisfy the payload description  */
   discriminator?: OpenAPI3Discriminator;
 

--- a/packages/openapi3/test/openapi-output.test.ts
+++ b/packages/openapi3/test/openapi-output.test.ts
@@ -177,6 +177,35 @@ describe("openapi3: definitions", () => {
     });
   });
 
+  it("specify default value on enum property", async () => {
+    const res = await oapiForModel(
+      "Foo",
+      `
+      model Foo {
+        optionalEnum?: MyEnum = MyEnum.a;
+      };
+      
+      enum MyEnum {
+        a: "a-value",
+        b,
+      }
+      `
+    );
+
+    ok(res.isRef);
+    ok(res.schemas.Foo, "expected definition named Foo");
+    ok(res.schemas.MyEnum, "expected definition named MyEnum");
+    deepStrictEqual(res.schemas.Foo, {
+      type: "object",
+      properties: {
+        optionalEnum: {
+          allOf: [{ $ref: "#/components/schemas/MyEnum" }],
+          default: "a-value",
+        },
+      },
+    });
+  });
+
   it("emits models extended from models when parent is emitted", async () => {
     const res = await openApiFor(
       `

--- a/packages/samples/optional/optional.cadl
+++ b/packages/samples/optional/optional.cadl
@@ -9,6 +9,7 @@ model HasOptional {
   optionalBoolean?: boolean = true;
   optionalArray?: string[] = ["foo", "bar"];
   optionalUnion?: "foo" | "bar" = "foo";
+  optionalEnum?: MyEnum = MyEnum.a;
 }
 
 @route("/test")
@@ -17,4 +18,9 @@ namespace OptionalMethods {
     @query queryString?: string = "defaultQueryString",
     @body queryNumber?: int64 = 123
   ): HasOptional;
+}
+
+enum MyEnum {
+  a,
+  b,
 }

--- a/packages/samples/test/output/grpc-kiosk-example/openapi.json
+++ b/packages/samples/test/output/grpc-kiosk-example/openapi.json
@@ -404,11 +404,19 @@
             "description": "name of device hardware"
           },
           "size": {
-            "$ref": "#/components/schemas/ScreenSize",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ScreenSize"
+              }
+            ],
             "description": "screen size"
           },
           "location": {
-            "$ref": "#/components/schemas/LatLng",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LatLng"
+              }
+            ],
             "description": "kiosk location"
           },
           "create_time": {

--- a/packages/samples/test/output/grpc-library-example/openapi.json
+++ b/packages/samples/test/output/grpc-library-example/openapi.json
@@ -445,7 +445,11 @@
         "type": "object",
         "properties": {
           "name": {
-            "$ref": "#/components/schemas/shelf_name",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/shelf_name"
+              }
+            ],
             "description": "The resource name of the shelf.\nShelf names have the form `shelves/{shelf_id}`.\nThe name is ignored when creating a shelf."
           },
           "theme": {
@@ -508,7 +512,11 @@
         "type": "object",
         "properties": {
           "name": {
-            "$ref": "#/components/schemas/book_name",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/book_name"
+              }
+            ],
             "description": "The resource name of the book.\nBook names have the form `shelves/{shelf_id}/books/{book_id}`.\nThe name is ignored when creating a book."
           },
           "author": {

--- a/packages/samples/test/output/optional/openapi.json
+++ b/packages/samples/test/output/optional/openapi.json
@@ -85,8 +85,23 @@
             ],
             "x-cadl-name": "foo | bar",
             "default": "foo"
+          },
+          "optionalEnum": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MyEnum"
+              }
+            ],
+            "default": "a"
           }
         }
+      },
+      "MyEnum": {
+        "type": "string",
+        "enum": [
+          "a",
+          "b"
+        ]
       }
     }
   }

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -1057,7 +1057,11 @@
             "description": "The items on this page"
           },
           "nextLink": {
-            "$ref": "#/components/schemas/Rest.ResourceLocation_Pet",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Rest.ResourceLocation_Pet"
+              }
+            ],
             "description": "The link to the next page of items"
           }
         },
@@ -1110,7 +1114,11 @@
             "description": "The items on this page"
           },
           "nextLink": {
-            "$ref": "#/components/schemas/Rest.ResourceLocation_Checkup",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Rest.ResourceLocation_Checkup"
+              }
+            ],
             "description": "The link to the next page of items"
           }
         },
@@ -1190,7 +1198,11 @@
             "description": "The items on this page"
           },
           "nextLink": {
-            "$ref": "#/components/schemas/Rest.ResourceLocation_Toy",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Rest.ResourceLocation_Toy"
+              }
+            ],
             "description": "The link to the next page of items"
           }
         },
@@ -1262,7 +1274,11 @@
             "description": "The items on this page"
           },
           "nextLink": {
-            "$ref": "#/components/schemas/Rest.ResourceLocation_Owner",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Rest.ResourceLocation_Owner"
+              }
+            ],
             "description": "The link to the next page of items"
           }
         },


### PR DESCRIPTION
fix #130 

There wasn't anything left in the compiler for this, the type releation PR already relaxed the validation allowing enum members. This just needed emitter support


Also fix the fact that we weren't producing valid OpenAPI3 when adding properties next to `$ref`