### PR TITLE
Make response description OpenAPI output more consistent

### DIFF
--- a/common/changes/@cadl-lang/openapi3/response-description-consistency_2022-07-25-20-35.json
+++ b/common/changes/@cadl-lang/openapi3/response-description-consistency_2022-07-25-20-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Make response descriptions more consistent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/response-description-consistency_2022-07-25-20-35.json
+++ b/common/changes/@cadl-lang/rest/response-description-consistency_2022-07-25-20-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Make response descriptions more consistent",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -481,7 +481,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
 
   function getResponseDescriptionForStatusCode(statusCode: string) {
     if (statusCode === "default") {
-      return "An unexpected error response";
+      return "An unexpected error response.";
     }
     return getStatusCodeDescription(statusCode) ?? "unknown";
   }

--- a/packages/rest/lib/http.cadl
+++ b/packages/rest/lib/http.cadl
@@ -4,14 +4,11 @@ namespace Cadl.Http;
 
 using Private;
 
-@doc("Http response with status code")
 model Response<Status> {
   @doc("The status code.")
   @statusCode
-  _: Status;
+  statusCode: Status;
 }
-
-@doc("The request has succeeded.")
 model OkResponse<Body> is Response<200> {
   @doc("The reponse body.")
   @body
@@ -25,30 +22,21 @@ model LocationHeader {
   location: string;
 }
 
-@doc("The request has succeeded and a new resource has been created as a result.")
+// Don't put @doc on these, change `getStatusCodeDescription` implementation
+// to update the default descriptions for these status codes. This ensures
+// that we get consistent emit between different ways to spell the same
+// responses in Cadl.
 model CreatedResponse is Response<201> {}
-
-@doc("The request has been received but not yet acted upon.")
 model AcceptedResponse is Response<202> {}
-
-@doc("There is no content to send for this request, but the headers may be useful. ")
 model NoContentResponse is Response<204> {}
-
-@doc("The URL of the requested resource has been changed permanently. The new URL is given in the response.")
 model MovedResponse is Response<301> {
   ...LocationHeader;
 }
-
-@doc("This is used for caching purposes.")
 model NotModifiedResponse is Response<304> {}
-
-@doc("The server could not understand the request due to invalid syntax.")
+model BadRequestResponse is Response<400> {}
 model UnauthorizedResponse is Response<401> {}
-
-@doc("The server can not find the requested resource.")
+model ForbiddenResponse is Response<403> {}
 model NotFoundResponse is Response<404> {}
-
-@doc("This response is sent when a request conflicts with the current state of the server.")
 model ConflictResponse is Response<409> {}
 
 // Produces a new model with the same properties as T, but with @query,

--- a/packages/rest/src/http/decorators.ts
+++ b/packages/rest/src/http/decorators.ts
@@ -184,35 +184,35 @@ export function getStatusCodes(program: Program, entity: Type): string[] {
   return program.stateMap(statusCodeKey).get(entity) ?? [];
 }
 
-// Note: these descriptions come from https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+// Reference: https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
 export function getStatusCodeDescription(statusCode: string) {
   switch (statusCode) {
     case "200":
-      return "Ok";
+      return "The request has succeeded.";
     case "201":
-      return "Created";
+      return "The request has succeeded and a new resource has been created as a result.";
     case "202":
-      return "Accepted";
+      return "The request has been accepted for processing, but processing has not yet completed.";
     case "204":
-      return "No Content";
+      return "There is no content to send for this request, but the headers may be useful. ";
     case "301":
-      return "Moved Permanently";
+      return "The URL of the requested resource has been changed permanently. The new URL is given in the response.";
     case "304":
-      return "Not Modified";
+      return "The client has made a conditional request and the resource has not been modified.";
     case "400":
-      return "Bad Request";
+      return "The server could not understand the request due to invalid syntax.";
     case "401":
-      return "Unauthorized";
+      return "Access is unauthorized.";
     case "403":
-      return "Forbidden";
+      return "Access is forbidden";
     case "404":
-      return "Not Found";
+      return "The server cannot find the requested resource.";
     case "409":
-      return "Conflict";
+      return "The request conflicts with the current state of the server.";
     case "412":
-      return "Precondition Failed";
+      return "Precondition failed.";
     case "503":
-      return "Service Unavailable";
+      return "Service unavailable.";
   }
 
   switch (statusCode.charAt(0)) {

--- a/packages/rest/src/http/responses.ts
+++ b/packages/rest/src/http/responses.ts
@@ -137,7 +137,7 @@ function processResponseType(
     const response: HttpOperationResponse = responses[statusCode] ?? {
       statusCode: statusCode,
       type: responseModel,
-      description: getResponseDescription(program, responseModel, statusCode),
+      description: getResponseDescription(program, responseModel, statusCode, bodyModel),
       responses: [],
     };
 
@@ -301,12 +301,22 @@ function getResponseBody(
 
 function getResponseDescription(
   program: Program,
-  responseModel: Type,
-  statusCode: string
+  responseType: Type,
+  statusCode: string,
+  bodyType: Type | undefined
 ): string | undefined {
-  const desc = getDoc(program, responseModel);
-  if (desc) {
-    return desc;
+  // NOTE: If the response type is an envelope and not the same as the body
+  // type, then use its @doc as the response description. However, if the
+  // response type is the same as the body type, then use the default status
+  // code description and don't duplicate the schema description of the body
+  // as the response description. This allows more freedom to change how
+  // Cadl is expressed in semantically equivalent ways without causing
+  // the output to change unnecessarily.
+  if (responseType !== bodyType) {
+    const desc = getDoc(program, responseType);
+    if (desc) {
+      return desc;
+    }
   }
 
   return getStatusCodeDescription(statusCode);

--- a/packages/samples/test/output/binary/openapi.json
+++ b/packages/samples/test/output/binary/openapi.json
@@ -12,7 +12,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -39,7 +39,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "text/plain": {
                 "schema": {
@@ -68,7 +68,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/octect-stream": {
                 "schema": {
@@ -97,7 +97,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "image/png": {
                 "schema": {

--- a/packages/samples/test/output/documentation/openapi.json
+++ b/packages/samples/test/output/documentation/openapi.json
@@ -12,7 +12,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -40,7 +40,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Response from @doc",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -50,7 +50,7 @@
             }
           },
           "default": {
-            "description": "Error from @doc",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -68,7 +68,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -78,7 +78,7 @@
             }
           },
           "404": {
-            "description": "Not found",
+            "description": "The server cannot find the requested resource.",
             "content": {
               "application/json": {
                 "schema": {
@@ -106,7 +106,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Response from @doc",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -116,7 +116,7 @@
             }
           },
           "404": {
-            "description": "Not Found",
+            "description": "The server cannot find the requested resource.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/documentation/openapi.json
+++ b/packages/samples/test/output/documentation/openapi.json
@@ -22,7 +22,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -50,7 +50,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -88,7 +88,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -126,7 +126,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/grpc-kiosk-example/openapi.json
+++ b/packages/samples/test/output/grpc-kiosk-example/openapi.json
@@ -30,7 +30,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -69,7 +69,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -111,7 +111,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -144,7 +144,7 @@
             "description": "There is no content to send for this request, but the headers may be useful. "
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -176,7 +176,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -247,7 +247,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -280,7 +280,7 @@
             "description": "There is no content to send for this request, but the headers may be useful. "
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -309,7 +309,7 @@
             "description": "There is no content to send for this request, but the headers may be useful. "
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -365,7 +365,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/grpc-kiosk-example/openapi.json
+++ b/packages/samples/test/output/grpc-kiosk-example/openapi.json
@@ -20,7 +20,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Describes a hardware device that can display signs.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -30,7 +30,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -59,7 +59,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -69,7 +69,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -101,7 +101,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Describes a hardware device that can display signs.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -111,7 +111,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -141,10 +141,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "There is no content to send for this request, but the headers may be useful. "
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -166,7 +166,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Describes a digital sign.\nSigns can include text, images, or both.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -176,7 +176,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -205,7 +205,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A successful response.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -237,7 +237,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Describes a digital sign.\nSigns can include text, images, or both.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -247,7 +247,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -277,10 +277,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "There is no content to send for this request, but the headers may be useful. "
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -306,10 +306,10 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "There is no content to send for this request, but the headers may be useful. "
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -355,7 +355,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A successful response.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -365,7 +365,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/grpc-library-example/openapi.json
+++ b/packages/samples/test/output/grpc-library-example/openapi.json
@@ -20,7 +20,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "A Shelf contains a collection of books with a theme.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -30,7 +30,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -67,7 +67,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Response message for LibraryService.ListShelves.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -77,7 +77,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -103,7 +103,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A Shelf contains a collection of books with a theme.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -113,7 +113,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -140,7 +140,7 @@
             "description": "No body returned"
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -166,7 +166,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A Shelf contains a collection of books with a theme.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -176,7 +176,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -212,7 +212,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A single book in the library.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -222,7 +222,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -262,7 +262,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Response message for LibraryService.ListBooks.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -272,7 +272,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -298,7 +298,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A single book in the library.",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -308,7 +308,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -335,7 +335,7 @@
             "description": "No body returned"
           },
           "default": {
-            "description": "An unexpected error response.",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/grpc-library-example/openapi.json
+++ b/packages/samples/test/output/grpc-library-example/openapi.json
@@ -30,7 +30,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -77,7 +77,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -113,7 +113,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -140,7 +140,7 @@
             "description": "No body returned"
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -176,7 +176,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -222,7 +222,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -272,7 +272,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -308,7 +308,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -335,7 +335,7 @@
             "description": "No body returned"
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/nested/openapi.json
+++ b/packages/samples/test/output/nested/openapi.json
@@ -39,7 +39,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/nullable/openapi.json
+++ b/packages/samples/test/output/nullable/openapi.json
@@ -22,7 +22,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/openapi-extensions/openapi.json
+++ b/packages/samples/test/output/openapi-extensions/openapi.json
@@ -12,7 +12,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/optional/openapi.json
+++ b/packages/samples/test/output/optional/openapi.json
@@ -22,7 +22,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/petstore/openapi.json
+++ b/packages/samples/test/output/petstore/openapi.json
@@ -18,10 +18,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -62,7 +62,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -100,7 +100,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -126,7 +126,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -180,7 +180,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/petstore/openapi.json
+++ b/packages/samples/test/output/petstore/openapi.json
@@ -21,7 +21,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -62,7 +62,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -100,7 +100,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -126,7 +126,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -180,7 +180,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/polymorphism/openapi.json
+++ b/packages/samples/test/output/polymorphism/openapi.json
@@ -12,7 +12,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -17,7 +17,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -48,7 +48,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -110,7 +110,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -156,7 +156,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Paged response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -192,7 +192,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -244,7 +244,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Paged response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -277,7 +277,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -308,7 +308,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -353,7 +353,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -393,7 +393,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Paged response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -429,7 +429,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -463,7 +463,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -505,7 +505,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -553,7 +553,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Paged response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -586,7 +586,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -617,7 +617,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -679,7 +679,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -725,7 +725,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Paged response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -761,7 +761,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -813,7 +813,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Paged response",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -846,7 +846,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -877,7 +877,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -27,7 +27,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -58,7 +58,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -91,7 +91,7 @@
             "description": "Resource deleted successfully."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -130,7 +130,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -166,7 +166,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -212,7 +212,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -254,7 +254,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -287,7 +287,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -318,7 +318,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -363,7 +363,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -403,7 +403,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -439,7 +439,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -473,7 +473,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -525,7 +525,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -563,7 +563,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -596,7 +596,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -627,7 +627,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -660,7 +660,7 @@
             "description": "Resource deleted successfully."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -699,7 +699,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -735,7 +735,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -781,7 +781,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -823,7 +823,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -856,7 +856,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -887,7 +887,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/signatures/openapi.json
+++ b/packages/samples/test/output/signatures/openapi.json
@@ -22,7 +22,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -51,7 +51,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -98,7 +98,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -127,7 +127,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/signatures/openapi.json
+++ b/packages/samples/test/output/signatures/openapi.json
@@ -32,7 +32,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -61,7 +61,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -108,7 +108,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -137,7 +137,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/simple/openapi.json
+++ b/packages/samples/test/output/simple/openapi.json
@@ -21,7 +21,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -48,7 +48,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/tags/openapi.json
+++ b/packages/samples/test/output/tags/openapi.json
@@ -52,7 +52,7 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "There is no content to send for this request, but the headers may be useful. "
           }
         }
       },
@@ -77,7 +77,7 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "There is no content to send for this request, but the headers may be useful. "
           }
         }
       }
@@ -89,7 +89,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -125,7 +125,7 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "There is no content to send for this request, but the headers may be useful. "
           }
         }
       }
@@ -152,7 +152,7 @@
         ],
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "There is no content to send for this request, but the headers may be useful. "
           }
         }
       }

--- a/packages/samples/test/output/testserver/body-boolean/openapi.json
+++ b/packages/samples/test/output/testserver/body-boolean/openapi.json
@@ -26,7 +26,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -46,7 +46,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -90,7 +90,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -117,7 +117,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -158,7 +158,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -187,7 +187,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/body-boolean/openapi.json
+++ b/packages/samples/test/output/testserver/body-boolean/openapi.json
@@ -13,7 +13,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -26,7 +26,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -43,10 +43,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -77,7 +77,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -90,7 +90,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -107,7 +107,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -117,7 +117,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -148,7 +148,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -158,7 +158,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -177,7 +177,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -187,7 +187,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/body-complex/openapi.json
+++ b/packages/samples/test/output/testserver/body-complex/openapi.json
@@ -23,7 +23,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -40,10 +40,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -81,7 +81,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -98,10 +98,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -139,7 +139,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -156,10 +156,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -197,7 +197,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -214,10 +214,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -255,7 +255,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -272,10 +272,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -313,7 +313,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -330,10 +330,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -371,7 +371,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -388,10 +388,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -429,7 +429,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -446,10 +446,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -487,7 +487,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -504,10 +504,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -545,7 +545,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -562,10 +562,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -603,7 +603,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -620,10 +620,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -661,7 +661,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -678,10 +678,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -719,7 +719,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -736,10 +736,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/body-complex/openapi.json
+++ b/packages/samples/test/output/testserver/body-complex/openapi.json
@@ -23,7 +23,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -43,7 +43,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -81,7 +81,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -101,7 +101,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -139,7 +139,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -159,7 +159,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -197,7 +197,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -217,7 +217,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -255,7 +255,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -275,7 +275,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -313,7 +313,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -333,7 +333,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -371,7 +371,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -391,7 +391,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -429,7 +429,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -449,7 +449,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -487,7 +487,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -507,7 +507,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -545,7 +545,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -565,7 +565,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -603,7 +603,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -623,7 +623,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -661,7 +661,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -681,7 +681,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -719,7 +719,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -739,7 +739,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/body-string/openapi.json
+++ b/packages/samples/test/output/testserver/body-string/openapi.json
@@ -32,7 +32,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -52,10 +52,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -101,7 +101,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -121,10 +121,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -171,7 +171,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -191,10 +191,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -241,7 +241,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -261,10 +261,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -309,7 +309,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -329,10 +329,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -374,7 +374,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -394,10 +394,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -438,7 +438,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -458,10 +458,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/body-string/openapi.json
+++ b/packages/samples/test/output/testserver/body-string/openapi.json
@@ -32,7 +32,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -55,7 +55,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -101,7 +101,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -124,7 +124,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -171,7 +171,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -194,7 +194,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -241,7 +241,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -264,7 +264,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -309,7 +309,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -332,7 +332,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -374,7 +374,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -397,7 +397,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -438,7 +438,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -461,7 +461,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/body-time/openapi.json
+++ b/packages/samples/test/output/testserver/body-time/openapi.json
@@ -24,7 +24,7 @@
             }
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {
@@ -41,10 +41,10 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok"
+            "description": "The request has succeeded."
           },
           "default": {
-            "description": "Error",
+            "description": "An unexpected error response",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/body-time/openapi.json
+++ b/packages/samples/test/output/testserver/body-time/openapi.json
@@ -24,7 +24,7 @@
             }
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {
@@ -44,7 +44,7 @@
             "description": "The request has succeeded."
           },
           "default": {
-            "description": "An unexpected error response",
+            "description": "An unexpected error response.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/use-versioned-lib/openapi.json
+++ b/packages/samples/test/output/use-versioned-lib/openapi.json
@@ -12,7 +12,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/visibility/openapi.json
+++ b/packages/samples/test/output/visibility/openapi.json
@@ -32,7 +32,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -50,7 +50,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
@@ -75,7 +75,7 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "Ok",
+            "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
1. Remove the `@doc` comments on XxxResponse and rely on getStatusCodeDescription for the default response description for each status code.

2. Update getStatusCodeDescription defaults to match removed `@doc` comments.

3. Don't use the response type's `@doc` if the response type is also the body type as this duplicates the body schema description.

Taken together, these leave a lot more flexibility in writing Cadl in semantically equivalent ways without making unnecessary and insignificant changes to response descriptions.

This change is a precursor to making OkResponse non-generic (https://github.com/Azure/cadl-azure/issues/545). Reviewing this separately will make reviewing that much easier.