### PR TITLE
Improve language configuration for auto indent

### DIFF
--- a/common/changes/@cadl-lang/compiler/tweak-language-config_2022-07-26-16-57.json
+++ b/common/changes/@cadl-lang/compiler/tweak-language-config_2022-07-26-16-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Improve language configuration to help with comment indentation",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/server/language-config.ts
+++ b/packages/compiler/server/language-config.ts
@@ -15,6 +15,7 @@ export const CadlLanguageConfiguration = {
     { open: "{", close: "}" },
     { open: "[", close: "]" },
     { open: "(", close: ")" },
+    { open: "/**", close: " */", notIn: ["string"] },
     // NOTE: quotes omitted here intentionally for now as they interfere with typing """
   ],
   surroundingPairs: [
@@ -22,5 +23,76 @@ export const CadlLanguageConfiguration = {
     { open: "[", close: "]" },
     { open: "(", close: ")" },
     { open: '"', close: '"' },
+  ],
+  indentationRules: {
+    decreaseIndentPattern: {
+      pattern: "^((?!.*?/\\*).*\\*/)?\\s*[\\}\\]].*$",
+    },
+    increaseIndentPattern: {
+      pattern: "^((?!//).)*(\\{([^}\"'`/]*|(\\t|[ ])*//.*)|\\([^)\"'`/]*|\\[[^\\]\"'`/]*)$",
+    },
+    // e.g.  * ...| or */| or *-----*/|
+    unIndentedLinePattern: {
+      pattern:
+        "^(\\t|[ ])*[ ]\\*[^/]*\\*/\\s*$|^(\\t|[ ])*[ ]\\*/\\s*$|^(\\t|[ ])*[ ]\\*([ ]([^\\*]|\\*(?!/))*)?$",
+    },
+  },
+  onEnterRules: [
+    {
+      // e.g. /** | */
+      beforeText: {
+        pattern: "^\\s*/\\*\\*(?!/)([^\\*]|\\*(?!/))*$",
+      },
+      afterText: {
+        pattern: "^\\s*\\*/$",
+      },
+      action: {
+        indent: "indentOutdent",
+        appendText: " * ",
+      },
+    },
+    {
+      // e.g. /** ...|
+      beforeText: {
+        pattern: "^\\s*/\\*\\*(?!/)([^\\*]|\\*(?!/))*$",
+      },
+      action: {
+        indent: "none",
+        appendText: " * ",
+      },
+    },
+    {
+      // e.g.  * ...|
+      beforeText: {
+        pattern: "^(\\t|[ ])*[ ]\\*([ ]([^\\*]|\\*(?!/))*)?$",
+      },
+      previousLineText: {
+        pattern: "(?=^(\\s*(/\\*\\*|\\*)).*)(?=(?!(\\s*\\*/)))",
+      },
+      action: {
+        indent: "none",
+        appendText: "* ",
+      },
+    },
+    {
+      // e.g.  */|
+      beforeText: {
+        pattern: "^(\\t|[ ])*[ ]\\*/\\s*$",
+      },
+      action: {
+        indent: "none",
+        removeText: 1,
+      },
+    },
+    {
+      // e.g.  *-----*/|
+      beforeText: {
+        pattern: "^(\\t|[ ])*[ ]\\*[^/]*\\*/\\s*$",
+      },
+      action: {
+        indent: "none",
+        removeText: 1,
+      },
+    },
   ],
 } as const;

--- a/packages/compiler/server/language-config.ts
+++ b/packages/compiler/server/language-config.ts
@@ -24,6 +24,7 @@ export const CadlLanguageConfiguration = {
     { open: "(", close: ")" },
     { open: '"', close: '"' },
   ],
+  // From https://github.com/Microsoft/vscode/blob/main/extensions/javascript/javascript-language-configuration.json
   indentationRules: {
     decreaseIndentPattern: {
       pattern: "^((?!.*?/\\*).*\\*/)?\\s*[\\}\\]].*$",


### PR DESCRIPTION
Copied some `onEnterRules` and `indentationRules` from the javascript language configuaration so we could have automatic indentation and typing of `*` in doc comment 

https://github.com/Microsoft/vscode/blob/main/extensions/javascript/javascript-language-configuration.json
![auto-comment](https://user-images.githubusercontent.com/1031227/181065784-9f52622d-741b-4ce1-95e6-f9777203430f.gif)
