### PR TITLE
Remove unnecessary addition of derived models to effective type candidates

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-effective-type2_2022-07-26-20-24.json
+++ b/common/changes/@cadl-lang/compiler/fix-effective-type2_2022-07-26-20-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -4206,8 +4206,8 @@ const IntrinsicTypeRelations = new IntrinsicTypeRelationTree({
 
 /**
  * Find all named models that could have been the source of the given
- * property. This includes all property sources in a chain and their derived
- * models.
+ * property. This includes the named parents of all property sources in a
+ * chain.
  */
 function getNamedSourceModels(property: ModelTypeProperty): Set<ModelType> | undefined {
   if (!property.sourceProperty) {
@@ -4218,11 +4218,6 @@ function getNamedSourceModels(property: ModelTypeProperty): Set<ModelType> | und
   for (let p: ModelTypeProperty | undefined = property; p; p = p.sourceProperty) {
     if (p.model?.name) {
       set.add(p.model);
-      for (const derived of p.model.derivedModels) {
-        if (derived.name) {
-          set.add(derived);
-        }
-      }
     }
   }
 

--- a/packages/compiler/test/checker/effective-type.test.ts
+++ b/packages/compiler/test/checker/effective-type.test.ts
@@ -69,7 +69,7 @@ describe("compiler: effective type", () => {
     expectIdenticalTypes(effective, Source);
   });
 
-  it("indirect spread and filter", async () => {
+  it("indirect spread, intersect, and filter", async () => {
     testHost.addCadlFile(
       "main.cadl",
       `
@@ -187,6 +187,36 @@ describe("compiler: effective type", () => {
       }
 
       @test model Derived extends Base {
+        @remove test: string;
+      }
+      `
+    );
+    const { Base, Derived } = await testHost.compile("./");
+    strictEqual(Base.kind, "Model" as const);
+    strictEqual(Derived.kind, "Model" as const);
+
+    const propType = Derived.properties.get("test")?.type;
+    strictEqual(propType?.kind, "Model" as const);
+
+    const effective = testHost.program.checker.getEffectiveModelType(Derived, removeFilter);
+    expectIdenticalTypes(effective, Base);
+  });
+
+  it("extend and filter two levels", async () => {
+    testHost.addCadlFile(
+      "main.cadl",
+      `
+      import "./remove.js";
+
+      @test model Base {
+        prop: string;
+      }
+
+      @test model Middle extends Base {
+        @remove prop2: string;
+      }
+
+      @test model Derived extends Middle {
         @remove test: string;
       }
       `


### PR DESCRIPTION
It turns out that code I put in to replace the isDerivedFrom checks in the prior implementation of getEffectiveType isn't needed. This is great because I was going back to it because I realized it should have been recursive, and to put a comment where code would need to change with property overrides but then I ended up deleting the code. :)

Also added an additional test with another level of inheritance and renamed another to match the naming of nearby tests.