### PR TITLE
Fix regression in getEffectiveModelType

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-effective-type2_2022-07-27-13-53.json
+++ b/common/changes/@cadl-lang/compiler/fix-effective-type2_2022-07-27-13-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -4053,8 +4053,19 @@ export function createChecker(program: Program): Checker {
         continue;
       }
 
+      // Add any derived types we observe to both sides. A derived type can
+      // substitute for a base type in these sets because derived types have
+      // all the properties of their bases.
+      //
+      // NOTE: Once property overrides are allowed, this code will need to
+      // be updated to check that the current property is not overridden by
+      // the derived type before adding it here. An override would invalidate
+      // this substitution.
+      addDerivedModels(sources, candidates);
+      addDerivedModels(candidates, sources);
+
       // remove candidates that are not common to this property
-      for (const element of sources) {
+      for (const element of candidates) {
         if (!sources.has(element)) {
           candidates.delete(element);
         }
@@ -4222,6 +4233,23 @@ function getNamedSourceModels(property: ModelTypeProperty): Set<ModelType> | und
   }
 
   return set;
+}
+
+/**
+ * Find derived types of `models` in `possiblyDerivedModels` and add them to
+ * `models`.
+ */
+function addDerivedModels(models: Set<ModelType>, possiblyDerivedModels: ReadonlySet<ModelType>) {
+  for (const element of possiblyDerivedModels) {
+    if (!models.has(element)) {
+      for (let t = element.baseModel; t; t = t.baseModel) {
+        if (models.has(t)) {
+          models.add(element);
+          break;
+        }
+      }
+    }
+  }
 }
 
 export function isNeverIndexer(indexer: ModelIndexer): indexer is NeverIndexer {


### PR DESCRIPTION
The last change that deleted code went in the wrong direction. Tests were passing due to unfortunate coincidences which then masked what the deleted code needed to accomplish.

However, take a better approach to the deleted code to only consider derived types that are observed as sources. The deleted approach would have needed to do a deep recursive walk of derived models.

Also, add comment on impact of property overrides in the future for this code.