### PR TITLE
Add `ResourceCreateOrReplace` and `createsOrReplacesResource`

### DIFF
--- a/common/changes/@cadl-lang/rest/create-or-replace_2022-07-27-15-27.json
+++ b/common/changes/@cadl-lang/rest/create-or-replace_2022-07-27-15-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add `ResourceCreateOrReplace` type and `createsOrReplaces` decorator to model an \"upsert\" operation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -48,6 +48,16 @@ model ResourceCreatedResponse<T> {
   @body body: T;
 }
 
+interface ResourceCreateOrReplace<TResource, TError> {
+  @autoRoute
+  @doc("Creates or replaces a instance of the resource.")
+  @createsOrReplacesResource(TResource)
+  createOrReplace(
+    ...ResourceParameters<TResource>,
+    @body resource: ResourceCreateModel<TResource>
+  ): TResource | ResourceCreatedResponse<TResource> | TError;
+}
+
 @friendlyName("{name}Update", TResource)
 model ResourceCreateOrUpdateModel<TResource> is OptionalProperties<UpdateableProperties<DefaultKeyVisibility<TResource, "read">>> {}
 

--- a/packages/rest/src/http/route.ts
+++ b/packages/rest/src/http/route.ts
@@ -573,7 +573,8 @@ function validateRouteUnique(diagnostics: DiagnosticCollector, operations: Opera
 const resourceOperationToVerb: any = {
   read: "get",
   create: "post",
-  createOrUpdate: "put",
+  createOrUpdate: "patch",
+  createOrReplace: "put",
   update: "patch",
   delete: "delete",
   list: "get",

--- a/packages/rest/src/rest.ts
+++ b/packages/rest/src/rest.ts
@@ -196,8 +196,9 @@ export function getSegmentSeparator(program: Program, entity: Type): string | un
 
 export type ResourceOperations =
   | "read"
-  | "createOrUpdate"
   | "create"
+  | "createOrReplace"
+  | "createOrUpdate"
   | "update"
   | "delete"
   | "list";
@@ -269,6 +270,26 @@ export function $createsResource(
   context.call($segmentOf, entity, resourceType);
 
   setResourceOperation(context, entity, resourceType, "create", createsResourceDecorator);
+}
+
+const createsOrReplacesResourceDecorator = createDecoratorDefinition({
+  name: "@createsOrReplacesResource",
+  target: "Operation",
+  args: [{ kind: "Model" }],
+} as const);
+
+export function $createsOrReplacesResource(
+  context: DecoratorContext,
+  entity: OperationType,
+  resourceType: ModelType
+) {
+  setResourceOperation(
+    context,
+    entity,
+    resourceType,
+    "createOrReplace",
+    createsOrReplacesResourceDecorator
+  );
 }
 
 const createsOrUpdatesResourceDecorator = createDecoratorDefinition({

--- a/packages/rest/test/resource.test.ts
+++ b/packages/rest/test/resource.test.ts
@@ -162,6 +162,58 @@ describe("rest: resources", () => {
     ]);
   });
 
+  it("resources: standard lifecycle operations have expected paths and verbs", async () => {
+    const routes = await getRoutesFor(
+      `
+      using Cadl.Rest.Resource;
+
+      model Thing {
+        @key
+        @segment("things")
+        thingId: string;
+      }
+
+      @error model Error {}
+
+      interface Things extends ResourceOperations<Thing, Error>, ResourceCreateOrReplace<Thing, Error> {
+      }
+      `
+    );
+
+    deepStrictEqual(routes, [
+      {
+        params: ["thingId"],
+        path: "/things/{thingId}",
+        verb: "get",
+      },
+      {
+        params: ["thingId"],
+        path: "/things/{thingId}",
+        verb: "patch",
+      },
+      {
+        params: ["thingId"],
+        path: "/things/{thingId}",
+        verb: "delete",
+      },
+      {
+        params: [],
+        path: "/things",
+        verb: "post",
+      },
+      {
+        params: [],
+        path: "/things",
+        verb: "get",
+      },
+      {
+        params: ["thingId"],
+        path: "/things/{thingId}",
+        verb: "put",
+      },
+    ]);
+  });
+
   it("singleton resource: generates standard operations", async () => {
     const routes = await getRoutesFor(
       `

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -179,7 +179,7 @@
       }
     },
     "/pets/{petId}/checkups/{checkupId}": {
-      "put": {
+      "patch": {
         "operationId": "PetCheckups_CreateOrUpdate",
         "description": "Creates or update a instance of the extension resource.",
         "parameters": [
@@ -495,7 +495,7 @@
       }
     },
     "/checkups/{checkupId}": {
-      "put": {
+      "patch": {
         "operationId": "Checkups_createOrUpdate",
         "description": "Creates or update a instance of the resource.",
         "parameters": [
@@ -748,7 +748,7 @@
       }
     },
     "/owners/{ownerId}/checkups/{checkupId}": {
-      "put": {
+      "patch": {
         "operationId": "OwnerCheckups_CreateOrUpdate",
         "description": "Creates or update a instance of the extension resource.",
         "parameters": [


### PR DESCRIPTION
This change fixes #776 by adding a new core lifecycle operation called `ResourceCreateOrReplace` which differs from `ResourceCreateOrUpdate` in that it has a body like a normal `create` operation but with the added ability to update an existing resource.

This also changes the default HTTP verb for `ResourceCreateOrUpdate` to `PATCH` instead of `PUT` like it was previously.  This will impact many existing specs since it's pretty common to use this operation signature.