### PR TITLE
Fix formatting issue in resource.cadl

### DIFF
--- a/common/changes/@cadl-lang/rest/fix-formatting_2022-07-28-14-53.json
+++ b/common/changes/@cadl-lang/rest/fix-formatting_2022-07-28-14-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -59,8 +59,7 @@ interface ResourceCreateOrReplace<TResource, TError> {
 }
 
 @friendlyName("{name}Update", TResource)
-model ResourceCreateOrUpdateModel<TResource>
-  is OptionalProperties<UpdateableProperties<DefaultKeyVisibility<TResource, "read">>> {}
+model ResourceCreateOrUpdateModel<TResource> is OptionalProperties<UpdateableProperties<DefaultKeyVisibility<TResource, "read">>> {}
 
 interface ResourceCreateOrUpdate<TResource, TError> {
   @autoRoute
@@ -73,8 +72,7 @@ interface ResourceCreateOrUpdate<TResource, TError> {
 }
 
 @friendlyName("{name}Create", TResource)
-model ResourceCreateModel<TResource>
-  is UpdateableProperties<DefaultKeyVisibility<TResource, "read">> {}
+model ResourceCreateModel<TResource> is UpdateableProperties<DefaultKeyVisibility<TResource, "read">> {}
 
 interface ResourceCreate<TResource, TError> {
   @autoRoute


### PR DESCRIPTION
Not sure how this slipped through the cracks!  It's blocking uptake of the submodule in `cadl-azure.