### PR TITLE
Add `ResourceLocation<T>` for properties containing a resource location

### DIFF
--- a/common/changes/@cadl-lang/rest/resource-links_2022-07-28-15-03.json
+++ b/common/changes/@cadl-lang/rest/resource-links_2022-07-28-15-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add `ResourceLocation<T>` to mark a property as containing a link to a specific resource type",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -120,7 +120,7 @@ model Page<T> {
   value: T[];
 
   @doc("The link to the next page of items")
-  nextLink?: string;
+  nextLink?: ResourceLocation<T>;
 }
 
 interface ResourceList<TResource, TError> {

--- a/packages/rest/lib/rest.cadl
+++ b/packages/rest/lib/rest.cadl
@@ -2,3 +2,9 @@ import "../dist/src/validate.js";
 
 import "./http.cadl";
 import "./resource.cadl";
+
+namespace Cadl.Rest;
+
+@doc("The location of an instance of {name}", TResource)
+@Private.resourceLocation(TResource)
+model ResourceLocation<TResource> is string {}

--- a/packages/rest/test/rest-decorators.test.ts
+++ b/packages/rest/test/rest-decorators.test.ts
@@ -1,6 +1,7 @@
+import { ModelType } from "@cadl-lang/compiler";
 import { BasicTestRunner, expectDiagnostics } from "@cadl-lang/compiler/testing";
-import { deepStrictEqual } from "assert";
-import { getConsumes, getProduces } from "../src/rest.js";
+import { deepStrictEqual, ok, strictEqual } from "assert";
+import { getConsumes, getProduces, getResourceLocationType } from "../src/rest.js";
 import { createRestTestRunner } from "./test-host.js";
 
 describe("rest: http decorators", () => {
@@ -117,6 +118,39 @@ describe("rest: http decorators", () => {
         "application/xml",
         "application/yaml",
       ]);
+    });
+  });
+
+  describe("@resourceLocation", () => {
+    it("emit diagnostic when used on non-model", async () => {
+      const diagnostics = await runner.diagnose(`
+          model Widget {};
+
+          @Cadl.Rest.Private.resourceLocation(Widget)
+          op test(): string;
+
+          model WidgetLocation is ResourceLocation<Widget>;
+        `);
+
+      expectDiagnostics(diagnostics, [
+        {
+          code: "decorator-wrong-target",
+          message: "Cannot apply @resourceLocation decorator to Operation",
+        },
+      ]);
+    });
+
+    it("marks a model type as a resource location for a specific type", async () => {
+      const { WidgetLocation } = (await runner.compile(`
+          model Widget {};
+
+          @test
+          model WidgetLocation is ResourceLocation<Widget>;
+`)) as { WidgetLocation: ModelType };
+
+      const resourceType = getResourceLocationType(runner.program, WidgetLocation);
+      ok(resourceType);
+      strictEqual(resourceType!.name, "Widget");
     });
   });
 });

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -1057,7 +1057,7 @@
             "description": "The items on this page"
           },
           "nextLink": {
-            "type": "string",
+            "$ref": "#/components/schemas/Rest.ResourceLocation_Pet",
             "description": "The link to the next page of items"
           }
         },
@@ -1110,7 +1110,7 @@
             "description": "The items on this page"
           },
           "nextLink": {
-            "type": "string",
+            "$ref": "#/components/schemas/Rest.ResourceLocation_Checkup",
             "description": "The link to the next page of items"
           }
         },
@@ -1190,7 +1190,7 @@
             "description": "The items on this page"
           },
           "nextLink": {
-            "type": "string",
+            "$ref": "#/components/schemas/Rest.ResourceLocation_Toy",
             "description": "The link to the next page of items"
           }
         },
@@ -1262,7 +1262,7 @@
             "description": "The items on this page"
           },
           "nextLink": {
-            "type": "string",
+            "$ref": "#/components/schemas/Rest.ResourceLocation_Owner",
             "description": "The link to the next page of items"
           }
         },
@@ -1270,6 +1270,22 @@
         "required": [
           "value"
         ]
+      },
+      "Rest.ResourceLocation_Pet": {
+        "type": "string",
+        "description": "The location of an instance of Pet"
+      },
+      "Rest.ResourceLocation_Checkup": {
+        "type": "string",
+        "description": "The location of an instance of Checkup"
+      },
+      "Rest.ResourceLocation_Toy": {
+        "type": "string",
+        "description": "The location of an instance of Toy"
+      },
+      "Rest.ResourceLocation_Owner": {
+        "type": "string",
+        "description": "The location of an instance of Owner"
       }
     }
   }


### PR DESCRIPTION
This is the first part of the implementation of https://github.com/Azure/cadl-azure/issues/1672.  The ask is for a new, private `@resourceLocation` decorator that gets exposed through a `ResourceLocation<T>` template type for the purpose of identifying model properties that contain a link to a specific resource type.

I've followed the design spec here: https://gist.github.com/markcowl/dc297422b20069541d59d0e991d9eacc#resource-links-resourcelocation

A follow-up PR to `cadl-azure` will be made to address the rest of the implementation.