### PR TITLE
[OpenAPI 3] Inline template instances with no friendly name

### DIFF
--- a/common/changes/@cadl-lang/openapi/inline-unfriendly-generics_2022-07-28-19-47.json
+++ b/common/changes/@cadl-lang/openapi/inline-unfriendly-generics_2022-07-28-19-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "Inline generic instantiations without `@friendlyName`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/openapi3/inline-unfriendly-generics_2022-07-28-19-47.json
+++ b/common/changes/@cadl-lang/openapi3/inline-unfriendly-generics_2022-07-28-19-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Inline generic instantiations without `@friendlyName`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/inline-unfriendly-generics_2022-07-29-15-46.json
+++ b/common/changes/@cadl-lang/rest/inline-unfriendly-generics_2022-07-29-15-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add friendly name for Page<T> as TPage",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/openapi3/src/lib.ts
+++ b/packages/openapi3/src/lib.ts
@@ -109,6 +109,12 @@ export const libDef = {
         default: paramMessage`Invalid type '${"type"}' for a default value`,
       },
     },
+    "inline-cycle": {
+      severity: "error",
+      messages: {
+        default: paramMessage`Cycle detected in '${"type"}'. Use @friendlyName decorator to assign an OpenAPI definition name and make it non-inline.`,
+      },
+    },
   },
   emitter: {
     options: EmiterOptionsSchema as JSONSchemaType<OpenAPI3EmitterOptions>,

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -187,6 +187,10 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
   // Keep a list of all Types encountered that need schema definitions
   let schemas = new Set<Type>();
 
+  // Keep track of inline types still in the process of having their schema computed
+  // This is used to detect cycles in inline types, which is an
+  let inProgressInlineTypes = new Set<Type>();
+
   // Map model properties that represent shared parameters to their parameter
   // definition that will go in #/components/parameters. Inlined parameters do not go in
   // this map.
@@ -233,6 +237,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     serviceNamespace = getServiceNamespaceString(program);
     currentPath = root.paths;
     schemas = new Set();
+    inProgressInlineTypes = new Set();
     params = new Map();
     tags = new Set();
   }
@@ -524,7 +529,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     const name = getTypeName(program, type, typeNameOptions);
 
     if (shouldInline(program, type)) {
-      const schema = getSchemaForType(type);
+      const schema = getSchemaForInlineType(type, name);
 
       if (schema === undefined && isErrorType(type)) {
         // Exit early so that syntax errors are exposed.  This error will
@@ -544,6 +549,21 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
       schemas.add(type);
       return placeholder;
     }
+  }
+
+  function getSchemaForInlineType(type: Type, name: string) {
+    if (inProgressInlineTypes.has(type)) {
+      reportDiagnostic(program, {
+        code: "inline-cycle",
+        format: { type: name },
+        target: type,
+      });
+      return {};
+    }
+    inProgressInlineTypes.add(type);
+    const schema = getSchemaForType(type);
+    inProgressInlineTypes.delete(type);
+    return schema;
   }
 
   /**

--- a/packages/openapi3/test/openapi-output.test.ts
+++ b/packages/openapi3/test/openapi-output.test.ts
@@ -117,14 +117,14 @@ describe("openapi3: definitions", () => {
       };`
     );
 
-    ok(res.isRef);
-    ok(res.schemas.Foo_int32, "expected definition named Foo_int32");
-    deepStrictEqual(res.schemas.Foo_int32, {
+    ok(!res.isRef);
+    deepStrictEqual(res.useSchema, {
       type: "object",
       properties: {
         x: { type: "integer", format: "int32" },
       },
       required: ["x"],
+      "x-cadl-name": "Foo<int32>",
     });
   });
 
@@ -140,14 +140,14 @@ describe("openapi3: definitions", () => {
       };`
     );
 
-    ok(res.isRef);
-    ok(res.schemas["Foo_Test.M"], "expected definition named Foo_Test.M");
-    deepStrictEqual(res.schemas["Foo_Test.M"], {
+    ok(!res.isRef);
+    deepStrictEqual(res.useSchema, {
       type: "object",
       properties: {
         x: { $ref: "#/components/schemas/Test.M" },
       },
       required: ["x"],
+      "x-cadl-name": "Foo<Test.M>",
     });
   });
 
@@ -208,6 +208,7 @@ describe("openapi3: definitions", () => {
       model Parent {
         x?: int32;
       };
+      @friendlyName("TParent_{name}", T)
       model TParent<T> extends Parent {
         t: T;
       }
@@ -221,7 +222,7 @@ describe("openapi3: definitions", () => {
     );
     ok(
       !("TParent" in res.components.schemas),
-      "Parent templated type shouldn't be includd in OpenAPI"
+      "Parent templated type shouldn't be included in OpenAPI"
     );
     deepStrictEqual(res.components.schemas.Parent, {
       type: "object",
@@ -316,6 +317,7 @@ describe("openapi3: definitions", () => {
     const res = await oapiForModel(
       "Bar",
       `
+      @friendlyName("Foo_{name}", T)
       model Foo<T> {
         y: T;
       };
@@ -353,20 +355,24 @@ describe("openapi3: definitions", () => {
       }`
     );
 
-    ok(res.isRef);
-    ok(res.schemas.Foo_int32, "expected definition named Foo_int32");
-    ok(res.schemas.Bar_int32, "expected definition named Bar_int32");
-    deepStrictEqual(res.schemas.Bar_int32, {
+    ok(!res.isRef);
+    deepStrictEqual(res.useSchema, {
       type: "object",
-      properties: { x: { type: "integer", format: "int32" } },
-      allOf: [{ $ref: "#/components/schemas/Foo_int32" }],
+      properties: {
+        x: { type: "integer", format: "int32" },
+      },
       required: ["x"],
-    });
-
-    deepStrictEqual(res.schemas.Foo_int32, {
-      type: "object",
-      properties: { y: { type: "integer", format: "int32" } },
-      required: ["y"],
+      "x-cadl-name": "Bar<int32>",
+      allOf: [
+        {
+          type: "object",
+          properties: {
+            y: { type: "integer", format: "int32" },
+          },
+          required: ["y"],
+          "x-cadl-name": "Foo<int32>",
+        },
+      ],
     });
   });
 
@@ -798,6 +804,17 @@ describe("openapi3: definitions", () => {
         $ref: "#/components/schemas/Thing",
       }
     );
+  });
+
+  it("detects cycles in inline type", async () => {
+    const diagnostics = await diagnoseOpenApiFor(
+      `
+      model Thing<T> { inner?: Thing<T>; }
+      op get(): Thing<string>;
+      `
+    );
+
+    expectDiagnostics(diagnostics, [{ code: "@cadl-lang/openapi3/inline-cycle" }]);
   });
 });
 

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -114,7 +114,8 @@ interface ResourceDelete<TResource, TError> {
   delete(...ResourceParameters<TResource>): ResourceDeletedResponse | TError;
 }
 
-@doc("Paged response")
+@doc("Paged response of {name} items", T)
+@friendlyName("{name}Page", T)
 model Page<T> {
   @doc("The items on this page")
   value: T[];

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -160,27 +160,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "value": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Pet"
-                      },
-                      "x-cadl-name": "Pet[]",
-                      "description": "The items on this page"
-                    },
-                    "nextLink": {
-                      "type": "string",
-                      "description": "The link to the next page of items",
-                      "x-cadl-name": "Rest.ResourceLocation<Pet>"
-                    }
-                  },
-                  "description": "Paged response",
-                  "required": [
-                    "value"
-                  ],
-                  "x-cadl-name": "Rest.Resource.Page<Pet>"
+                  "$ref": "#/components/schemas/PetPage"
                 }
               }
             }
@@ -268,27 +248,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "value": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Checkup"
-                      },
-                      "x-cadl-name": "Checkup[]",
-                      "description": "The items on this page"
-                    },
-                    "nextLink": {
-                      "type": "string",
-                      "description": "The link to the next page of items",
-                      "x-cadl-name": "Rest.ResourceLocation<Checkup>"
-                    }
-                  },
-                  "description": "Paged response",
-                  "required": [
-                    "value"
-                  ],
-                  "x-cadl-name": "Rest.Resource.Page<Checkup>"
+                  "$ref": "#/components/schemas/CheckupPage"
                 }
               }
             }
@@ -437,27 +397,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "value": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Toy"
-                      },
-                      "x-cadl-name": "Toy[]",
-                      "description": "The items on this page"
-                    },
-                    "nextLink": {
-                      "type": "string",
-                      "description": "The link to the next page of items",
-                      "x-cadl-name": "Rest.ResourceLocation<Toy>"
-                    }
-                  },
-                  "description": "Paged response",
-                  "required": [
-                    "value"
-                  ],
-                  "x-cadl-name": "Rest.Resource.Page<Toy>"
+                  "$ref": "#/components/schemas/ToyPage"
                 }
               }
             }
@@ -617,27 +557,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "value": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Checkup"
-                      },
-                      "x-cadl-name": "Checkup[]",
-                      "description": "The items on this page"
-                    },
-                    "nextLink": {
-                      "type": "string",
-                      "description": "The link to the next page of items",
-                      "x-cadl-name": "Rest.ResourceLocation<Checkup>"
-                    }
-                  },
-                  "description": "Paged response",
-                  "required": [
-                    "value"
-                  ],
-                  "x-cadl-name": "Rest.Resource.Page<Checkup>"
+                  "$ref": "#/components/schemas/CheckupPage"
                 }
               }
             }
@@ -809,27 +729,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "value": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Owner"
-                      },
-                      "x-cadl-name": "Owner[]",
-                      "description": "The items on this page"
-                    },
-                    "nextLink": {
-                      "type": "string",
-                      "description": "The link to the next page of items",
-                      "x-cadl-name": "Rest.ResourceLocation<Owner>"
-                    }
-                  },
-                  "description": "Paged response",
-                  "required": [
-                    "value"
-                  ],
-                  "x-cadl-name": "Rest.Resource.Page<Owner>"
+                  "$ref": "#/components/schemas/OwnerPage"
                 }
               }
             }
@@ -917,27 +817,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "value": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Checkup"
-                      },
-                      "x-cadl-name": "Checkup[]",
-                      "description": "The items on this page"
-                    },
-                    "nextLink": {
-                      "type": "string",
-                      "description": "The link to the next page of items",
-                      "x-cadl-name": "Rest.ResourceLocation<Checkup>"
-                    }
-                  },
-                  "description": "Paged response",
-                  "required": [
-                    "value"
-                  ],
-                  "x-cadl-name": "Rest.Resource.Page<Checkup>"
+                  "$ref": "#/components/schemas/CheckupPage"
                 }
               }
             }
@@ -1165,6 +1045,28 @@
           "ownerId"
         ]
       },
+      "PetPage": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Pet"
+            },
+            "x-cadl-name": "Pet[]",
+            "description": "The items on this page"
+          },
+          "nextLink": {
+            "type": "string",
+            "description": "The link to the next page of items",
+            "x-cadl-name": "Rest.ResourceLocation<Pet>"
+          }
+        },
+        "description": "Paged response of Pet items",
+        "required": [
+          "value"
+        ]
+      },
       "CheckupUpdate": {
         "type": "object",
         "properties": {
@@ -1195,6 +1097,28 @@
           "id",
           "vetName",
           "notes"
+        ]
+      },
+      "CheckupPage": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Checkup"
+            },
+            "x-cadl-name": "Checkup[]",
+            "description": "The items on this page"
+          },
+          "nextLink": {
+            "type": "string",
+            "description": "The link to the next page of items",
+            "x-cadl-name": "Rest.ResourceLocation<Checkup>"
+          }
+        },
+        "description": "Paged response of Checkup items",
+        "required": [
+          "value"
         ]
       },
       "Insurance": {
@@ -1256,6 +1180,28 @@
           "name"
         ]
       },
+      "ToyPage": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Toy"
+            },
+            "x-cadl-name": "Toy[]",
+            "description": "The items on this page"
+          },
+          "nextLink": {
+            "type": "string",
+            "description": "The link to the next page of items",
+            "x-cadl-name": "Rest.ResourceLocation<Toy>"
+          }
+        },
+        "description": "Paged response of Toy items",
+        "required": [
+          "value"
+        ]
+      },
       "Owner": {
         "type": "object",
         "properties": {
@@ -1305,6 +1251,28 @@
         "required": [
           "name",
           "age"
+        ]
+      },
+      "OwnerPage": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Owner"
+            },
+            "x-cadl-name": "Owner[]",
+            "description": "The items on this page"
+          },
+          "nextLink": {
+            "type": "string",
+            "description": "The link to the next page of items",
+            "x-cadl-name": "Rest.ResourceLocation<Owner>"
+          }
+        },
+        "description": "Paged response of Owner items",
+        "required": [
+          "value"
         ]
       }
     }

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -160,7 +160,27 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Rest.Resource.Page_Pet"
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Pet"
+                      },
+                      "x-cadl-name": "Pet[]",
+                      "description": "The items on this page"
+                    },
+                    "nextLink": {
+                      "type": "string",
+                      "description": "The link to the next page of items",
+                      "x-cadl-name": "Rest.ResourceLocation<Pet>"
+                    }
+                  },
+                  "description": "Paged response",
+                  "required": [
+                    "value"
+                  ],
+                  "x-cadl-name": "Rest.Resource.Page<Pet>"
                 }
               }
             }
@@ -248,7 +268,27 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Rest.Resource.Page_Checkup"
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Checkup"
+                      },
+                      "x-cadl-name": "Checkup[]",
+                      "description": "The items on this page"
+                    },
+                    "nextLink": {
+                      "type": "string",
+                      "description": "The link to the next page of items",
+                      "x-cadl-name": "Rest.ResourceLocation<Checkup>"
+                    }
+                  },
+                  "description": "Paged response",
+                  "required": [
+                    "value"
+                  ],
+                  "x-cadl-name": "Rest.Resource.Page<Checkup>"
                 }
               }
             }
@@ -397,7 +437,27 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Rest.Resource.Page_Toy"
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Toy"
+                      },
+                      "x-cadl-name": "Toy[]",
+                      "description": "The items on this page"
+                    },
+                    "nextLink": {
+                      "type": "string",
+                      "description": "The link to the next page of items",
+                      "x-cadl-name": "Rest.ResourceLocation<Toy>"
+                    }
+                  },
+                  "description": "Paged response",
+                  "required": [
+                    "value"
+                  ],
+                  "x-cadl-name": "Rest.Resource.Page<Toy>"
                 }
               }
             }
@@ -557,7 +617,27 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Rest.Resource.Page_Checkup"
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Checkup"
+                      },
+                      "x-cadl-name": "Checkup[]",
+                      "description": "The items on this page"
+                    },
+                    "nextLink": {
+                      "type": "string",
+                      "description": "The link to the next page of items",
+                      "x-cadl-name": "Rest.ResourceLocation<Checkup>"
+                    }
+                  },
+                  "description": "Paged response",
+                  "required": [
+                    "value"
+                  ],
+                  "x-cadl-name": "Rest.Resource.Page<Checkup>"
                 }
               }
             }
@@ -729,7 +809,27 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Rest.Resource.Page_Owner"
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Owner"
+                      },
+                      "x-cadl-name": "Owner[]",
+                      "description": "The items on this page"
+                    },
+                    "nextLink": {
+                      "type": "string",
+                      "description": "The link to the next page of items",
+                      "x-cadl-name": "Rest.ResourceLocation<Owner>"
+                    }
+                  },
+                  "description": "Paged response",
+                  "required": [
+                    "value"
+                  ],
+                  "x-cadl-name": "Rest.Resource.Page<Owner>"
                 }
               }
             }
@@ -817,7 +917,27 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Rest.Resource.Page_Checkup"
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Checkup"
+                      },
+                      "x-cadl-name": "Checkup[]",
+                      "description": "The items on this page"
+                    },
+                    "nextLink": {
+                      "type": "string",
+                      "description": "The link to the next page of items",
+                      "x-cadl-name": "Rest.ResourceLocation<Checkup>"
+                    }
+                  },
+                  "description": "Paged response",
+                  "required": [
+                    "value"
+                  ],
+                  "x-cadl-name": "Rest.Resource.Page<Checkup>"
                 }
               }
             }
@@ -1045,27 +1165,6 @@
           "ownerId"
         ]
       },
-      "Rest.Resource.Page_Pet": {
-        "type": "object",
-        "properties": {
-          "value": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Pet"
-            },
-            "x-cadl-name": "Pet[]",
-            "description": "The items on this page"
-          },
-          "nextLink": {
-            "$ref": "#/components/schemas/Rest.ResourceLocation_Pet",
-            "description": "The link to the next page of items"
-          }
-        },
-        "description": "Paged response",
-        "required": [
-          "value"
-        ]
-      },
       "CheckupUpdate": {
         "type": "object",
         "properties": {
@@ -1096,27 +1195,6 @@
           "id",
           "vetName",
           "notes"
-        ]
-      },
-      "Rest.Resource.Page_Checkup": {
-        "type": "object",
-        "properties": {
-          "value": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Checkup"
-            },
-            "x-cadl-name": "Checkup[]",
-            "description": "The items on this page"
-          },
-          "nextLink": {
-            "$ref": "#/components/schemas/Rest.ResourceLocation_Checkup",
-            "description": "The link to the next page of items"
-          }
-        },
-        "description": "Paged response",
-        "required": [
-          "value"
         ]
       },
       "Insurance": {
@@ -1178,27 +1256,6 @@
           "name"
         ]
       },
-      "Rest.Resource.Page_Toy": {
-        "type": "object",
-        "properties": {
-          "value": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Toy"
-            },
-            "x-cadl-name": "Toy[]",
-            "description": "The items on this page"
-          },
-          "nextLink": {
-            "$ref": "#/components/schemas/Rest.ResourceLocation_Toy",
-            "description": "The link to the next page of items"
-          }
-        },
-        "description": "Paged response",
-        "required": [
-          "value"
-        ]
-      },
       "Owner": {
         "type": "object",
         "properties": {
@@ -1249,43 +1306,6 @@
           "name",
           "age"
         ]
-      },
-      "Rest.Resource.Page_Owner": {
-        "type": "object",
-        "properties": {
-          "value": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Owner"
-            },
-            "x-cadl-name": "Owner[]",
-            "description": "The items on this page"
-          },
-          "nextLink": {
-            "$ref": "#/components/schemas/Rest.ResourceLocation_Owner",
-            "description": "The link to the next page of items"
-          }
-        },
-        "description": "Paged response",
-        "required": [
-          "value"
-        ]
-      },
-      "Rest.ResourceLocation_Pet": {
-        "type": "string",
-        "description": "The location of an instance of Pet"
-      },
-      "Rest.ResourceLocation_Checkup": {
-        "type": "string",
-        "description": "The location of an instance of Checkup"
-      },
-      "Rest.ResourceLocation_Toy": {
-        "type": "string",
-        "description": "The location of an instance of Toy"
-      },
-      "Rest.ResourceLocation_Owner": {
-        "type": "string",
-        "description": "The location of an instance of Owner"
       }
     }
   }


### PR DESCRIPTION
Fix #562

I added an error for the case of a recursive template without a friendly name. Note that you could already trigger a stack overflow with nested generic so the need for this diagnostic isn't new:  [Playground Link](https://cadlplayground.z22.web.core.windows.net/?c=aW1wb3J0ICJAY2FkbC1sYW5nL3Jlc3QiOw0KDQp1c2luZyBDYWRsLkh0dHDFFG1vZGVsIEZvcmNlSW5saW5lPFQgPSB1bmtub3duPiB7fcwlbzxULCBfID3MMD4gew0KICB3OsYgPjsNCsU0b3AgZigpxhZzdHJpbmc%2BW107DQo%3D)

