### PR TITLE
Fix: allow to omit optional properties

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-assign-optional_2022-07-28-20-08.json
+++ b/common/changes/@cadl-lang/compiler/fix-assign-optional_2022-07-28-20-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix: Allow omiting optional properties",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -3920,17 +3920,19 @@ export function createChecker(program: Program): Checker {
     for (const prop of walkPropertiesInherited(target)) {
       const sourceProperty = getProperty(source, prop.name);
       if (sourceProperty === undefined) {
-        diagnostics.push(
-          createDiagnostic({
-            code: "missing-property",
-            format: {
-              propertyName: prop.name,
-              sourceType: getTypeName(source),
-              targetType: getTypeName(target),
-            },
-            target: source,
-          })
-        );
+        if (!prop.optional) {
+          diagnostics.push(
+            createDiagnostic({
+              code: "missing-property",
+              format: {
+                propertyName: prop.name,
+                sourceType: getTypeName(source),
+                targetType: getTypeName(target),
+              },
+              target: source,
+            })
+          );
+        }
       } else {
         const [related, propDiagnostics] = isTypeAssignableTo(
           sourceProperty.type,

--- a/packages/compiler/test/checker/relation.test.ts
+++ b/packages/compiler/test/checker/relation.test.ts
@@ -583,6 +583,24 @@ describe("compiler: checker: type relations", () => {
         `,
       });
     });
+
+    it("can assign object without some of the optional properties", async () => {
+      await expectTypeAssignable({
+        source: "{name: string}",
+        target: "{name: string, age?: int32}",
+      });
+    });
+
+    it("emit diagnostic when required property is missing", async () => {
+      await expectTypeNotAssignable(
+        { source: `{foo: "abc"}`, target: `{foo: string, bar: string}` },
+        {
+          code: "missing-property",
+          message:
+            "Property 'bar' is missing on type '(anonymous model)' but required in '(anonymous model)'",
+        }
+      );
+    });
   });
 
   describe("Array target", () => {

--- a/packages/compiler/test/checker/relation.test.ts
+++ b/packages/compiler/test/checker/relation.test.ts
@@ -725,3 +725,8 @@ describe("compiler: checker: type relations", () => {
     });
   });
 });
+
+interface Foo {
+  name: string;
+  age?: string;
+}

--- a/packages/compiler/test/checker/relation.test.ts
+++ b/packages/compiler/test/checker/relation.test.ts
@@ -725,8 +725,3 @@ describe("compiler: checker: type relations", () => {
     });
   });
 });
-
-interface Foo {
-  name: string;
-  age?: string;
-}


### PR DESCRIPTION
fix #793 

Enable this

```
model Foo<T extends {required: string, optional?: string}> {}

alias B = Foo<{required: "one"}>
```