### PR TITLE
Format `model Foo is Bar {}` to `model Foo is Bar;`

### DIFF
--- a/common/changes/@cadl-lang/compiler/formatter-print-model-is-body_2022-07-29-15-14.json
+++ b/common/changes/@cadl-lang/compiler/formatter-print-model-is-body_2022-07-29-15-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Format `model Foo is Bar {}` to `model Foo is Bar;`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/rest/formatter-print-model-is-body_2022-07-29-15-14.json
+++ b/common/changes/@cadl-lang/rest/formatter-print-model-is-body_2022-07-29-15-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -118,7 +118,7 @@ model Thing<T> {
   property: T;
 }
 
-model StringThing is Thing<string> {}
+model StringThing is Thing<string>;
 
 // StringThing declaration is equivalent to the following declaration:
 @decorator

--- a/docs/type-relations.md
+++ b/docs/type-relations.md
@@ -95,7 +95,7 @@ alias S = {
   foo: int8;
   bar: int32;
 };
-model S is Record<int32> {}
+model S is Record<int32>;
 model S is Record<int32> {
   foo: 123;
 }

--- a/packages/compiler/formatter/print/comment-handler.ts
+++ b/packages/compiler/formatter/print/comment-handler.ts
@@ -88,7 +88,9 @@ function addEmptyModelComment(comment: CommentNode) {
     enclosingNode.kind === SyntaxKind.ModelStatement &&
     enclosingNode.properties.length === 0 &&
     precedingNode &&
-    precedingNode.kind === SyntaxKind.Identifier
+    (precedingNode === enclosingNode.is ||
+      precedingNode === enclosingNode.id ||
+      precedingNode === enclosingNode.extends)
   ) {
     util.addDanglingComment(enclosingNode, comment, undefined);
     return true;

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -733,17 +733,21 @@ export function printModelStatement(
 ) {
   const node = path.getValue();
   const id = path.call(print, "id");
-  const heritage = node.extends ? [softline, "extends ", path.call(print, "extends"), " "] : "";
-  const isBase = node.is ? [softline, "is ", path.call(print, "is"), " "] : "";
+  const heritage = node.extends
+    ? [ifBreak(line, " "), "extends ", path.call(print, "extends")]
+    : "";
+  const isBase = node.is ? [ifBreak(line, " "), "is ", path.call(print, "is")] : "";
   const generic = printTemplateParameters(path, options, print, "templateParameters");
+  const nodeHasComments = hasComments(node, CommentCheckFlags.Dangling);
+  const shouldPrintBody = nodeHasComments || !(node.properties.length === 0 && node.is);
+  const body = shouldPrintBody ? [" ", printModelPropertiesBlock(path, options, print)] : ";";
   return [
     printDecorators(path, options, print, { tryInline: false }).decorators,
     "model ",
     id,
     generic,
-    " ",
     group(indent(["", heritage, isBase])),
-    printModelPropertiesBlock(path, options, print),
+    body,
   ];
 }
 

--- a/packages/compiler/lib/lib.cadl
+++ b/packages/compiler/lib/lib.cadl
@@ -89,7 +89,7 @@ model boolean {}
 model null {}
 
 @deprecated("Map is deprecated, use Record<T> instead")
-model Map<K, V> is Record<V> {}
+model Map<K, V> is Record<V>;
 
 @doc("The template for adding optional properties.")
 @withOptionalProperties

--- a/packages/compiler/test/formatter/formatter.test.ts
+++ b/packages/compiler/test/formatter/formatter.test.ts
@@ -202,8 +202,8 @@ model Foo
       });
     });
 
-    describe("model `is`", () => {
-      it("format inline", () => {
+    describe.only("model `is`", () => {
+      it("remove body if its empty", () => {
         assertFormat({
           code: `
 model   Foo is Base {
@@ -214,9 +214,24 @@ model   Bar is Base<
 }
 `,
           expected: `
-model Foo is Base {}
+model Foo is Base;
 
-model Bar is Base<string> {}
+model Bar is Base<string>;
+`,
+        });
+      });
+
+      it("keeps body if there is a comment inside", () => {
+        assertFormat({
+          code: `
+model   Foo is Base {
+   // Some comment
+}
+`,
+          expected: `
+model Foo is Base {
+  // Some comment
+}
 `,
         });
       });
@@ -224,12 +239,12 @@ model Bar is Base<string> {}
       it("split and indent is when model declaration line is too long", () => {
         assertFormat({
           code: `
-model   Foo is SuperExtremeAndVeryVeryVeryVeryVeryVeryLongModelThatWillBeTooLong {
+model   Foo is SuperExtremeAndVeryVeryVeryVeryVeryVeryLongLongLongModelThatWillBeTooLong {
 }
 `,
           expected: `
 model Foo
-  is SuperExtremeAndVeryVeryVeryVeryVeryVeryLongModelThatWillBeTooLong {}
+  is SuperExtremeAndVeryVeryVeryVeryVeryVeryLongLongLongModelThatWillBeTooLong;
 `,
         });
       });

--- a/packages/compiler/test/formatter/formatter.test.ts
+++ b/packages/compiler/test/formatter/formatter.test.ts
@@ -202,7 +202,7 @@ model Foo
       });
     });
 
-    describe.only("model `is`", () => {
+    describe("model `is`", () => {
       it("remove body if its empty", () => {
         assertFormat({
           code: `

--- a/packages/rest/lib/http.cadl
+++ b/packages/rest/lib/http.cadl
@@ -31,19 +31,19 @@ model LocationHeader {
 // to update the default descriptions for these status codes. This ensures
 // that we get consistent emit between different ways to spell the same
 // responses in Cadl.
-model OkResponse is Response<200> {}
-model CreatedResponse is Response<201> {}
-model AcceptedResponse is Response<202> {}
-model NoContentResponse is Response<204> {}
+model OkResponse is Response<200>;
+model CreatedResponse is Response<201>;
+model AcceptedResponse is Response<202>;
+model NoContentResponse is Response<204>;
 model MovedResponse is Response<301> {
   ...LocationHeader;
 }
-model NotModifiedResponse is Response<304> {}
-model BadRequestResponse is Response<400> {}
-model UnauthorizedResponse is Response<401> {}
-model ForbiddenResponse is Response<403> {}
-model NotFoundResponse is Response<404> {}
-model ConflictResponse is Response<409> {}
+model NotModifiedResponse is Response<304>;
+model BadRequestResponse is Response<400>;
+model UnauthorizedResponse is Response<401>;
+model ForbiddenResponse is Response<403>;
+model NotFoundResponse is Response<404>;
+model ConflictResponse is Response<409>;
 
 /**
  * Produces a new model with the same properties as T, but with `@query`,

--- a/packages/rest/lib/resource.cadl
+++ b/packages/rest/lib/resource.cadl
@@ -60,7 +60,7 @@ interface ResourceCreateOrReplace<TResource, TError> {
 
 @friendlyName("{name}Update", TResource)
 model ResourceCreateOrUpdateModel<TResource>
-  is OptionalProperties<UpdateableProperties<DefaultKeyVisibility<TResource, "read">>> {}
+  is OptionalProperties<UpdateableProperties<DefaultKeyVisibility<TResource, "read">>>;
 
 interface ResourceCreateOrUpdate<TResource, TError> {
   @autoRoute
@@ -74,7 +74,7 @@ interface ResourceCreateOrUpdate<TResource, TError> {
 
 @friendlyName("{name}Create", TResource)
 model ResourceCreateModel<TResource>
-  is UpdateableProperties<DefaultKeyVisibility<TResource, "read">> {}
+  is UpdateableProperties<DefaultKeyVisibility<TResource, "read">>;
 
 interface ResourceCreate<TResource, TError> {
   @autoRoute

--- a/packages/rest/lib/rest.cadl
+++ b/packages/rest/lib/rest.cadl
@@ -7,4 +7,4 @@ namespace Cadl.Rest;
 
 @doc("The location of an instance of {name}", TResource)
 @Private.resourceLocation(TResource)
-model ResourceLocation<TResource> is string {}
+model ResourceLocation<TResource> is string;

--- a/packages/samples/grpc-library-example/library.cadl
+++ b/packages/samples/grpc-library-example/library.cadl
@@ -83,7 +83,7 @@ The name of a book.
 Book names have the form `shelves/{shelf_id}/books/{book_id}`
 """)
 @pattern("shelves/\\w+/books/\\w+")
-model book_name is string {}
+model book_name is string;
 
 @doc("A single book in the library.")
 model Book {
@@ -109,7 +109,7 @@ The name of a shelf.
 Shelf names have the form `shelves/{shelf_id}`.
 """)
 @pattern("shelves/\\w+")
-model shelf_name is string {}
+model shelf_name is string;
 
 @doc("A Shelf contains a collection of books with a theme.")
 model Shelf {


### PR DESCRIPTION
Now that this is supported syntax. The formatter actually format it the other way around right now which makes this syntax pointless