### PR TITLE
Route consistency

### DIFF
--- a/common/changes/@cadl-lang/compiler/route-consistency_2022-07-29-18-34.json
+++ b/common/changes/@cadl-lang/compiler/route-consistency_2022-07-29-18-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add helper to check if a namespace is the global namespace",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi3/route-consistency_2022-07-29-18-34.json
+++ b/common/changes/@cadl-lang/openapi3/route-consistency_2022-07-29-18-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Add warning if there is no exposed routes",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/route-consistency_2022-07-29-18-34.json
+++ b/common/changes/@cadl-lang/rest/route-consistency_2022-07-29-18-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Update route resolution logic to be more consistent. If service namespace is provided use routes under otherwise use routes directly at the global namespace level(do not go into the nested namespaces)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/compiler/core/type-utils.ts
+++ b/packages/compiler/core/type-utils.ts
@@ -1,4 +1,5 @@
-import { TemplateDeclarationNode, TemplatedType, Type } from "./types.js";
+import { Program } from "./program.js";
+import { NamespaceType, TemplateDeclarationNode, TemplatedType, Type } from "./types.js";
 
 /**
  * Check if the given type has template arguments.
@@ -33,4 +34,11 @@ export function isTemplateDeclarationOrInstance(type: TemplatedType): boolean {
   }
   const node = type.node as TemplateDeclarationNode;
   return node.templateParameters && node.templateParameters.length > 0;
+}
+
+export function isGlobalNamespace(
+  program: Program,
+  namespace: NamespaceType
+): namespace is NamespaceType & { name: "" } {
+  return program.checker.getGlobalNamespaceType() === namespace;
 }

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -64,6 +64,7 @@ import {
   HttpOperationResponse,
   isStatusCode,
   OperationDetails,
+  reportIfNoRoutes,
 } from "@cadl-lang/rest/http";
 import { buildVersionProjections } from "@cadl-lang/versioning";
 import { getOneOf, getRef } from "./decorators.js";
@@ -333,6 +334,8 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     initializeEmitter(serviceNamespace, version);
     try {
       const [routes] = getAllRoutes(program);
+      reportIfNoRoutes(program, routes);
+
       for (const operation of routes) {
         emitOperation(operation);
       }

--- a/packages/openapi3/test/discriminator.test.ts
+++ b/packages/openapi3/test/discriminator.test.ts
@@ -29,10 +29,7 @@ describe("openapi3: discriminated unions", () => {
         bark: string;
       }
 
-      @route("/")
-      namespace root {
-        op read(): { @body body: Pet };
-      }
+      op read(): { @body body: Pet };
       `);
     ok(openApi.components.schemas.Pet, "expected definition named Pet");
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
@@ -76,10 +73,7 @@ describe("openapi3: discriminated unions", () => {
         bark: string;
       }
 
-      @route("/")
-      namespace root {
-        op read(): { @body body: Pet };
-      }
+      op read(): { @body body: Pet };
       `);
     ok(openApi.components.schemas.Pet, "expected definition named Pet");
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
@@ -126,10 +120,7 @@ describe("openapi3: discriminated unions", () => {
       bark: string;
     }
 
-    @route("/")
-    namespace root {
-      op read(): { @body body: Pet };
-    }
+    op read(): { @body body: Pet };
     `);
     ok(openApi.components.schemas.Pet, "expected definition named Pet");
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
@@ -169,10 +160,7 @@ describe("openapi3: discriminated unions", () => {
         purebred: boolean;
       }
 
-      @route("/")
-      namespace root {
-        op read(): { @body body: Pet };
-      }
+      op read(): { @body body: Pet };
       `);
     ok(openApi.components.schemas.Pet, "expected definition named Pet");
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
@@ -232,10 +220,7 @@ describe("openapi3: discriminated unions", () => {
         breed: "poodle";
       }
 
-      @route("/")
-      namespace root {
-        op read(): { @body body: Pet };
-      }
+      op read(): { @body body: Pet };
       `);
     ok(openApi.components.schemas.Pet, "expected definition named Pet");
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
@@ -309,10 +294,7 @@ describe("openapi3: discriminated unions", () => {
         kind: string;
       }
 
-      @route("/")
-      namespace root {
-        op read(): { @body body: Pet };
-      }
+      op read(): { @body body: Pet };
       `);
     ok(openApi.components.schemas.Pet, "expected definition named Pet");
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
@@ -368,10 +350,7 @@ describe("openapi3: discriminated unions", () => {
         tail: float64;
       }
 
-      @route("/")
-      namespace root {
-        op read(): { @body body: Pet };
-      }
+      op read(): { @body body: Pet };
       `);
     strictEqual(diagnostics.length, 6);
     strictEqual((diagnostics[0].target as ModelType).name, "Dog");
@@ -404,10 +383,7 @@ describe("openapi3: discriminated unions", () => {
         bark: string;
       }
 
-      @route("/")
-      namespace root {
-        op read(): { @body body: Pet };
-      }
+      op read(): { @body body: Pet };
       `);
     strictEqual(diagnostics.length, 2);
     match(diagnostics[0].message, /"housepet" defined in two different variants: Cat and Dog/);

--- a/packages/openapi3/test/documentation.test.ts
+++ b/packages/openapi3/test/documentation.test.ts
@@ -4,12 +4,9 @@ import { openApiFor } from "./test-host.js";
 describe("openapi3: documentation", () => {
   it("supports summary and description", async () => {
     const openApi = await openApiFor(`
-      @route("/")
-      namespace N {
-        @summary("This is a summary")
-        @doc("This is the longer description")
-        op read(): {};
-      }
+      @summary("This is a summary")
+      @doc("This is the longer description")
+      op read(): {};
       `);
     strictEqual(openApi.paths["/"].get.summary, "This is a summary");
     strictEqual(openApi.paths["/"].get.description, "This is the longer description");
@@ -17,11 +14,8 @@ describe("openapi3: documentation", () => {
 
   it("supports externalDocs on operation", async () => {
     const openApi = await openApiFor(`
-      @route("/")
-      namespace N {
-        @externalDocs("https://example.com", "more info")
-        op read(): {};
-      }
+      @externalDocs("https://example.com", "more info")
+      op read(): {};
       `);
     deepStrictEqual(openApi.paths["/"].get.externalDocs, {
       url: "https://example.com",
@@ -31,10 +25,7 @@ describe("openapi3: documentation", () => {
 
   it("supports externalDocs on models", async () => {
     const openApi = await openApiFor(`
-      @route("/")
-      namespace N {
-        op read(): Foo;
-      }
+      op read(): Foo;
 
       @externalDocs("https://example.com", "more info")
       model Foo {

--- a/packages/openapi3/test/info.test.ts
+++ b/packages/openapi3/test/info.test.ts
@@ -6,7 +6,9 @@ describe("openapi3: info", () => {
     const res = await openApiFor(
       `
       @serviceTitle("My Service")
-      namespace Foo {}
+      namespace Foo {
+        op test(): string;
+      }
       `
     );
     strictEqual(res.info.title, "My Service");
@@ -16,7 +18,9 @@ describe("openapi3: info", () => {
     const res = await openApiFor(
       `
       @serviceVersion("1.2.3-test")
-      namespace Foo {}
+      namespace Foo {
+        op test(): string;
+      }
       `
     );
     strictEqual(res.info.version, "1.2.3-test");
@@ -27,7 +31,9 @@ describe("openapi3: info", () => {
       `
       @doc("My service description")
       @serviceTitle("My Service")
-      namespace Foo {}
+      namespace Foo {
+        op test(): string;
+      }
       `
     );
     strictEqual(res.info.description, "My service description");
@@ -37,7 +43,9 @@ describe("openapi3: info", () => {
       `
       @externalDocs("https://example.com", "more info")
       @serviceTitle("My Service")
-      namespace Foo {}
+      namespace Foo {
+        op test(): string;
+      }
       `
     );
     deepStrictEqual(res.externalDocs, {

--- a/packages/openapi3/test/openapi-output.test.ts
+++ b/packages/openapi3/test/openapi-output.test.ts
@@ -1,5 +1,5 @@
 import { resolvePath } from "@cadl-lang/compiler";
-import { expectDiagnostics } from "@cadl-lang/compiler/testing";
+import { expectDiagnosticEmpty, expectDiagnostics } from "@cadl-lang/compiler/testing";
 import { deepStrictEqual, ok, strictEqual } from "assert";
 import { OpenAPI3EmitterOptions } from "../src/lib.js";
 import {
@@ -15,10 +15,12 @@ describe("openapi3: output file", () => {
 
     const outPath = resolvePath("/openapi.json");
 
-    await runner.compile(code, {
+    const diagnostics = await runner.diagnose(code, {
       noEmit: false,
       emitters: { "@cadl-lang/openapi3": { ...options, "output-file": outPath } },
     });
+
+    expectDiagnosticEmpty(diagnostics.filter((x) => x.code !== "@cadl-lang/rest/no-routes"));
 
     return runner.fs.get(outPath)!;
   }
@@ -105,7 +107,7 @@ describe("openapi3: definitions", () => {
         x: { type: "integer", format: "int32" },
       },
       required: ["x"],
-      "x-cadl-name": "root.(anonymous model)",
+      "x-cadl-name": "(anonymous model)",
     });
   });
 
@@ -186,9 +188,7 @@ describe("openapi3: definitions", () => {
       model Child extends Parent {
         y?: int32;
       }
-      namespace Test {
-        @route("/") op test(): Parent;
-      }
+      @route("/") op test(): Parent;
       `
     );
     deepStrictEqual(res.components.schemas.Parent, {
@@ -214,9 +214,7 @@ describe("openapi3: definitions", () => {
       model Child extends TParent<string> {
         y?: int32;
       }
-      namespace Test {
-        @route("/") op test(): Parent;
-      }
+      @route("/") op test(): Parent;
       `
     );
     ok(
@@ -252,9 +250,7 @@ describe("openapi3: definitions", () => {
       model Child is TParent<string> {
         y?: int32;
       }
-      namespace Test {
-        @route("/") op test(): Parent;
-      }
+      @route("/") op test(): Parent;
       `
     );
     ok(
@@ -561,10 +557,7 @@ describe("openapi3: definitions", () => {
       enum PetType {
       }
       model Pet { type: PetType };
-      @route("/")
-      namespace root {
-        op read(): Pet;
-      }
+      op read(): Pet;
       `);
 
     expectDiagnostics(diagnostics, {
@@ -582,10 +575,7 @@ describe("openapi3: definitions", () => {
       model Dog {
         bark: string;
       }
-      @route("/")
-      namespace root {
-        @post op create(@body body: Cat | Dog): { ...Response<200> };
-      }
+      @post op create(@body body: Cat | Dog): { ...Response<200> };
       `);
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
     ok(openApi.components.schemas.Dog, "expected definition named Dog");
@@ -600,10 +590,8 @@ describe("openapi3: definitions", () => {
       model Cat {
         meow: int32;
       }
-      @route("/")
-      namespace root {
-        @post op create(@body body: Cat | string): { ...Response<200> };
-      }
+      
+      @post op create(@body body: Cat | string): { ...Response<200> };
       `);
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
     deepStrictEqual(openApi.paths["/"].post.requestBody.content["application/json"].schema, {
@@ -621,10 +609,7 @@ describe("openapi3: definitions", () => {
       bark: string;
     }
     alias Pet = Cat | Dog;
-    @route("/")
-    namespace root {
-      @post op create(@body body: Pet): { ...Response<200> };
-    }
+    @post op create(@body body: Pet): { ...Response<200> };
     `);
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
     ok(openApi.components.schemas.Dog, "expected definition named Dog");
@@ -642,10 +627,8 @@ describe("openapi3: definitions", () => {
       model Dog {
         bark: string;
       }
-      @route("/")
-      namespace root {
-        op read(): { @body body: Cat | Dog };
-      }
+      
+      op read(): { @body body: Cat | Dog };
       `);
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
     ok(openApi.components.schemas.Dog, "expected definition named Dog");
@@ -660,10 +643,8 @@ describe("openapi3: definitions", () => {
     model Cat {
       meow: int32;
     }
-    @route("/")
-    namespace root {
-      op read(): { @body body: Cat | string };
-    }
+    
+    op read(): { @body body: Cat | string };
     `);
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
     deepStrictEqual(openApi.paths["/"].get.responses["200"].content["application/json"].schema, {
@@ -681,10 +662,7 @@ describe("openapi3: definitions", () => {
         bark: string;
       }
       alias Pet = Cat | Dog;
-      @route("/")
-      namespace root {
-        op read(): { @body body: Pet };
-      }
+      op read(): { @body body: Pet };
       `);
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
     ok(openApi.components.schemas.Dog, "expected definition named Dog");
@@ -702,10 +680,7 @@ describe("openapi3: definitions", () => {
       model Dog {
         bark: string;
       }
-      @route("/")
-      namespace root {
-        op read(): OkResponse & Body<Cat | Dog>;
-      }
+      op read(): OkResponse & Body<Cat | Dog>;
       `);
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
     ok(openApi.components.schemas.Dog, "expected definition named Dog");
@@ -724,10 +699,8 @@ describe("openapi3: definitions", () => {
         bark: string;
       }
       union Pet { cat: Cat, dog: Dog }
-      @route("/")
-      namespace root {
-        op read(): { @body body: Pet };
-      }
+      
+      op read(): { @body body: Pet };
       `);
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
     ok(openApi.components.schemas.Dog, "expected definition named Dog");
@@ -750,10 +723,7 @@ describe("openapi3: definitions", () => {
       }
       @oneOf
       union Pet { cat: Cat, dog: Dog }
-      @route("/")
-      namespace root {
-        op read(): { @body body: Pet };
-      }
+      op read(): { @body body: Pet };
       `);
     ok(openApi.components.schemas.Cat, "expected definition named Cat");
     ok(openApi.components.schemas.Dog, "expected definition named Dog");
@@ -866,10 +836,8 @@ describe("openapi3: operations", () => {
     const res = await openApiFor(
       `
       @route("/")
-      namespace root {
-        @get()
-        op read(@query queryWithDefault?: string = "defaultValue"): string;
-      }
+      @get()
+      op read(@query queryWithDefault?: string = "defaultValue"): string;
       `
     );
 
@@ -879,19 +847,16 @@ describe("openapi3: operations", () => {
   it("define operations with param with decorators", async () => {
     const res = await openApiFor(
       `
-      @route("/thing")
-      namespace root {
-        @get
-        @route("{name}")
-        op getThing(
-          @pattern("^[a-zA-Z0-9-]{3,24}$")
-          @path name: string,
+      @get
+      @route("/thing/{name}")
+      op getThing(
+        @pattern("^[a-zA-Z0-9-]{3,24}$")
+        @path name: string,
 
-          @minValue(1)
-          @maxValue(10)
-          @query count: int32
-        ): string;
-      }
+        @minValue(1)
+        @maxValue(10)
+        @query count: int32
+      ): string;
       `
     );
 
@@ -912,14 +877,9 @@ describe("openapi3: operations", () => {
 describe("openapi3: request", () => {
   describe("binary request", () => {
     it("bytes request should default to application/json byte", async () => {
-      const res = await openApiFor(
-        `
-      @route("/")
-      namespace root {
+      const res = await openApiFor(`
         @post op read(@body body: bytes): {};
-      }
-      `
-      );
+      `);
 
       const requestBody = res.paths["/"].post.requestBody;
       ok(requestBody);
@@ -928,14 +888,9 @@ describe("openapi3: request", () => {
     });
 
     it("bytes request should respect @header contentType and use binary format when not json or text", async () => {
-      const res = await openApiFor(
-        `
-      @route("/")
-      namespace root {
+      const res = await openApiFor(`
         @post op read(@header contentType: "image/png", @body body: bytes): {};
-      }
-      `
-      );
+      `);
 
       const requestBody = res.paths["/"].post.requestBody;
       ok(requestBody);
@@ -947,19 +902,13 @@ describe("openapi3: request", () => {
 
 describe("openapi3: extension decorator", () => {
   it("adds an arbitrary extension to a model", async () => {
-    const oapi = await openApiFor(
-      `
+    const oapi = await openApiFor(`
       @extension("x-model-extension", "foobar")
       model Pet {
         name: string;
       }
-      @route("/")
-      namespace root {
-        @get()
-        op read(): Pet;
-      }
-      `
-    );
+      @get() op read(): Pet;
+      `);
     ok(oapi.components.schemas.Pet);
     strictEqual(oapi.components.schemas.Pet["x-model-extension"], "foobar");
   });
@@ -970,12 +919,9 @@ describe("openapi3: extension decorator", () => {
       model Pet {
         name: string;
       }
-      @route("/")
-      namespace root {
-        @get()
-        @extension("x-operation-extension", "barbaz")
-        op list(): Pet[];
-      }
+      @get()
+      @extension("x-operation-extension", "barbaz")
+      op list(): Pet[];
       `
     );
     ok(oapi.paths["/"].get);
@@ -994,10 +940,8 @@ describe("openapi3: extension decorator", () => {
         petId: string;
       }
       @route("/Pets")
-      namespace root {
-        @get()
-        op get(... PetId): Pet;
-      }
+      @get()
+      op get(... PetId): Pet;
       `
     );
     ok(oapi.paths["/Pets/{petId}"].get);
@@ -1023,10 +967,8 @@ describe("openapi3: extension decorator", () => {
         petId: string;
       }
       @route("/Pets")
-      namespace root {
-        @get()
-        op get(... PetId): Pet;
-      }
+      @get()
+      op get(... PetId): Pet;
       `
     );
     ok(oapi.paths["/Pets/{petId}"].get);

--- a/packages/openapi3/test/parameters.test.ts
+++ b/packages/openapi3/test/parameters.test.ts
@@ -54,8 +54,7 @@ describe("openapi3: parameters", () => {
   });
 
   it("encodes parameter keys in references", async () => {
-    const oapi = await openApiFor(
-      `
+    const oapi = await openApiFor(`
       model Pet extends Pet$Id {
         name: string;
       }
@@ -63,13 +62,11 @@ describe("openapi3: parameters", () => {
         @path
         petId: string;
       }
+
       @route("/Pets")
-      namespace root {
-        @get()
-        op get(... Pet$Id): Pet;
-      }
-      `
-    );
+      @get()
+      op get(... Pet$Id): Pet;
+      `);
 
     ok(oapi.paths["/Pets/{petId}"].get);
     strictEqual(

--- a/packages/openapi3/test/return-types.test.ts
+++ b/packages/openapi3/test/return-types.test.ts
@@ -12,11 +12,7 @@ describe("openapi3: return types", () => {
       model Key {
         key: string;
       }
-      @route("/")
-      namespace root {
-        @get()
-        op read(): Key & ETagHeader;
-      }
+      @get() op read(): Key & ETagHeader;
       `
     );
     ok(res.paths["/"].get.responses["200"].headers);
@@ -32,11 +28,7 @@ describe("openapi3: return types", () => {
       model Key {
         key: string;
       }
-      @route("/")
-      namespace root {
-        @put
-        op create(): CreatedResponse & Key;
-      }
+      @put op create(): CreatedResponse & Key;
       `
     );
     ok(res.paths["/"].put.responses["201"]);
@@ -52,11 +44,7 @@ describe("openapi3: return types", () => {
       model Key {
         key: string;
       }
-      @route("/")
-      namespace root {
-        @put
-        op create(): CreatedResponse & Key;
-      }
+      @put op create(): CreatedResponse & Key;
       `
     );
     ok(res.paths["/"].put.responses["201"]);
@@ -75,11 +63,7 @@ describe("openapi3: return types", () => {
       model Key {
         key: string;
       }
-      @route("/")
-      namespace root {
-        @put
-        op create(): { ...CreatedResponse, ...ETagHeader, @body body: Key};
-      }
+      @put op create(): { ...CreatedResponse, ...ETagHeader, @body body: Key};
       `
     );
     ok(res.paths["/"].put.responses["201"]);
@@ -103,11 +87,7 @@ describe("openapi3: return types", () => {
       model CreatePageResponse extends CreatedResponse {
         @body body: Page;
       }
-      @route("/")
-      namespace root {
-        @put
-        op create(): CreatePageResponse;
-      }
+      @put op create(): CreatePageResponse;
       `
     );
     ok(res.paths["/"].put.responses["201"]);
@@ -129,11 +109,7 @@ describe("openapi3: return types", () => {
       model Key {
         key: string;
       }
-      @route("/")
-      namespace root {
-        @put
-        op create(): CreatedOrUpdatedResponse & DateHeader & Key;
-      }
+      @put op create(): CreatedOrUpdatedResponse & DateHeader & Key;
       `
     );
     ok(res.paths["/"].put.responses["200"]);
@@ -162,11 +138,7 @@ describe("openapi3: return types", () => {
       model Key {
         key: string;
       }
-      @route("/")
-      namespace root {
-        @put
-        op create(): CreatedOrUpdatedResponse & DateHeader & Key;
-      }
+      @put op create(): CreatedOrUpdatedResponse & DateHeader & Key;
       `
     );
     ok(res.paths["/"].put.responses["200"]);
@@ -194,11 +166,7 @@ describe("openapi3: return types", () => {
       model Key {
         key: string;
       }
-      @route("/")
-      namespace root {
-        @get
-        op read(): Key | Error;
-      }
+      @get op read(): Key | Error;
       `
     );
     ok(res.paths["/"].get.responses["200"]);
@@ -227,12 +195,9 @@ describe("openapi3: return types", () => {
       model Key {
         key: string;
       }
-      @route("/")
-      namespace root {
-        @get
-        // Note: & takes precedence over |
-        op read(): Key & TextPlain | Error;
-      }
+      
+      // Note: & takes precedence over |
+      @get op read(): Key & TextPlain | Error;
       `
     );
     ok(res.paths["/"].get.responses["200"]);
@@ -249,11 +214,7 @@ describe("openapi3: return types", () => {
       model TextMulti {
         @header contentType: "text/plain" | "text/html" | "text/csv";
       }
-      @route("/")
-      namespace root {
-        @get
-        op read(): { ...TextMulti, @body body: string };
-      }
+      @get op read(): { ...TextMulti, @body body: string };
     `
     );
     ok(res.paths["/"].get.responses["200"]);
@@ -273,17 +234,15 @@ describe("openapi3: return types", () => {
         code: "4XX";
       }
 
-      namespace root {
-        @route("/test1")
-        @get
-        op test1(): { @statusCode code: string, @body body: Foo };
-        @route("/test2")
-        @get
-        op test2(): { @statusCode code: "Ok", @body body: Foo };
-        @route("/test3")
-        @get
-        op test3(): { @statusCode code: "200" | BadRequest, @body body: Foo };
-      }
+      @route("/test1")
+      @get
+      op test1(): { @statusCode code: string, @body body: Foo };
+      @route("/test2")
+      @get
+      op test2(): { @statusCode code: "Ok", @body body: Foo };
+      @route("/test3")
+      @get
+      op test3(): { @statusCode code: "200" | BadRequest, @body body: Foo };
     `
     );
     expectDiagnostics(diagnostics, [
@@ -297,15 +256,9 @@ describe("openapi3: return types", () => {
   });
 
   it("defines responses with primitive types", async () => {
-    const res = await openApiFor(
-      `
-      @route("/")
-      namespace root {
-        @get()
-        op read(): string;
-      }
-      `
-    );
+    const res = await openApiFor(`
+      @get() op read(): string;
+      `);
     ok(res.paths["/"].get.responses["200"]);
     ok(res.paths["/"].get.responses["200"].content);
     strictEqual(
@@ -320,11 +273,7 @@ describe("openapi3: return types", () => {
       model Foo {
         foo: string;
       }
-      @route("/")
-      namespace root {
-        @get()
-        op read(): Foo[];
-      }
+      @get() op read(): Foo[];
       `
     );
     ok(res.paths["/"].get.responses["200"]);
@@ -338,10 +287,7 @@ describe("openapi3: return types", () => {
   it("return type with no properties should be 204 response w/ no content", async () => {
     const res = await openApiFor(
       `
-      @route("/")
-      namespace root {
-        @get op delete(): {};
-      }
+      @get op delete(): {};
       `
     );
 
@@ -352,14 +298,9 @@ describe("openapi3: return types", () => {
   });
 
   it("return type with only response metadata should be 204 response w/ no content", async () => {
-    const res = await openApiFor(
-      `
-      @route("/")
-      namespace root {
-        @get op delete(): {@header date: string};
-      }
-      `
-    );
+    const res = await openApiFor(`
+      @get op delete(): {@header date: string};
+    `);
 
     const responses = res.paths["/"].get.responses;
     ok(responses["204"]);
@@ -368,15 +309,9 @@ describe("openapi3: return types", () => {
   });
 
   it("defaults status code to 204 when implicit body has no content", async () => {
-    const res = await openApiFor(
-      `
-      @route("/")
-      namespace root {
-        @delete
-        op delete(): { @header date: string };
-      }
-      `
-    );
+    const res = await openApiFor(`
+      @delete op delete(): { @header date: string };
+      `);
     const responses = res.paths["/"].delete.responses;
     ok(responses["200"] === undefined);
     ok(responses["204"]);
@@ -396,11 +331,7 @@ describe("openapi3: return types", () => {
         foo: string;
       }
 
-      @route("/")
-      namespace root {
-        @get
-        op get(): Foo | Error;
-      }
+      @get op get(): Foo | Error;
       `
     );
     const responses = res.paths["/"].get.responses;
@@ -428,11 +359,7 @@ describe("openapi3: return types", () => {
         foo: string;
       }
 
-      @route("/")
-      namespace root {
-        @get
-        op get(): Foo | Error;
-      }
+      @get op get(): Foo | Error;
       `
     );
     const responses = res.paths["/"].get.responses;
@@ -461,11 +388,7 @@ describe("openapi3: return types", () => {
         foo: string;
       }
 
-      @route("/")
-      namespace root {
-        @get
-        op get(): Foo | Error;
-      }
+      @get op get(): Foo | Error;
       `
     );
     const responses = res.paths["/"].get.responses;
@@ -485,11 +408,7 @@ describe("openapi3: return types", () => {
   it("defines body schema when explicit body has no content", async () => {
     const res = await openApiFor(
       `
-      @route("/")
-      namespace root {
-        @delete
-        op delete(): { @header date: string, @body body: {} };
-      }
+      @delete op delete(): { @header date: string, @body body: {} };
       `
     );
     const responses = res.paths["/"].delete.responses;
@@ -500,14 +419,9 @@ describe("openapi3: return types", () => {
   });
 
   it("return type with only statusCode should have specified status code and no content", async () => {
-    const res = await openApiFor(
-      `
-      @route("/")
-      namespace root {
-        @get op create(): {@statusCode code: 201};
-      }
-      `
-    );
+    const res = await openApiFor(`
+      @get op create(): {@statusCode code: 201};
+    `);
 
     const responses = res.paths["/"].get.responses;
     ok(responses["201"]);
@@ -571,14 +485,9 @@ describe("openapi3: return types", () => {
 
   describe("binary responses", () => {
     it("bytes responses should default to application/json with byte format", async () => {
-      const res = await openApiFor(
-        `
-      @route("/")
-      namespace root {
+      const res = await openApiFor(`
         @get op read(): bytes;
-      }
-      `
-      );
+      `);
 
       const response = res.paths["/"].get.responses["200"];
       ok(response);
@@ -588,14 +497,9 @@ describe("openapi3: return types", () => {
     });
 
     it("@body body: bytes responses default to application/json with bytes format", async () => {
-      const res = await openApiFor(
-        `
-      @route("/")
-      namespace root {
+      const res = await openApiFor(`
         @get op read(): {@body body: bytes};
-      }
-      `
-      );
+      `);
 
       const response = res.paths["/"].get.responses["200"];
       ok(response);
@@ -605,14 +509,9 @@ describe("openapi3: return types", () => {
     });
 
     it("@header contentType text/plain should keep format to byte", async () => {
-      const res = await openApiFor(
-        `
-      @route("/")
-      namespace root {
+      const res = await openApiFor(`
         @get op read(): {@header contentType: "text/plain", @body body: bytes};
-      }
-      `
-      );
+      `);
 
       const response = res.paths["/"].get.responses["200"];
       ok(response);
@@ -622,14 +521,9 @@ describe("openapi3: return types", () => {
     });
 
     it("@header contentType not json or text should set format to binary", async () => {
-      const res = await openApiFor(
-        `
-      @route("/")
-      namespace root {
+      const res = await openApiFor(`
         @get op read(): {@header contentType: "image/png", @body body: bytes};
-      }
-      `
-      );
+      `);
 
       const response = res.paths["/"].get.responses["200"];
       ok(response);

--- a/packages/openapi3/test/test-host.ts
+++ b/packages/openapi3/test/test-host.ts
@@ -1,4 +1,9 @@
-import { createTestHost, createTestWrapper, resolveVirtualPath } from "@cadl-lang/compiler/testing";
+import {
+  createTestHost,
+  createTestWrapper,
+  expectDiagnosticEmpty,
+  resolveVirtualPath,
+} from "@cadl-lang/compiler/testing";
 import { OpenAPITestLibrary } from "@cadl-lang/openapi/testing";
 import { RestTestLibrary } from "@cadl-lang/rest/testing";
 import { VersioningTestLibrary } from "@cadl-lang/versioning/testing";
@@ -26,7 +31,8 @@ function versionedOutput(path: string, version: string) {
 
 export async function diagnoseOpenApiFor(code: string) {
   const runner = await createOpenAPITestRunner();
-  return await runner.diagnose(code);
+  const diagnostics = await runner.diagnose(code);
+  return diagnostics.filter((x) => x.code !== "@cadl-lang/rest/no-routes");
 }
 
 export async function openApiFor(code: string, versions?: string[]) {
@@ -38,10 +44,11 @@ export async function openApiFor(code: string, versions?: string[]) {
       versions ? `import "@cadl-lang/versioning"; using Cadl.Versioning;` : ""
     }using Cadl.Rest;using Cadl.Http;using OpenAPI;${code}`
   );
-  await host.compile("./main.cadl", {
+  const diagnostics = await host.diagnose("./main.cadl", {
     noEmit: false,
     emitters: { "@cadl-lang/openapi3": { "output-file": outPath } },
   });
+  expectDiagnosticEmpty(diagnostics.filter((x) => x.code !== "@cadl-lang/rest/no-routes"));
 
   if (!versions) {
     return JSON.parse(host.fs.get(outPath)!);
@@ -62,6 +69,7 @@ export async function checkFor(code: string) {
 export async function oapiForModel(name: string, modelDef: string) {
   const oapi = await openApiFor(`
     ${modelDef};
+    @serviceTitle("Testing model")
     @route("/")
     namespace root {
       op read(): { @body body: ${name} };

--- a/packages/rest/src/diagnostics.ts
+++ b/packages/rest/src/diagnostics.ts
@@ -131,6 +131,13 @@ const libDefinition = {
         default: "content-type header ignored because return type has no body",
       },
     },
+    "no-routes": {
+      severity: "warning",
+      messages: {
+        default:
+          "Current spec is not exposing any routes. This could be to not having the service namespace marked with @serviceTitle.",
+      },
+    },
   },
 } as const;
 

--- a/packages/rest/src/http/route.ts
+++ b/packages/rest/src/http/route.ts
@@ -10,7 +10,6 @@ import {
   isTemplateDeclarationOrInstance,
   ModelTypeProperty,
   NamespaceType,
-  NoTarget,
   OperationType,
   Program,
   Type,
@@ -515,7 +514,7 @@ export function reportIfNoRoutes(program: Program, routes: OperationDetails[]) {
   if (routes.length === 0) {
     reportDiagnostic(program, {
       code: "no-routes",
-      target: NoTarget,
+      target: program.checker.getGlobalNamespaceType(),
     });
   }
 }

--- a/packages/rest/src/http/route.ts
+++ b/packages/rest/src/http/route.ts
@@ -5,6 +5,7 @@ import {
   DiagnosticCollector,
   getServiceNamespace,
   InterfaceType,
+  isGlobalNamespace,
   isTemplateDeclaration,
   isTemplateDeclarationOrInstance,
   ModelTypeProperty,
@@ -466,9 +467,11 @@ function buildRoutes(
 
   // Build all child routes and append them to the list, but don't recurse in
   // the global scope because that could pull in unwanted operations
-  if (container.kind === "Namespace" && container.name !== "") {
+  if (container.kind === "Namespace") {
+    // If building routes for the global namespace we shouldn't navigate the sub namespaces.
+    const includeSubNamespaces = isGlobalNamespace(program, container);
     const children: OperationContainer[] = [
-      ...container.namespaces.values(),
+      ...(includeSubNamespaces ? [] : container.namespaces.values()),
       ...container.interfaces.values(),
     ];
 

--- a/packages/rest/test/http-decorators.test.ts
+++ b/packages/rest/test/http-decorators.test.ts
@@ -236,7 +236,7 @@ describe("rest: http decorators", () => {
 
     it("set the body with @body", async () => {
       const { body } = await runner.compile(`
-          op test(@test @body body: string): string;
+          @post op test(@test @body body: string): string;
         `);
 
       ok(isBody(runner.program, body));

--- a/packages/rest/test/responses.test.ts
+++ b/packages/rest/test/responses.test.ts
@@ -1,7 +1,7 @@
 import { ModelType } from "@cadl-lang/compiler";
 import { expectDiagnosticEmpty, expectDiagnostics } from "@cadl-lang/compiler/testing";
 import { deepStrictEqual, ok, strictEqual } from "assert";
-import { compileOperations, getOperations } from "./test-host.js";
+import { compileOperations, getOperationsWithServiceNamespace } from "./test-host.js";
 
 describe("cadl: rest: responses", () => {
   it("issues diagnostics for duplicate body decorator", async () => {
@@ -77,7 +77,7 @@ describe("cadl: rest: responses", () => {
   });
 
   it("supports any casing for string literal 'Content-Type' header properties.", async () => {
-    const [routes, diagnostics] = await getOperations(
+    const [routes, diagnostics] = await getOperationsWithServiceNamespace(
       `
       model Foo {}
 
@@ -106,7 +106,7 @@ describe("cadl: rest: responses", () => {
 
   // Regression test for https://github.com/microsoft/cadl/issues/328
   it("empty response model becomes body if it has childrens", async () => {
-    const [routes, diagnostics] = await getOperations(
+    const [routes, diagnostics] = await getOperationsWithServiceNamespace(
       `
       @route("/") op read(): A;
 

--- a/packages/rest/test/routes.test.ts
+++ b/packages/rest/test/routes.test.ts
@@ -1,23 +1,128 @@
-import { expectDiagnosticEmpty } from "@cadl-lang/compiler/testing";
+import { expectDiagnosticEmpty, expectDiagnostics } from "@cadl-lang/compiler/testing";
 import { deepStrictEqual, strictEqual } from "assert";
-import { compileOperations, getRoutesFor } from "./test-host.js";
+import { OperationDetails } from "../src/http/route.js";
+import { compileOperations, getOperations, getRoutesFor } from "./test-host.js";
 
 describe("rest: routes", () => {
-  it("finds routes on bare operations", async () => {
-    const routes = await getRoutesFor(
-      `
-      @route("/things")
-      @get op GetThing(): string;
+  // Describe how routes should be included.
+  describe("route inclusion", () => {
+    function expectRouteIncluded(routes: OperationDetails[], expectedRoutePaths: string[]) {
+      const includedRoutes = routes.map((x) => x.path);
+      deepStrictEqual(includedRoutes, expectedRoutePaths);
+    }
 
-      @route("/things/{thingId}")
-      @post op CreateThing(@path thingId: string): string;
-      `
-    );
+    describe("when there is NO service namespace", () => {
+      it("operations at the document root are included", async () => {
+        const routes = await getOperations(`
+          @route("/one")
+          @get op one(): string;
+          @route("/two")
+          @get op two(): string;
+        `);
 
-    deepStrictEqual(routes, [
-      { verb: "get", path: "/things", params: [] },
-      { verb: "post", path: "/things/{thingId}", params: ["thingId"] },
-    ]);
+        expectRouteIncluded(routes, ["/one", "/two"]);
+      });
+
+      it("interface at the document root are included", async () => {
+        const routes = await getOperations(
+          `
+      interface Foo {
+        @get index(): void;
+      }
+      `
+        );
+
+        expectRouteIncluded(routes, ["/"]);
+      });
+
+      it("routes inside a namespace not marked as the service namespace aren't be included", async () => {
+        const routes = await getOperations(
+          `
+      namespace Foo {
+        @get op index(): void;
+      }
+      `
+        );
+
+        deepStrictEqual(routes, []);
+      });
+    });
+
+    describe("when there is a service namespace", () => {
+      it("operation in the service namespace are included", async () => {
+        const routes = await getOperations(
+          `
+          @serviceTitle("My Service")
+          namespace MyService;
+          @get op index(): void;
+          `
+        );
+
+        expectRouteIncluded(routes, ["/"]);
+      });
+
+      it("operation at the root of the document are NOT included", async () => {
+        const routes = await getOperations(
+          `
+          @route("/not-included")
+          @get op notIncluded(): void;
+
+          @serviceTitle("My Service")
+          namespace MyService {
+            @route("/included")
+            @get op included(): void;
+          }
+          `
+        );
+        expectRouteIncluded(routes, ["/included"]);
+      });
+
+      it("interface in the service namespace are included", async () => {
+        const routes = await getOperations(
+          `
+          @serviceTitle("My Service")
+          namespace MyService;
+          interface Foo {
+            @get index(): void;
+          }`
+        );
+
+        expectRouteIncluded(routes, ["/"]);
+      });
+
+      it("operation in namespace in the service namespace are be included", async () => {
+        const routes = await getOperations(
+          `
+          @serviceTitle("My Service")
+          namespace MyService;
+
+          namespace MyArea{ 
+            @get op index(): void;
+          }
+          `
+        );
+
+        expectRouteIncluded(routes, ["/"]);
+      });
+
+      it("operation in a different namespace are not included", async () => {
+        const routes = await getOperations(
+          `
+          @serviceTitle("My Service")
+          namespace MyService {
+            @route("/included")
+            @get op test(): string;
+          }
+          
+          namespace MyLib { 
+            @route("/not-included")
+            @get op notIncluded(): void;
+          }
+          `
+        );
+        expectRouteIncluded(routes, ["/included"]);
+      });
+    });
   });
 
   it("combines routes on namespaced bare operations", async () => {
@@ -314,9 +419,10 @@ describe("rest: routes", () => {
         @get op get(@body body: string, @path @query multiParam: string): string;
       `);
 
-      strictEqual(diagnostics.length, 1);
-      strictEqual(diagnostics[0].code, "@cadl-lang/rest/operation-param-duplicate-type");
-      strictEqual(diagnostics[0].message, "Param multiParam has multiple types: [query, path]");
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/rest/operation-param-duplicate-type",
+        message: "Param multiParam has multiple types: [query, path]",
+      });
     });
 
     it("emit diagnostic when there is an unannotated parameter and a @body param", async () => {
@@ -325,12 +431,11 @@ describe("rest: routes", () => {
         @get op get(param1: string, @body param2: string): string;
       `);
 
-      strictEqual(diagnostics.length, 1);
-      strictEqual(diagnostics[0].code, "@cadl-lang/rest/duplicate-body");
-      strictEqual(
-        diagnostics[0].message,
-        "Operation has a @body and an unannotated parameter. There can only be one representing the body"
-      );
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/rest/duplicate-body",
+        message:
+          "Operation has a @body and an unannotated parameter. There can only be one representing the body",
+      });
     });
 
     it("emit diagnostic when there are multiple @body param", async () => {
@@ -339,9 +444,10 @@ describe("rest: routes", () => {
         @get op get(@query select: string, @body param1: string, @body param2: string): string;
       `);
 
-      strictEqual(diagnostics.length, 1);
-      strictEqual(diagnostics[0].code, "@cadl-lang/rest/duplicate-body");
-      strictEqual(diagnostics[0].message, "Operation has multiple @body parameters declared");
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/rest/duplicate-body",
+        message: "Operation has multiple @body parameters declared",
+      });
     });
 
     it("resolve body when defined with @body", async () => {

--- a/packages/rest/test/routes.test.ts
+++ b/packages/rest/test/routes.test.ts
@@ -24,15 +24,33 @@ describe("rest: routes", () => {
       });
 
       it("interface at the document root are included", async () => {
-        const routes = await getOperations(
-          `
-      interface Foo {
-        @get index(): void;
-      }
-      `
-        );
+        const routes = await getOperations(`
+          interface Foo {
+            @get index(): void;
+          }
+        `);
 
         expectRouteIncluded(routes, ["/"]);
+      });
+
+      it("generic operation at the document root are NOT included", async () => {
+        const routes = await getOperations(`
+          @route("/not-included")
+          @get op index<T>(): T;
+        `);
+
+        expectRouteIncluded(routes, []);
+      });
+
+      it("generic interface at the document root are NOT included", async () => {
+        const routes = await getOperations(`
+          interface Foo<T> {
+            @route("/not-included")
+            @get index(): T;
+          }
+        `);
+
+        expectRouteIncluded(routes, []);
       });
 
       it("routes inside a namespace not marked as the service namespace aren't be included", async () => {

--- a/packages/rest/test/test-host.ts
+++ b/packages/rest/test/test-host.ts
@@ -26,7 +26,8 @@ export async function createRestTestRunner(): Promise<BasicTestRunner> {
   return createTestWrapper(
     host,
     (code) =>
-      `import "@cadl-lang/rest"; namespace TestNamespace; using Cadl.Rest; using Cadl.Http; ${code}`
+      `import "@cadl-lang/rest"; using Cadl.Rest; using Cadl.Http;
+      ${code}`
   );
 }
 
@@ -66,7 +67,7 @@ export async function compileOperations(
   code: string,
   routeOptions?: RouteOptions
 ): Promise<[SimpleOperationDetails[], readonly Diagnostic[]]> {
-  const [routes, diagnostics] = await getOperations(code, routeOptions);
+  const [routes, diagnostics] = await getOperationsWithServiceNamespace(code, routeOptions);
 
   const details = routes.map((r) => {
     return {
@@ -86,12 +87,26 @@ export async function compileOperations(
   return [details, diagnostics];
 }
 
-export async function getOperations(
+export async function getOperationsWithServiceNamespace(
   code: string,
   routeOptions?: RouteOptions
 ): Promise<[OperationDetails[], readonly Diagnostic[]]> {
   const runner = await createRestTestRunner();
-  await runner.compileAndDiagnose(code, { noEmit: true });
+  await runner.compileAndDiagnose(
+    `@serviceTitle("Test Service") namespace TestService;
+    ${code}`,
+    {
+      noEmit: true,
+    }
+  );
   const [routes] = getAllRoutes(runner.program, routeOptions);
   return [routes, runner.program.diagnostics];
+}
+
+export async function getOperations(code: string): Promise<OperationDetails[]> {
+  const runner = await createRestTestRunner();
+  await runner.compile(code);
+  const [routes, diagnostics] = getAllRoutes(runner.program);
+  expectDiagnosticEmpty(diagnostics);
+  return routes;
 }

--- a/packages/samples/binary/binary.cadl
+++ b/packages/samples/binary/binary.cadl
@@ -2,6 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
+@serviceTitle("Binary sample")
+namespace BinarySample;
+
 model HasBytes {
   bytes: bytes;
 }

--- a/packages/samples/documentation/docs.cadl
+++ b/packages/samples/documentation/docs.cadl
@@ -2,6 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
+@serviceTitle("Documentaion sample")
+namespace DocSample;
+
 @route("/foo")
 @doc("Things to do with foo")
 namespace Foo {

--- a/packages/samples/grpc-kiosk-example/kiosk.cadl
+++ b/packages/samples/grpc-kiosk-example/kiosk.cadl
@@ -2,6 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
+@serviceTitle("Grpc Kiosk sample")
+namespace GrpcKioskSample;
+
 @route("/v1")
 @tag("Display")
 namespace Display {

--- a/packages/samples/grpc-library-example/library.cadl
+++ b/packages/samples/grpc-library-example/library.cadl
@@ -8,6 +8,9 @@ import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
+@serviceTitle("Grpc Library sample")
+namespace GrpcLibrarySample;
+
 @doc("""
 This API represents a simple digital library.  It lets you manage Shelf
 resources and Book resources in the library. It defines the following
@@ -83,7 +86,7 @@ The name of a book.
 Book names have the form `shelves/{shelf_id}/books/{book_id}`
 """)
 @pattern("shelves/\\w+/books/\\w+")
-model book_name is string;
+model book_name is string {}
 
 @doc("A single book in the library.")
 model Book {
@@ -109,7 +112,7 @@ The name of a shelf.
 Shelf names have the form `shelves/{shelf_id}`.
 """)
 @pattern("shelves/\\w+")
-model shelf_name is string;
+model shelf_name is string {}
 
 @doc("A Shelf contains a collection of books with a theme.")
 model Shelf {

--- a/packages/samples/grpc-library-example/library.cadl
+++ b/packages/samples/grpc-library-example/library.cadl
@@ -86,7 +86,7 @@ The name of a book.
 Book names have the form `shelves/{shelf_id}/books/{book_id}`
 """)
 @pattern("shelves/\\w+/books/\\w+")
-model book_name is string {}
+model book_name is string;
 
 @doc("A single book in the library.")
 model Book {
@@ -112,7 +112,7 @@ The name of a shelf.
 Shelf names have the form `shelves/{shelf_id}`.
 """)
 @pattern("shelves/\\w+")
-model shelf_name is string {}
+model shelf_name is string;
 
 @doc("A Shelf contains a collection of books with a theme.")
 model Shelf {

--- a/packages/samples/nested/nested.cadl
+++ b/packages/samples/nested/nested.cadl
@@ -2,6 +2,7 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
+@serviceTitle("Nested sample")
 namespace Root {
   @route("/sub/a")
   namespace SubA {
@@ -31,6 +32,6 @@ namespace Root {
   }
 
   namespace SubC {
-    op anotherOp(thing: Root.SubA.Thing, thing2: SubA.Thing): string;
+    @post op anotherOp(thing: Root.SubA.Thing, thing2: SubA.Thing): string;
   }
 }

--- a/packages/samples/nullable/nullable.cadl
+++ b/packages/samples/nullable/nullable.cadl
@@ -3,6 +3,9 @@ import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
+@serviceTitle("Nullable sample")
+namespace NullableSample;
+
 model HasNullables {
   str: string;
   when: plainTime;

--- a/packages/samples/optional/optional.cadl
+++ b/packages/samples/optional/optional.cadl
@@ -2,6 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
+@serviceTitle("Optional sample")
+namespace OptionalSample;
+
 model HasOptional {
   optionalNoDefault?: string;
   optionalString?: string = "default string";

--- a/packages/samples/polymorphism/polymorphism.cadl
+++ b/packages/samples/polymorphism/polymorphism.cadl
@@ -3,6 +3,9 @@ import "@cadl-lang/rest";
 using Cadl.Http;
 using Cadl.Rest;
 
+@serviceTitle("Polymorphism sample")
+namespace PolymorphismSample;
+
 @discriminator("kind")
 model Pet {
   name: string;

--- a/packages/samples/tags/tagged-operations.cadl
+++ b/packages/samples/tags/tagged-operations.cadl
@@ -2,6 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
+@serviceTitle("Tags sample")
+namespace TagsSample;
+
 @route("/foo")
 @tag("foo")
 namespace Foo {

--- a/packages/samples/test/output/binary/openapi.json
+++ b/packages/samples/test/output/binary/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "Binary sample",
     "version": "0000-00-00"
   },
   "tags": [],

--- a/packages/samples/test/output/documentation/openapi.json
+++ b/packages/samples/test/output/documentation/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "Documentaion sample",
     "version": "0000-00-00"
   },
   "tags": [],

--- a/packages/samples/test/output/grpc-kiosk-example/openapi.json
+++ b/packages/samples/test/output/grpc-kiosk-example/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "Grpc Kiosk sample",
     "version": "0000-00-00"
   },
   "tags": [

--- a/packages/samples/test/output/grpc-library-example/openapi.json
+++ b/packages/samples/test/output/grpc-library-example/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "Grpc Library sample",
     "version": "0000-00-00"
   },
   "tags": [

--- a/packages/samples/test/output/nested/openapi.json
+++ b/packages/samples/test/output/nested/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "Nested sample",
     "version": "0000-00-00"
   },
   "tags": [],
@@ -26,7 +26,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Root.SubA.SubSubA.Thing"
+                "$ref": "#/components/schemas/SubA.SubSubA.Thing"
               }
             }
           }
@@ -53,7 +53,47 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Root.SubB.Thing"
+                "$ref": "#/components/schemas/SubB.Thing"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "post": {
+        "operationId": "SubC_anotherOp",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "thing": {
+                    "$ref": "#/components/schemas/SubA.Thing"
+                  },
+                  "thing2": {
+                    "$ref": "#/components/schemas/SubA.Thing"
+                  }
+                },
+                "required": [
+                  "thing",
+                  "thing2"
+                ],
+                "x-cadl-name": "SubC.(anonymous model)"
               }
             }
           }
@@ -63,7 +103,7 @@
   },
   "components": {
     "schemas": {
-      "Root.SubA.SubSubA.Thing": {
+      "SubA.SubSubA.Thing": {
         "type": "object",
         "properties": {
           "name": {
@@ -74,7 +114,19 @@
           "name"
         ]
       },
-      "Root.SubB.Thing": {
+      "SubB.Thing": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "SubA.Thing": {
         "type": "object",
         "properties": {
           "id": {

--- a/packages/samples/test/output/nullable/openapi.json
+++ b/packages/samples/test/output/nullable/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "Nullable sample",
     "version": "0000-00-00"
   },
   "tags": [],

--- a/packages/samples/test/output/optional/openapi.json
+++ b/packages/samples/test/output/optional/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "Optional sample",
     "version": "0000-00-00"
   },
   "tags": [],

--- a/packages/samples/test/output/polymorphism/openapi.json
+++ b/packages/samples/test/output/polymorphism/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "Polymorphism sample",
     "version": "0000-00-00"
   },
   "tags": [],

--- a/packages/samples/test/output/tags/openapi.json
+++ b/packages/samples/test/output/tags/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "Tags sample",
     "version": "0000-00-00"
   },
   "tags": [

--- a/packages/samples/test/output/testserver/body-boolean/openapi.json
+++ b/packages/samples/test/output/testserver/body-boolean/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "sample",
     "version": "0000-00-00"
   },
   "tags": [],

--- a/packages/samples/test/output/testserver/body-complex/openapi.json
+++ b/packages/samples/test/output/testserver/body-complex/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "sample",
     "version": "0000-00-00"
   },
   "tags": [],

--- a/packages/samples/test/output/testserver/body-string/openapi.json
+++ b/packages/samples/test/output/testserver/body-string/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "sample",
     "version": "0000-00-00"
   },
   "tags": [

--- a/packages/samples/test/output/testserver/body-time/openapi.json
+++ b/packages/samples/test/output/testserver/body-time/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "sample",
     "version": "0000-00-00"
   },
   "tags": [],

--- a/packages/samples/test/output/testserver/media-types/openapi.json
+++ b/packages/samples/test/output/testserver/media-types/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "sample",
     "version": "0000-00-00"
   },
   "tags": [],

--- a/packages/samples/test/output/testserver/multiple-inheritance/openapi.json
+++ b/packages/samples/test/output/testserver/multiple-inheritance/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "sample",
     "version": "0000-00-00"
   },
   "tags": [],

--- a/packages/samples/test/output/visibility/openapi.json
+++ b/packages/samples/test/output/visibility/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "(title)",
+    "title": "Visibility sample",
     "version": "0000-00-00"
   },
   "tags": [],

--- a/packages/samples/testserver/body-boolean/body-boolean.cadl
+++ b/packages/samples/testserver/body-boolean/body-boolean.cadl
@@ -4,6 +4,9 @@ import "@cadl-lang/openapi";
 using Cadl.Http;
 using OpenAPI;
 
+@serviceTitle("sample")
+namespace Sample;
+
 @doc("Error")
 @error
 model Error {

--- a/packages/samples/testserver/body-complex/body-complex.cadl
+++ b/packages/samples/testserver/body-complex/body-complex.cadl
@@ -3,6 +3,9 @@ import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
+@serviceTitle("sample")
+namespace Sample;
+
 @doc("Error")
 @error
 model Error {

--- a/packages/samples/testserver/body-string/body-string.cadl
+++ b/packages/samples/testserver/body-string/body-string.cadl
@@ -3,6 +3,9 @@ import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
+@serviceTitle("sample")
+namespace Sample;
+
 @doc("Error")
 @error
 model Error {

--- a/packages/samples/testserver/body-time/body-time.cadl
+++ b/packages/samples/testserver/body-time/body-time.cadl
@@ -3,6 +3,9 @@ import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
+@serviceTitle("sample")
+namespace Sample;
+
 @doc("Error")
 @error
 model Error {

--- a/packages/samples/testserver/media-types/media-types.cadl
+++ b/packages/samples/testserver/media-types/media-types.cadl
@@ -4,6 +4,9 @@ import "@cadl-lang/openapi";
 using Cadl.Http;
 using OpenAPI;
 
+@serviceTitle("sample")
+namespace Sample;
+
 @doc("Uri or local path to source data.")
 model SourcePath {
   @minLength(0)

--- a/packages/samples/testserver/multiple-inheritance/multiple-inheritance.cadl
+++ b/packages/samples/testserver/multiple-inheritance/multiple-inheritance.cadl
@@ -3,6 +3,9 @@ import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
+@serviceTitle("sample")
+namespace Sample;
+
 model Pet {
   name: string;
 }

--- a/packages/samples/visibility/visibility.cadl
+++ b/packages/samples/visibility/visibility.cadl
@@ -2,6 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
+@serviceTitle("Visibility sample")
+namespace VisibilitySample;
+
 model Person {
   @visibility("read") id: string;
   @visibility("write") secret: string;


### PR DESCRIPTION
Fixes #700
Fixes https://github.com/Azure/cadl-azure/issues/1697

![image](https://user-images.githubusercontent.com/1031227/181811242-53011e2d-b90d-4d95-bf61-def164830f27.png)


Bonus also fix versioning on interfaces #502 [link](https://cadlplayground.z22.web.core.windows.net/prs/800/?c=aW1wb3J0ICJAY2FkbC1sYW5nL3Jlc3QiOwrTGnZlcnNpb25pbmciOwoKdXNpbmcgQ2FkbC5WyRk7zBdIdHRwzRFSZXN0OwoKQMdJZWQoxzpzKQpAc2VydmljZVRpdGxlKCJXaWRnZXQgU8YVIikKbmFtZXNwYWNlIERlbW%2FHGDsKCmVudW0gyEcgewogICJ2MSIsxQgyIiwKfQoKQHJvdXRlKMQYKQpvcCBvcDEoKTogc3Ry5QCyyiAyIikKQGFkZOsAmS52MikKaW50ZXJmxHxWMsVjb3AyzEJ9Cg%3D%3D) 


## Changes
Resolving the routes now follow the following logic:
- if there is a service namespace specified
  - only take the operation and interface under that namespace(recursively)
- if not:
  - only take the operation and interfaces defined at the root  (DO NOT look into namespaces)

### Operation at the root
```cadl
op test(): void;
```
✅ [Stay the same](https://cadlplayground.z22.web.core.windows.net/prs/800/?c=b3AgdGVzdCgpOiB2b2lkOw%3D%3D): `/` endpoint


### Operation in namespace (not service namespace)
```
namespace DemoService;

op test(): void;
```
⚠️  [Output stay the same but add warning that there is no routes](https://cadlplayground.z22.web.core.windows.net/prs/800/?c=bmFtZXNwYWNlIERlbW9TZXJ2aWNlOwoKb3AgdGVzdCgpOiB2b2lkOw%3D%3D)



### Operation in namespace (not service namespace) with @route
```
namespace DemoService;

@route("/")
op test(): void;
```
⚠️  [Now the same as previous case, no route included and emit warning](https://cadlplayground.z22.web.core.windows.net/prs/800/?c=aW1wb3J0ICJAY2FkbC1sYW5nL3Jlc3QiOwoKbmFtZXNwYWNlIERlbW9TZXJ2aWNlOwoKQENhZGwuSHR0cC5yb3V0ZSgiLyIpCm9wIHRlc3QoKTogdm9pZDs%3D)


### Operation in service namespace
```cadl
@serviceTitle("My Service")
namespace Foo;

op test(): void;
```
✅ [Stay the same](https://cadlplayground.z22.web.core.windows.net/prs/800/?c=QHNlcnZpY2VUaXRsZSgiTXkgU8YRIikKbmFtZXNwYWNlIEZvbzsKCm9wIHRlc3QoKTogdm9pZDs%3D): `/` endpoint

### Operation in other namespace than service namespace

```
import "@cadl-lang/rest";

using Cadl.Http;

@serviceTitle("My Service")
namespace Foo {
  @route("in-service")
  op test(): void;
}

namespace MyLib {
  @route("my-lib")
  op test(): void;
}
```
⚠️  [Other namespace routes are not included anymore](https://cadlplayground.z22.web.core.windows.net/prs/800/?c=aW1wb3J0ICJAY2FkbC1sYW5nL3Jlc3QiOwoKdXNpbmcgQ2FkbC5IdHRwOwoKQHNlcnZpY2VUaXRsZSgiTXkgU8YRIikKbmFtZXNwYWNlIEZvbyB7CiAgQHJvdXRlKCJpbi3HOCIpCiAgb3AgdGVzdCgpOiB2b2lkOwp9Css9TXlMaWLNP215LWxpYtc7)
