### PR TITLE
Emit diagnostic when an optional property is marked with @key

### DIFF
--- a/common/changes/@cadl-lang/compiler/no-optional-key_2022-08-01-09-09.json
+++ b/common/changes/@cadl-lang/compiler/no-optional-key_2022-08-01-09-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Emit diagnostic when an optional property is marked with @key",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/rest/no-optional-key_2022-08-01-12-00.json
+++ b/common/changes/@cadl-lang/rest/no-optional-key_2022-08-01-12-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -516,6 +516,12 @@ const diagnostics = {
       default: paramMessage`Deprecated: ${"message"}`,
     },
   },
+  "no-optional-key": {
+    severity: "error",
+    messages: {
+      default: paramMessage`Property '${"propertyName"}' marked as key cannot be optional.`,
+    },
+  },
 
   /**
    * Service

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -716,6 +716,17 @@ export function $key(context: DecoratorContext, entity: Type, altName?: string):
     return;
   }
 
+  // Ensure that the key property is not marked as optional
+  if (entity.optional) {
+    reportDiagnostic(context.program, {
+      code: "no-optional-key",
+      format: { propertyName: entity.name },
+      target: entity,
+    });
+
+    return;
+  }
+
   // Register the key property
   context.program.stateMap(keyKey).set(entity, altName || entity.name);
 }

--- a/packages/compiler/test/decorators/decorators.test.ts
+++ b/packages/compiler/test/decorators/decorators.test.ts
@@ -333,6 +333,22 @@ describe("compiler: built-in decorators", () => {
       strictEqual(prop.kind, "ModelProperty" as const);
       strictEqual(getKeyName(runner.program, prop), "alternateName");
     });
+
+    it("emits diagnostic when key property is marked as optional", async () => {
+      const diagnostics = await runner.diagnose(
+        `model M {
+          @key
+          prop?: string;
+        }`
+      );
+
+      expectDiagnostics(diagnostics, [
+        {
+          code: "no-optional-key",
+          message: "Property 'prop' marked as key cannot be optional.",
+        },
+      ]);
+    });
   });
 
   describe("@withoutOmittedProperties", () => {

--- a/packages/rest/test/routes.test.ts
+++ b/packages/rest/test/routes.test.ts
@@ -219,32 +219,6 @@ describe("rest: routes", () => {
     ]);
   });
 
-  it("models with non-required key property will produce required path parameter for key", async () => {
-    const [routes, diagnostics] = await compileOperations(`
-      using Cadl.Rest.Resource;
-
-      namespace Things {
-        model Thing {
-          @key
-          @segment("things")
-          thingId?: string;
-        }
-
-        @autoRoute
-        @get op GetThingWithParams(...KeysOf<Thing>): string;
-      }
-      `);
-
-    deepStrictEqual(routes, [
-      {
-        verb: "get",
-        path: "/things/{thingId}",
-        params: { body: undefined, params: [{ name: "thingId", type: "path" }] },
-      },
-    ]);
-    expectDiagnosticEmpty(diagnostics);
-  });
-
   it("autoRoute operations filter out path parameters with a string literal type", async () => {
     const routes = await getRoutesFor(
       `


### PR DESCRIPTION
This PR fixes #736 by adding a `no-optional-key` diagnostic preventing a `@key` property from also being marked optional.