### PR TITLE
Operations with a body and no verb will default route to POST

### DIFF
--- a/common/changes/@cadl-lang/rest/post-no-body_2022-08-01-09-22.json
+++ b/common/changes/@cadl-lang/rest/post-no-body_2022-08-01-09-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Operations with a body and no verb will default route to POST",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/src/diagnostics.ts
+++ b/packages/rest/src/diagnostics.ts
@@ -15,12 +15,6 @@ const libDefinition = {
         default: paramMessage`Cannot use @${"verb"} on a ${"entityKind"}`,
       },
     },
-    "http-verb-missing-with-body": {
-      severity: "error",
-      messages: {
-        default: paramMessage`Operation ${"operationName"} has a body but doesn't specify a verb.`,
-      },
-    },
     "operation-resource-wrong-type": {
       severity: "error",
       messages: {

--- a/packages/rest/src/http/route.ts
+++ b/packages/rest/src/http/route.ts
@@ -409,17 +409,9 @@ function getVerbForOperation(
     return verb;
   }
 
-  if (parameters.bodyType) {
-    diagnostics.add(
-      createDiagnostic({
-        code: "http-verb-missing-with-body",
-        format: { operationName: operation.name },
-        target: operation,
-      })
-    );
-  }
-
-  return "get";
+  // If no verb was found by this point, choose a verb based on whether there is
+  // a body type for the request
+  return parameters.bodyType ? "post" : "get";
 }
 
 function buildRoutes(

--- a/packages/rest/test/routes.test.ts
+++ b/packages/rest/test/routes.test.ts
@@ -280,14 +280,19 @@ describe("rest: routes", () => {
     ]);
   });
 
-  it("emit diagnostics if operation has a body but didn't specify the verb", async () => {
-    const [_, diagnostics] = await compileOperations(`
+  it("defaults to POST when operation has a body but didn't specify the verb", async () => {
+    const routes = await getRoutesFor(`
         @route("/test")
         op get(@body body: string): string;
     `);
-    strictEqual(diagnostics.length, 1);
-    strictEqual(diagnostics[0].code, "@cadl-lang/rest/http-verb-missing-with-body");
-    strictEqual(diagnostics[0].message, "Operation get has a body but doesn't specify a verb.");
+
+    deepStrictEqual(routes, [
+      {
+        verb: "post",
+        path: "/test",
+        params: [],
+      },
+    ]);
   });
 
   it("emit diagnostics if 2 operation have the same path and verb", async () => {


### PR DESCRIPTION
This PR fixes #766 by defaulting any operation with a body and no verb to POST.