### PR TITLE
Add @overload decorator and accessor(s)

### DIFF
--- a/common/changes/@cadl-lang/compiler/overloads_2022-08-03-05-46.json
+++ b/common/changes/@cadl-lang/compiler/overloads_2022-08-03-05-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add @overload decorator",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}


### PR DESCRIPTION
New overload decorator along with accessor to see what overloads exist for a given operation as well as which operation (if any) a given operation overloads.

No emitters were updated to take advantage of the new decorator.