### PR TITLE
Add @resource decorator for marking resource model types

### DIFF
--- a/common/changes/@cadl-lang/rest/2022-08-05-14-42.json
+++ b/common/changes/@cadl-lang/rest/2022-08-05-14-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add a @resource decorator to simplify how one defines resource types and specifies the collection (segment) name",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -100,6 +100,7 @@ The `@cadl-lang/rest` library defines the following decorators in `Cadl.Rest` na
 | @produces                 | namespace, operations                                 | Syntax:<br> `@produces(mimetypeString)` <br><br>Note:<br> The `@produces` decorator is used to specify the MIME media types or representations a resource can produce and send back to the client.                                                                                                                                                                                                                                                           |
 | @consumes                 | namespace, operations                                 | Syntax:<br> `@consumes(mimetypeString)` <br><br>Note:<br> The `@consumes` decorator is used to specify which MIME media types of representations a resource can accept, or consume, from the client.                                                                                                                                                                                                                                                         |
 | @discriminator            | models                                                | Syntax:<br> `@discriminator(kindString)` <br><br>Note:<br> `@discriminator` allows defining polymorphic models to be used by API as parameters and return types. In many strongly typed languages, they are expressed as inheritance.                                                                                                                                                                                                                        |
+| @resource                 | Model                                                 | Syntax:<br> `@resource(collectionName)` <br><br>Note:<br> This decorator is to used to mark a model as a resource type with a name for the type's collection.                                                                                                                                                                                                                                                                                                |
 | @readsResource            | operations                                            | Syntax:<br> `@readsResource(modelType)` <br><br>Note:<br> This decorator is to used to signal the operation that is the Read operation for a particular resource.                                                                                                                                                                                                                                                                                            |
 | @createsResource          | operations                                            | Syntax:<br> `@createsResource(modelType)` <br><br>Note:<br> This decorator is to used to signal the operation that is the Create operation for a particular resource.                                                                                                                                                                                                                                                                                        |
 | @createsOrUpdatesResource | operations                                            | Syntax:<br> `@createsOrUpdatesResource(modelType)` <br><br>Note:<br> This decorator is to used to signal the operation that is the CreatesOrUpdate operation for a particular resource.                                                                                                                                                                                                                                                                      |
@@ -121,22 +122,23 @@ The `@cadl-lang/rest` library defines the following decorators in `Cadl.Rest` na
 
 These standard interfaces defines resource operations in basic building blocks that you can expose on the resources. You can use `extends` to compose the operations to meet the exact needs of your resource APIs.
 
-For example, for below `foo` model
+For example, for below `Widget` model
 
 ```
-model foo {
+@resource("widgets")
+model Widget {
   @key id: string;
   name: string;
 }
 ```
 
-- `foo` resource supports full CRUDL operations.
+- `Widget` resource supports full CRUDL operations.
 
 ```Cadl
-interface FooService extends Resource.ResourceOperations<Foo, Error>;
+interface WidgetService extends Resource.ResourceOperations<Widget, Error>;
 ```
 
-- `foo` resource supports only CRD operations.
+- `Widget` resource supports only CRD operations.
 
 ```Cadl
 interface WidgetService

--- a/packages/rest/src/resource.ts
+++ b/packages/rest/src/resource.ts
@@ -173,7 +173,7 @@ export function getParentResource(
 }
 
 /**
- * `@parentResource` marks a model property with a reference to its parent resource type
+ * `@parentResource` marks a model with a reference to its parent resource type
  *
  * The first argument should be a reference to a model type which will be treated as the parent
  * type of the target model type.  This will cause the `@key` properties of all parent types of

--- a/packages/samples/rest/petstore/petstore.cadl
+++ b/packages/samples/rest/petstore/petstore.cadl
@@ -16,8 +16,8 @@ model PetStoreError {
   message: string;
 }
 
+@resource("pets")
 model Pet {
-  @segment("pets")
   @key("petId")
   id: int32;
   name: string;
@@ -29,25 +29,25 @@ model Pet {
   ownerId: int64;
 }
 
+@resource("toys")
 @parentResource(Pet)
 model Toy {
-  @segment("toys")
   @key("toyId")
   id: int64;
   petId: int64;
   name: string;
 }
 
+@resource("owners")
 model Owner {
-  @segment("owners")
   @key("ownerId")
   id: int64;
   name: string;
   age: int32;
 }
 
+@resource("checkups")
 model Checkup {
-  @segment("checkups")
   @key("checkupId")
   id: int32;
   vetName: string;


### PR DESCRIPTION
This PR fixes Azure/cadl-azure#1768 which requests a new `@resource` decorator used for marking a model type as a resource.  The initial goal of the decorator is to simplify the pattern for how a spec author creates a new resource type.  

Previously, one would write a resource type like so:

```
model Widget {
  @key("widgetId")
  @segment("widgets")
  id: string;
}
```

After this change, it now looks like:

```
@resource("widgets")
model Widget {
  @key("widgetId")
  id: string;
}
```

The improvement here is that the resource type is more clearly marked and the user no longer has to know to use the `@segment` decorator directly on the key property to define the collection name for route generation.

This decorator can later be expanded to add other functionality, but we're keeping it simple for now to solve this one problem.  Also worth mentioning that **the previous approach with @segment still works**, the new `@resource` decorator is not required at this time (and probably shouldn't ever be if we can avoid it).