### PR TITLE
The ResourceLocation<T> type should have `@format("url")`

### DIFF
--- a/common/changes/@cadl-lang/rest/resource-location-url_2022-08-05-15-47.json
+++ b/common/changes/@cadl-lang/rest/resource-location-url_2022-08-05-15-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "The ResourceLocation<T> type now reports \"format: url\" in OpenAPI emitters",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/lib/rest.cadl
+++ b/packages/rest/lib/rest.cadl
@@ -7,4 +7,5 @@ namespace Cadl.Rest;
 
 @doc("The location of an instance of {name}", TResource)
 @Private.resourceLocation(TResource)
+@format("url")
 model ResourceLocation<TResource> is string;

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -1059,6 +1059,7 @@
           "nextLink": {
             "type": "string",
             "description": "The link to the next page of items",
+            "format": "url",
             "x-cadl-name": "Rest.ResourceLocation<Pet>"
           }
         },
@@ -1113,6 +1114,7 @@
           "nextLink": {
             "type": "string",
             "description": "The link to the next page of items",
+            "format": "url",
             "x-cadl-name": "Rest.ResourceLocation<Checkup>"
           }
         },
@@ -1194,6 +1196,7 @@
           "nextLink": {
             "type": "string",
             "description": "The link to the next page of items",
+            "format": "url",
             "x-cadl-name": "Rest.ResourceLocation<Toy>"
           }
         },
@@ -1267,6 +1270,7 @@
           "nextLink": {
             "type": "string",
             "description": "The link to the next page of items",
+            "format": "url",
             "x-cadl-name": "Rest.ResourceLocation<Owner>"
           }
         },


### PR DESCRIPTION
This PR fixes Azure/cadl-azure#1836 which requests that the `ResourceLocation<T>` type should add `@format("url")` so that the "url" format is specified in OpenAPI emitters.