### PR TITLE
Fix parent uninitialized parent namespace during projection

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-proj-missing-ns_2022-08-05-20-12.json
+++ b/common/changes/@cadl-lang/compiler/fix-proj-missing-ns_2022-08-05-20-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix uninitialzed parent namespaces in projections",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi3/fix-proj-missing-ns_2022-08-05-20-12.json
+++ b/common/changes/@cadl-lang/openapi3/fix-proj-missing-ns_2022-08-05-20-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Fix uninitialized parent namespaces in projection",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/compiler/core/projector.ts
+++ b/packages/compiler/core/projector.ts
@@ -149,7 +149,6 @@ export function createProjector(
       if (projected.kind === "Namespace") {
         // todo: check for never?
         projectedNs.namespaces.set(key, projected);
-        projected.namespace = projectedNs;
       }
     }
   }
@@ -178,6 +177,10 @@ export function createProjector(
     });
 
     projectedNs.decorators = projectDecorators(ns.decorators);
+
+    if (ns.namespace) {
+      projectedNs.namespace = projectNamespace(ns.namespace, false);
+    }
 
     // ns run decorators before projecting anything inside them
     checker.finishType(projectedNs);

--- a/packages/openapi3/test/versioning.test.ts
+++ b/packages/openapi3/test/versioning.test.ts
@@ -1,5 +1,7 @@
+import { DecoratorContext, NamespaceType, OperationType } from "@cadl-lang/compiler";
+import { createTestWrapper } from "@cadl-lang/compiler/testing";
 import { deepStrictEqual, strictEqual } from "assert";
-import { openApiFor } from "./test-host.js";
+import { createOpenAPITestHost, openApiFor } from "./test-host.js";
 
 describe("openapi3: versioning", () => {
   it("works with models", async () => {
@@ -97,6 +99,57 @@ describe("openapi3: versioning", () => {
         prop3: { type: "string" },
       },
       required: ["prop1", "prop2", "prop3"],
+    });
+  });
+
+  describe.only("Versioning Bug Repro", () => {
+    it("doesn't lose parent namespace", async () => {
+      const host = await createOpenAPITestHost();
+
+      let storedNamespace: string | undefined = undefined;
+      host.addJsFile("test.js", {
+        $armNamespace(context: DecoratorContext, entity: NamespaceType) {
+          storedNamespace = context.program.checker.getNamespaceString(entity);
+        },
+      });
+
+      const runner = createTestWrapper(
+        host,
+        (code) =>
+          `import "@cadl-lang/rest"; import "@cadl-lang/openapi";
+           import "@cadl-lang/openapi3"; import "@cadl-lang/versioning";
+           import "./test.js";
+
+           using Cadl.Rest; using Cadl.Http; using OpenAPI; using Cadl.Versioning; ${code}`,
+        { emitters: { "@cadl-lang/openapi3": {} } }
+      );
+
+      const { get } = (await runner.compile(`
+
+      @versioned(Contoso.Library.Versions)
+      namespace Contoso.Library {
+        enum Versions { v1 };
+      }
+
+      @armNamespace
+      @serviceTitle("Widgets 'r' Us")
+      @versionedDependency(Contoso.Library.Versions.v1)
+      namespace Contoso.WidgetService {
+        model Widget {
+          @key
+          @segment("widgets")
+          id: string;
+        }
+
+        interface Operations {
+          @test
+          op get(id: string): Widget;
+        }
+      }
+      `)) as { get: OperationType };
+
+      // Fail!
+      strictEqual(storedNamespace, "Contoso.WidgetService");
     });
   });
 });

--- a/packages/openapi3/test/versioning.test.ts
+++ b/packages/openapi3/test/versioning.test.ts
@@ -1,4 +1,4 @@
-import { DecoratorContext, NamespaceType, OperationType } from "@cadl-lang/compiler";
+import { DecoratorContext, NamespaceType } from "@cadl-lang/compiler";
 import { createTestWrapper } from "@cadl-lang/compiler/testing";
 import { deepStrictEqual, strictEqual } from "assert";
 import { createOpenAPITestHost, openApiFor } from "./test-host.js";
@@ -123,7 +123,7 @@ describe("openapi3: versioning", () => {
       { emitters: { "@cadl-lang/openapi3": {} } }
     );
 
-    const { get } = (await runner.compile(`
+    await runner.compile(`
 
     @versioned(Contoso.Library.Versions)
     namespace Contoso.Library {
@@ -146,7 +146,7 @@ describe("openapi3: versioning", () => {
         op get(id: string): Widget;
       }
     }
-    `)) as { get: OperationType };
+    `);
 
     strictEqual(storedNamespace, "Contoso.WidgetService");
   });


### PR DESCRIPTION
Previously, the parent namespace wasn't set until the subnamespace was initialized and projected. This meant that the parent namespacewas uninitialized when decorators would run on the subnamespace.

This fix moves the initialization of parent namespace to occur before running decorators and projections on the subnamespace.