### PR TITLE
Fix for GET with projections

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-proj-plus-GET_2022-08-06-01-58.json
+++ b/common/changes/@cadl-lang/compiler/fix-proj-plus-GET_2022-08-06-01-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Run projections on types returned from getEffectiveType",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi3/fix-proj-plus-GET_2022-08-06-01-58.json
+++ b/common/changes/@cadl-lang/openapi3/fix-proj-plus-GET_2022-08-06-01-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Run projections on types returned from getEffectiveType",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -373,7 +373,7 @@ export function createChecker(program: Program): Checker {
     finishType,
     isTypeAssignableTo,
     isStdType,
-    getEffectiveModelType,
+    getEffectiveModelType: getProjectedEffectiveModelType,
     filterModelProperties,
   };
 
@@ -4108,6 +4108,24 @@ export function createChecker(program: Program): Checker {
     if (stdType === "Array" && type === stdTypes["Array"]) return true;
     if (stdType === "Record" && type === stdTypes["Record"]) return true;
     return false;
+  }
+
+  function getProjectedEffectiveModelType(
+    model: ModelType,
+    filter?: (property: ModelTypeProperty) => boolean
+  ): ModelType {
+    const type = getEffectiveModelType(model, filter);
+    if (!program.currentProjector) {
+      return type;
+    }
+
+    const projectedType = program.currentProjector.projectType(type);
+    if (projectedType.kind !== "Model") {
+      compilerAssert(false, "Fail");
+    }
+
+    console.log("Returning projected type", projectedType);
+    return projectedType;
   }
 
   function getEffectiveModelType(

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -373,7 +373,7 @@ export function createChecker(program: Program): Checker {
     finishType,
     isTypeAssignableTo,
     isStdType,
-    getEffectiveModelType: getProjectedEffectiveModelType,
+    getEffectiveModelType,
     filterModelProperties,
   };
 
@@ -4110,11 +4110,7 @@ export function createChecker(program: Program): Checker {
     return false;
   }
 
-  function getProjectedEffectiveModelType(
-    model: ModelType,
-    filter?: (property: ModelTypeProperty) => boolean
-  ): ModelType {
-    const type = getEffectiveModelType(model, filter);
+  function getProjectedEffectiveModelType(type: ModelType): ModelType {
     if (!program.currentProjector) {
       return type;
     }
@@ -4137,7 +4133,7 @@ export function createChecker(program: Program): Checker {
 
     if (model.name) {
       // named model
-      return model;
+      return getProjectedEffectiveModelType(model);
     }
 
     // We would need to change the algorithm if this doesn't hold. We
@@ -4205,7 +4201,7 @@ export function createChecker(program: Program): Checker {
       }
     }
 
-    return match ?? model;
+    return match ? getProjectedEffectiveModelType(match) : model;
   }
 
   function filterModelProperties(

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -4124,7 +4124,6 @@ export function createChecker(program: Program): Checker {
       compilerAssert(false, "Fail");
     }
 
-    console.log("Returning projected type", projectedType);
     return projectedType;
   }
 

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -449,7 +449,7 @@ export function $withOptionalProperties(context: DecoratorContext, target: Type)
   target.properties.forEach((p) => (p.optional = true));
 }
 
-// -- @withUpdatableProperties decorator ----------------------
+// -- @withUpdateableProperties decorator ----------------------
 
 export function $withUpdateableProperties(context: DecoratorContext, target: Type) {
   if (!validateDecoratorTarget(context, target, "@withUpdateableProperties", "Model")) {

--- a/packages/openapi3/test/test-host.ts
+++ b/packages/openapi3/test/test-host.ts
@@ -15,14 +15,22 @@ export async function createOpenAPITestHost() {
   });
 }
 
-export async function createOpenAPITestRunner() {
+export async function createOpenAPITestRunner({
+  withVersioning,
+}: { withVersioning?: boolean } = {}) {
   const host = await createOpenAPITestHost();
-  return createTestWrapper(
-    host,
-    (code) =>
-      `import "@cadl-lang/rest"; import "@cadl-lang/openapi"; import "@cadl-lang/openapi3"; using Cadl.Rest; using Cadl.Http; using OpenAPI; ${code}`,
-    { emitters: { "@cadl-lang/openapi3": {} } }
-  );
+  const importAndUsings = `
+  import "@cadl-lang/rest"; import "@cadl-lang/openapi";
+  import "@cadl-lang/openapi3"; 
+  ${withVersioning ? `import "@cadl-lang/versioning"` : ""};
+  using Cadl.Rest;
+  using Cadl.Http;
+  using OpenAPI;
+  ${withVersioning ? "using Cadl.Versioning;" : ""}
+`;
+  return createTestWrapper(host, (code) => `${importAndUsings} ${code}`, {
+    emitters: { "@cadl-lang/openapi3": {} },
+  });
 }
 
 function versionedOutput(path: string, version: string) {

--- a/packages/openapi3/test/versioning.test.ts
+++ b/packages/openapi3/test/versioning.test.ts
@@ -1,5 +1,6 @@
+import { createTestWrapper } from "@cadl-lang/compiler/testing";
 import { deepStrictEqual, strictEqual } from "assert";
-import { openApiFor } from "./test-host.js";
+import { createOpenAPITestHost, openApiFor } from "./test-host.js";
 
 describe("openapi3: versioning", () => {
   it("works with models", async () => {
@@ -100,9 +101,20 @@ describe("openapi3: versioning", () => {
     });
   });
 
-  it.only("works with something?", async () => {
-    const { v1 } = await openApiFor(
-      `      
+  it("doesn't throw errors when using UpdateableProperties", async () => {
+    // if this test throws a duplicate name diagnostic, check that getEffectiveType
+    // is returning the projected type.
+    const host = await createOpenAPITestHost();
+    const runner = createTestWrapper(
+      host,
+      (code) =>
+        `import "@cadl-lang/rest"; import "@cadl-lang/openapi";
+          import "@cadl-lang/openapi3"; import "@cadl-lang/versioning";
+          using Cadl.Rest; using Cadl.Http; using OpenAPI; using Cadl.Versioning; ${code}`,
+      { emitters: { "@cadl-lang/openapi3": {} } }
+    );
+
+    await runner.compile(`
       @versioned(Library.Versions)
       namespace Library {
         enum Versions { v1, v2 };
@@ -129,8 +141,6 @@ describe("openapi3: versioning", () => {
           oops(...UpdateableProperties<Widget>): Widget;
         }
       }
-    `,
-      ["v1", "v2"]
-    );
+    `);
   });
 });

--- a/packages/openapi3/test/versioning.test.ts
+++ b/packages/openapi3/test/versioning.test.ts
@@ -99,4 +99,38 @@ describe("openapi3: versioning", () => {
       required: ["prop1", "prop2", "prop3"],
     });
   });
+
+  it.only("works with something?", async () => {
+    const { v1 } = await openApiFor(
+      `      
+      @versioned(Library.Versions)
+      namespace Library {
+        enum Versions { v1, v2 };
+      }
+      
+      @serviceTitle("Service")
+      @versionedDependency(Library.Versions.v1)
+      namespace Service {
+        model Widget {
+          @key
+          @segment("widgets")
+          name: string;
+          details?: WidgetDetails;
+        }
+      
+        model WidgetDetails {};
+      
+        @autoRoute
+        interface Projects {
+          @doc("Gets the details of a widget.")
+          get(): Widget;
+          
+          // Comment out the next line to make the error go away!
+          oops(...UpdateableProperties<Widget>): Widget;
+        }
+      }
+    `,
+      ["v1", "v2"]
+    );
+  });
 });


### PR DESCRIPTION
Tentative fix #812, as I ran out of time to fix it properly. The root cause of this issue seems to be that `getEffectiveType` doesn't respect projections. The fix I think we should do is to update gET to consult the program's current projection and map the type there. I think @nguerrera should comment on a proper fix, so this is a minimally invasive and somewhat garbage-y wrapper around gET that projects any return value.