### PR TITLE
Combine Route and autoroute together

### DIFF
--- a/packages/rest/src/http/route.ts
+++ b/packages/rest/src/http/route.ts
@@ -322,16 +322,17 @@ function getPathForOperation(
   const parameters = diagnostics.pipe(getOperationParameters(program, operation));
   const pathFragments = [...routeFragments];
   const routePath = getRoutePath(program, operation);
+
+  // Prepend any explicit route path
+  if (routePath) {
+    pathFragments.push(routePath.path);
+  }
+
   if (isAutoRoute(program, operation)) {
     // The operation exists within an @autoRoute scope, generate the path.  This
     // mutates the pathFragments and parameters lists that are passed in!
     generatePathFromParameters(program, operation, pathFragments, parameters, options);
   } else {
-    // Prepend any explicit route path
-    if (routePath) {
-      pathFragments.push(routePath.path);
-    }
-
     // Pull out path parameters to verify what's in the path string
     const paramByName = new Map(
       parameters.parameters


### PR DESCRIPTION
fix Azure/cadl-azure#1658

This is a tentative to fix this problem:
- You have an operation template using `@autoRoute`
- Define an operation with `is <templated op>` Try to change the base path using `@route`

Previously we just ignore @route on the operation without warning.

This makes it that if both @route and @autoRoute are provided it will prepend `@autoRoute` generated path with value in `@route` value.

However not sure this is a correct behavior.

Other options:
- `@route` override `@autoRoute`
- keep it as it is but emit warning if both are provided. This is now the same problem as https://github.com/microsoft/cadl/issues/685