### PR TITLE
Implement discriminated unions

### DIFF
--- a/common/changes/@cadl-lang/openapi3/union-reform_2022-08-11-01-33.json
+++ b/common/changes/@cadl-lang/openapi3/union-reform_2022-08-11-01-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Support more kinds of unions, fix various union bugs, and add support for @discriminator on unions",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/union-reform_2022-08-11-01-33.json
+++ b/common/changes/@cadl-lang/rest/union-reform_2022-08-11-01-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Support more kinds of unions, fix various union bugs, and add support for @discriminator on unions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -843,7 +843,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
       schema.discriminator = discriminator;
       const mapping = getDiscriminatorMapping(
         discriminator,
-        variants.map((v) => v.type) as ModelType[]
+        variants.map((v) => v.type) as Model[]
       );
       if (mapping) {
         schema.discriminator.mapping = mapping;

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1,4 +1,5 @@
 import {
+  BooleanLiteral,
   compilerAssert,
   emitFile,
   EmitOptionsFor,
@@ -35,9 +36,11 @@ import {
   ModelProperty,
   Namespace,
   NewLine,
+  NumericLiteral,
   Operation,
   Program,
   resolvePath,
+  StringLiteral,
   Type,
   TypeNameOptions,
   Union,
@@ -744,90 +747,87 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     }
   }
 
+  /**
+   * A Cadl union maps to a variety of OA3 structures according to the following rules:
+   *
+   * * A union containing `null` makes a `nullable` schema comprised of the remaining
+   *   union variants.
+   * * A union containing literal types are converted to OA3 enums. All literals of the
+   *   same type are combined into single enums.
+   * * A union that contains multiple items (after removing null and combining like-typed
+   *   literals into enums) is an `anyOf` union unless `oneOf` is applied to the union
+   *   declaration.
+   */
   function getSchemaForUnion(union: Union) {
-    let type: string;
-    const nonNullOptions = union.options.filter((t) => !isNullType(t));
-    const nullable = union.options.length != nonNullOptions.length;
-    if (nonNullOptions.length === 0) {
-      reportDiagnostic(program, { code: "union-null", target: union });
-      return {};
+    const variants = Array.from(union.variants.values());
+    const literalVariantEnumByType: Record<string, any> = {};
+    const ofType = getOneOf(program, union) ? "oneOf" : "anyOf";
+    const schemaMembers: { schema: any; type: Type | null }[] = [];
+    let nullable = false;
+
+    for (const variant of variants) {
+      if (isNullType(variant.type)) {
+        nullable = true;
+        continue;
+      }
+
+      if (isLiteralType(variant.type)) {
+        if (!literalVariantEnumByType[variant.type.kind]) {
+          const enumSchema = mapCadlTypeToOpenAPI(variant.type);
+          literalVariantEnumByType[variant.type.kind] = enumSchema;
+          schemaMembers.push({ schema: enumSchema, type: null });
+        } else {
+          literalVariantEnumByType[variant.type.kind].enum.push(variant.type.value);
+        }
+        continue;
+      }
+
+      schemaMembers.push({ schema: getSchemaOrRef(variant.type), type: variant.type });
     }
 
-    const kind = nonNullOptions[0].kind;
-    switch (kind) {
-      case "String":
-        type = "string";
-        break;
-      case "Number":
-        type = "number";
-        break;
-      case "Boolean":
-        type = "boolean";
-        break;
-      case "Model":
-        type = "model";
-        break;
-      case "UnionVariant":
-        type = "model";
-        break;
-      default:
-        reportUnsupportedUnionType(nonNullOptions[0]);
+    if (schemaMembers.length === 0) {
+      if (nullable) {
+        // This union is equivalent to just `null` but OA3 has no way to specify
+        // null as a value, so we throw an error.
+        reportDiagnostic(program, { code: "union-null", target: union });
         return {};
+      } else {
+        // completely empty union can maybe only happen with bugs?
+        compilerAssert(false, "Attempting to emit an empty union");
+      }
     }
 
-    if (type === "model" || type === "array") {
-      if (nonNullOptions.length === 1) {
-        // Get the schema for the model type
-        let schema: any = getSchemaOrRef(nonNullOptions[0]);
-        if (nullable && schema.$ref) {
-          schema = {
-            type: "object",
-            allOf: [schema],
-            nullable: true,
-          };
-        } else if (nullable) {
+    if (schemaMembers.length === 1) {
+      // we can just return the single schema member after applying nullable
+      const schema = schemaMembers[0].schema;
+      const type = schemaMembers[0].type;
+
+      if (nullable) {
+        if (schema.$ref) {
+          // but we can't make a ref "nullable", so wrap in an allOf (for models)
+          // or oneOf (for all other types)
+          if (type && type.kind === "Model") {
+            return { type: "object", allOf: [schema], nullable: true };
+          } else {
+            return { oneOf: [schema], nullable: true };
+          }
+        } else {
           schema.nullable = true;
         }
-        return schema;
-      } else {
-        const ofType = getOneOf(program, union) ? "oneOf" : "anyOf";
-        const schema: any = { [ofType]: nonNullOptions.map((s) => getSchemaOrRef(s)) };
-        return schema;
-      }
-    }
-
-    const values = [];
-    for (const option of nonNullOptions) {
-      if (option.kind != kind) {
-        reportUnsupportedUnion();
       }
 
-      // We already know it's not a model type
-      values.push((option as any).value);
+      return schema;
     }
 
-    const schema: any = { type };
-    if (values.length > 0) {
-      schema.enum = values;
-    }
+    const schema: any = {
+      [ofType]: schemaMembers.map((m) => m.schema),
+    };
+
     if (nullable) {
-      schema["nullable"] = true;
+      schema.nullable = true;
     }
 
     return schema;
-
-    function reportUnsupportedUnionType(type: Type) {
-      reportDiagnostic(program, {
-        code: "union-unsupported",
-        messageId: "type",
-        format: { kind: type.kind },
-        target: type,
-      });
-    }
-
-    function reportUnsupportedUnion() {
-      reportDiagnostic(program, { code: "union-unsupported", target: union });
-    }
   }
 
   function getSchemaForUnionVariant(variant: UnionVariant) {
@@ -837,6 +837,10 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
 
   function isNullType(type: Type): boolean {
     return isIntrinsic(program, type) && getIntrinsicModelName(program, type) === "null";
+  }
+
+  function isLiteralType(type: Type): type is StringLiteral | NumericLiteral | BooleanLiteral {
+    return type.kind === "Boolean" || type.kind === "String" || type.kind === "Number";
   }
 
   function getDefaultValue(type: Type): any {

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -773,7 +773,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     const ofType = getOneOf(program, union) ? "oneOf" : "anyOf";
     const schemaMembers: { schema: any; type: Type | null }[] = [];
     let nullable = false;
-    let discriminator = getDiscriminator(program, union);
+    const discriminator = getDiscriminator(program, union);
 
     for (const variant of variants) {
       if (isNullType(variant.type)) {

--- a/packages/openapi3/test/openapi-output.test.ts
+++ b/packages/openapi3/test/openapi-output.test.ts
@@ -561,30 +561,6 @@ describe("openapi3: definitions", () => {
     });
   });
 
-  it("defines enums with a nullable variant", async () => {
-    const res = await oapiForModel(
-      "Pet",
-      `
-      model Pet {
-        type: "cat" | "dog" | null;
-      };
-    `
-    );
-    ok(res.isRef);
-    deepStrictEqual(res.schemas.Pet, {
-      type: "object",
-      properties: {
-        type: {
-          type: "string",
-          enum: ["cat", "dog"],
-          nullable: true,
-          "x-cadl-name": "cat | dog | null",
-        },
-      },
-      required: ["type"],
-    });
-  });
-
   it("throws diagnostics for empty enum definitions", async () => {
     const runner = await createOpenAPITestRunner();
 

--- a/packages/openapi3/test/union-schema.test.ts
+++ b/packages/openapi3/test/union-schema.test.ts
@@ -62,7 +62,7 @@ describe("openapi3: union type", () => {
     });
   });
 
-  it.only("handles discriminated unions with enum typed fields", async () => {
+  it("handles discriminated unions with enum typed fields", async () => {
     const res = await openApiFor(
       `
       enum Types {

--- a/packages/openapi3/test/union-schema.test.ts
+++ b/packages/openapi3/test/union-schema.test.ts
@@ -1,5 +1,5 @@
-import { deepStrictEqual } from "assert";
-import { openApiFor } from "./test-host.js";
+import { deepStrictEqual, ok } from "assert";
+import { oapiForModel, openApiFor } from "./test-host.js";
 
 describe("openapi3: union type", () => {
   it("makes nullable schema when union with null", async () => {
@@ -18,5 +18,187 @@ describe("openapi3: union type", () => {
       nullable: true,
       "x-cadl-name": "Thing | null",
     });
+  });
+
+  it("handles discriminated unions", async () => {
+    const res = await openApiFor(
+      `
+      model A {
+        type: "A";
+        a: string;
+      }
+
+      model B {
+        type: "B";
+        b: string;
+      }
+
+      @discriminator("type")
+      union AorB {
+        a: A,
+        b: B
+      }
+
+      @discriminator("type")
+      model Base {
+        x: string;
+      }
+      model X extends Base { type: "X" }
+      model Y extends Base { type: "Y"}
+
+
+
+      op foo(x: Base): { thing: Base };
+      `
+    );
+  });
+
+  it("defines nullable properties with multiple variants", async () => {
+    const res = await oapiForModel(
+      "Pet",
+      `
+      model Pet {
+        name: int32 | string | null;
+      };
+      `
+    );
+    ok(res.isRef);
+    ok(res.schemas.Pet.properties.name.nullable);
+    deepStrictEqual(res.schemas.Pet.properties.name.anyOf, [
+      {
+        type: "integer",
+        format: "int32",
+      },
+      {
+        type: "string",
+      },
+    ]);
+  });
+
+  it("defines enums with a nullable variant", async () => {
+    const res = await oapiForModel(
+      "Pet",
+      `
+      model Pet {
+        type: "cat" | "dog" | null;
+      };
+    `
+    );
+    ok(res.isRef);
+    deepStrictEqual(res.schemas.Pet, {
+      type: "object",
+      properties: {
+        type: {
+          type: "string",
+          enum: ["cat", "dog"],
+          nullable: true,
+          "x-cadl-name": "cat | dog | null",
+        },
+      },
+      required: ["type"],
+    });
+  });
+
+  it("handles unions of heterogenous types", async () => {
+    const res = await oapiForModel(
+      "X",
+      `
+      model C {}
+      model X {
+        prop: 1 | C;
+        prop2: C | 1; 
+      }
+      `
+    );
+    ok(res.isRef);
+    deepStrictEqual(res.schemas.X.properties.prop.anyOf, [
+      {
+        type: "number",
+        enum: [1],
+      },
+      {
+        $ref: "#/components/schemas/C",
+      },
+    ]);
+    deepStrictEqual(res.schemas.X.properties.prop2.anyOf, [
+      {
+        $ref: "#/components/schemas/C",
+      },
+      {
+        type: "number",
+        enum: [1],
+      },
+    ]);
+  });
+
+  it("handles unions of different primitive types", async () => {
+    const res = await oapiForModel(
+      "X",
+      `
+      model X {
+        prop: 1 | "string"
+      }
+      `
+    );
+    ok(res.isRef);
+    deepStrictEqual(res.schemas.X.properties.prop.anyOf, [
+      {
+        type: "number",
+        enum: [1],
+      },
+      {
+        type: "string",
+        enum: ["string"],
+      },
+    ]);
+  });
+
+  it("handles enum unions", async () => {
+    const res = await oapiForModel(
+      "X",
+      `
+      enum A {
+        a: 1
+      }
+      
+      enum B {
+        b: 2
+      }
+      model X {
+        prop: A | B
+      }
+      `
+    );
+    ok(res.isRef);
+    deepStrictEqual(res.schemas.X.properties.prop.anyOf, [
+      {
+        $ref: "#/components/schemas/A",
+      },
+      {
+        $ref: "#/components/schemas/B",
+      },
+    ]);
+  });
+
+  it("handles a nullable enum", async () => {
+    const res = await oapiForModel(
+      "X",
+      `
+      enum A {
+        a: 1
+      }
+      
+      model X {
+        prop: A | null
+      }
+      `
+    );
+    ok(res.isRef);
+    deepStrictEqual(res.schemas.X.properties.prop.oneOf, [
+      {
+        $ref: "#/components/schemas/A",
+      },
+    ]);
+    ok(res.schemas.X.properties.prop.nullable);
   });
 });

--- a/packages/rest/src/lib.ts
+++ b/packages/rest/src/lib.ts
@@ -139,6 +139,20 @@ const libDefinition = {
         default: paramMessage`@useAuth ${"kind"} only accept Auth model, Tuple of auth model or union of auth model.`,
       },
     },
+    "invalid-discriminated-union": {
+      severity: "error",
+      messages: {
+        noAnonVariants: "Unions with anonymous variants cannot be discriminated",
+      },
+    },
+    "invalid-discriminated-union-variant": {
+      severity: "error",
+      messages: {
+        default: paramMessage`Union variant ${"name"} must be a model type`,
+        noDiscriminant: paramMessage`Variant ${"name"}'s type is missing the discriminant property ${"discriminant"}`,
+        wrongDiscriminantType: paramMessage`Variant ${"name"}'s type's discriminant property ${"discriminant"} must be a string literal or string enum member`,
+      },
+    },
   },
 } as const;
 

--- a/packages/rest/src/rest.ts
+++ b/packages/rest/src/rest.ts
@@ -10,6 +10,7 @@ import {
   Program,
   setCadlNamespace,
   Type,
+  Union,
 } from "@cadl-lang/compiler";
 import { createStateSymbol, reportDiagnostic } from "./lib.js";
 import { getResourceTypeKey } from "./resource.js";
@@ -68,14 +69,83 @@ const discriminatorKey = createStateSymbol("discriminator");
 
 const discriminatorDecorator = createDecoratorDefinition({
   name: "@discriminator",
-  target: "Model",
+  target: ["Model", "Union"],
   args: [{ kind: "String" }],
 } as const);
 
-export function $discriminator(context: DecoratorContext, entity: Model, propertyName: string) {
+export function $discriminator(
+  context: DecoratorContext,
+  entity: Model | Union,
+  propertyName: string
+) {
   if (!discriminatorDecorator.validate(context, entity, [propertyName])) {
     return;
   }
+
+  let hasErrors = false;
+  if (entity.kind === "Union") {
+    // we can validate discriminator up front for unions. Models are validated
+    // in emitters.
+    for (const variant of entity.variants.values()) {
+      if (typeof variant.name === "symbol") {
+        // likely not possible to hit this without applying the decorator programmatically
+        reportDiagnostic(context.program, {
+          code: "invalid-discriminated-union",
+          target: entity,
+        });
+
+        return;
+      }
+
+      if (variant.type.kind !== "Model") {
+        reportDiagnostic(context.program, {
+          code: "invalid-discriminated-union-variant",
+          messageId: "default",
+          format: {
+            name: variant.name,
+          },
+          target: variant,
+        });
+        hasErrors = true;
+        continue;
+      }
+
+      const prop = variant.type.properties.get(propertyName);
+      if (!prop) {
+        reportDiagnostic(context.program, {
+          code: "invalid-discriminated-union-variant",
+          messageId: "noDiscriminant",
+          format: {
+            name: variant.name,
+            discriminant: propertyName,
+          },
+          target: variant,
+        });
+        hasErrors = true;
+        continue;
+      }
+
+      if (
+        prop.type.kind !== "String" &&
+        (prop.type.kind !== "EnumMember" ||
+          (prop.type.value !== undefined && typeof prop.type.value !== "string"))
+      ) {
+        reportDiagnostic(context.program, {
+          code: "invalid-discriminated-union-variant",
+          messageId: "wrongDiscriminantType",
+          format: {
+            name: variant.name,
+            discriminant: propertyName,
+          },
+          target: variant,
+        });
+        hasErrors = true;
+        continue;
+      }
+    }
+  }
+
+  if (hasErrors) return;
 
   context.program.stateMap(discriminatorKey).set(entity, propertyName);
 }

--- a/packages/rest/test/rest-decorators.test.ts
+++ b/packages/rest/test/rest-decorators.test.ts
@@ -153,4 +153,61 @@ describe("rest: http decorators", () => {
       strictEqual(resourceType!.name, "Widget");
     });
   });
+
+  describe("@discriminator on unions", () => {
+    it("requires variants to be models", async () => {
+      const diagnostics = await runner.diagnose(`
+        @discriminator("kind")
+        union Foo {
+          a: "hi"
+        }
+      `);
+
+      expectDiagnostics(diagnostics, [
+        {
+          code: "@cadl-lang/rest/invalid-discriminated-union-variant",
+          message: "Union variant a must be a model type",
+        },
+      ]);
+    });
+    it("requires variants to have the discriminator property", async () => {
+      const diagnostics = await runner.diagnose(`
+        model A {
+
+        }
+        @discriminator("kind")
+        union Foo {
+          a: A
+        }
+      `);
+
+      expectDiagnostics(diagnostics, [
+        {
+          code: "@cadl-lang/rest/invalid-discriminated-union-variant",
+          message: "Variant a's type is missing the discriminant property kind",
+        },
+      ]);
+    });
+
+    it("requires variant discriminator properties to be string literals or string enum values", async () => {
+      const diagnostics = await runner.diagnose(`
+        model A {
+          kind: string,
+        }
+
+        @discriminator("kind")
+        union Foo {
+          a: A
+        }
+      `);
+
+      expectDiagnostics(diagnostics, [
+        {
+          code: "@cadl-lang/rest/invalid-discriminated-union-variant",
+          message:
+            "Variant a's type's discriminant property kind must be a string literal or string enum member",
+        },
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
* [x] fix various union-related issues as described in #834.
* [x] allow `@discriminator` on unions to emit discriminated unions using the `discriminator` property.
* [x] allow discriminant to be an enum property