### PR TITLE
OpenAPI3: Support @extension on server parameter

### DIFF
--- a/common/changes/@cadl-lang/openapi3/server-variable-openapi-extentensions_2022-08-12-15-17.json
+++ b/common/changes/@cadl-lang/openapi3/server-variable-openapi-extentensions_2022-08-12-15-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Add support for `@extension` on Server variables",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -313,6 +313,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
         } else if (prop.type.kind === "String") {
           variable.enum = [prop.type.value];
         }
+        attachExtensions(program, prop, variable);
         variables[name] = variable;
       }
       return {

--- a/packages/openapi3/test/servers.test.ts
+++ b/packages/openapi3/test/servers.test.ts
@@ -135,6 +135,28 @@ describe("openapi3: servers", () => {
     ]);
   });
 
+  it("set a server with parameters with extensions", async () => {
+    const res = await openApiFor(
+      `
+      @serviceTitle("My service")
+      @server("https://{region}.example.com", "Regional account endpoint", {
+        @extension("x-custom", "Foo")
+        region: string,
+      })
+      namespace MyService {}
+      `
+    );
+    deepStrictEqual(res.servers, [
+      {
+        description: "Regional account endpoint",
+        url: "https://{region}.example.com",
+        variables: {
+          region: { default: "", "x-custom": "Foo" },
+        },
+      },
+    ]);
+  });
+
   it("set a server with enum properties", async () => {
     const res = await openApiFor(
       `


### PR DESCRIPTION
fix #852, this was only a problem in openapi3 emitter, cadl-autorest was already using some shared logic for parameters that included the extensions