### PR TITLE
Remove `evalCadlScript`

### DIFF
--- a/common/changes/@cadl-lang/compiler/remove-eval-cadl_2022-08-15-17-24.json
+++ b/common/changes/@cadl-lang/compiler/remove-eval-cadl_2022-08-15-17-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Internal: Remove `evalCadlScript` from `Program`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/test/checker/duplicate-ids.test.ts
+++ b/packages/compiler/test/checker/duplicate-ids.test.ts
@@ -1,5 +1,5 @@
 import { match, strictEqual } from "assert";
-import { DecoratorContext, Diagnostic } from "../../core/types.js";
+import { Diagnostic } from "../../core/types.js";
 import { createTestHost, TestHost } from "../../testing/index.js";
 
 describe("compiler: duplicate declarations", () => {
@@ -34,26 +34,6 @@ describe("compiler: duplicate declarations", () => {
     assertDuplicates(diagnostics);
   });
 
-  it("reports duplicate model declarations in global scope using eval", async () => {
-    testHost.addJsFile("test.js", {
-      $eval({ program }: DecoratorContext) {
-        program.evalCadlScript(`model A { }`);
-      },
-    });
-    testHost.addCadlFile(
-      "main.cadl",
-      `
-      import "./test.js";
-      @eval
-      model A { }
-    `
-    );
-
-    const diagnostics = await testHost.diagnose("./");
-
-    assertDuplicates(diagnostics);
-  });
-
   it("reports duplicate model declarations in a single namespace", async () => {
     testHost.addCadlFile(
       "main.cadl",
@@ -61,24 +41,6 @@ describe("compiler: duplicate declarations", () => {
       namespace Foo;
       model A { }
       model A { }
-    `
-    );
-
-    const diagnostics = await testHost.diagnose("./");
-    assertDuplicates(diagnostics);
-  });
-
-  it("reports duplicate model declarations in a single namespace using eval", async () => {
-    testHost.addJsFile("test.js", {
-      $eval({ program }: DecoratorContext) {
-        program.evalCadlScript(`namespace Foo; model A { }; model A { };`);
-      },
-    });
-    testHost.addCadlFile(
-      "main.cadl",
-      `
-      import "./test.js";
-      @eval model test { }
     `
     );
 
@@ -97,25 +59,6 @@ describe("compiler: duplicate declarations", () => {
       namespace N {
         model A { };
       }
-    `
-    );
-
-    const diagnostics = await testHost.diagnose("./");
-    assertDuplicates(diagnostics);
-  });
-
-  it("reports duplicate model declarations across multiple namespaces using eval", async () => {
-    testHost.addJsFile("test.js", {
-      $eval({ program }: DecoratorContext) {
-        program.evalCadlScript(`namespace Foo; model A { }`);
-      },
-    });
-    testHost.addCadlFile(
-      "main.cadl",
-      `
-      import "./test.js";
-      namespace Foo;
-      @eval model A { }
     `
     );
 

--- a/packages/compiler/test/checker/namespaces.test.ts
+++ b/packages/compiler/test/checker/namespaces.test.ts
@@ -381,58 +381,6 @@ describe("compiler: blockless namespaces", () => {
     strictEqual(Z.properties.size, 2, "has two properties");
   });
 
-  it("merges properly with other namespaces using eval", async () => {
-    testHost.addCadlFile(
-      "main.cadl",
-      `
-      import "./a.cadl";
-      import "./b.cadl";
-      import "./c.cadl";
-      `
-    );
-    testHost.addCadlFile(
-      "a.cadl",
-      `
-      namespace N;
-      model X { x: int32 }
-      `
-    );
-    testHost.addCadlFile(
-      "b.cadl",
-      `
-      namespace N;
-      model Y { y: int32 }
-      `
-    );
-    testHost.addCadlFile(
-      "c.cadl",
-      `
-      import "./test.js";
-      @eval model test { }
-      `
-    );
-    const { Z } = (await testHost.compile("./")) as {
-      Z: ModelType;
-    };
-    strictEqual(Z.properties.size, 2, "has two properties");
-  });
-
-  it("can access the cadl namespace using eval", async () => {
-    testHost.addCadlFile(
-      "main.cadl",
-      `
-      import "./test.js";
-
-      @test @eval model X { x: int32 }
-      `
-    );
-
-    const { X } = (await testHost.compile("./")) as {
-      X: ModelType;
-    };
-    strictEqual((X.properties.get("x")!.type as ModelType).name, "int32");
-  });
-
   it("does lookup correctly", async () => {
     testHost.addCadlFile(
       "main.cadl",

--- a/packages/compiler/test/checker/namespaces.test.ts
+++ b/packages/compiler/test/checker/namespaces.test.ts
@@ -1,6 +1,6 @@
 import { ok, strictEqual } from "assert";
 import { Program } from "../../core/program.js";
-import { DecoratorContext, ModelType, NamespaceType, Type } from "../../core/types.js";
+import { ModelType, NamespaceType, Type } from "../../core/types.js";
 import { createTestHost, expectDiagnostics, TestHost } from "../../testing/index.js";
 
 describe("compiler: namespaces with blocks", () => {
@@ -382,11 +382,6 @@ describe("compiler: blockless namespaces", () => {
   });
 
   it("merges properly with other namespaces using eval", async () => {
-    testHost.addJsFile("test.js", {
-      $eval({ program }: DecoratorContext) {
-        program.evalCadlScript(`namespace N; @test model Z { ... X, ... Y }`);
-      },
-    });
     testHost.addCadlFile(
       "main.cadl",
       `
@@ -423,12 +418,6 @@ describe("compiler: blockless namespaces", () => {
   });
 
   it("can access the cadl namespace using eval", async () => {
-    testHost.addJsFile("test.js", {
-      $eval({ program }: DecoratorContext) {
-        program.evalCadlScript(`namespace Z; @test model Z { @doc("x") x: int32 }`);
-      },
-    });
-
     testHost.addCadlFile(
       "main.cadl",
       `

--- a/packages/compiler/test/checker/using.test.ts
+++ b/packages/compiler/test/checker/using.test.ts
@@ -1,5 +1,5 @@
 import { match, rejects, strictEqual } from "assert";
-import { DecoratorContext, getSourceLocation } from "../../core/index.js";
+import { getSourceLocation } from "../../core/index.js";
 import { ModelType } from "../../core/types.js";
 import { createTestHost, expectDiagnosticEmpty, TestHost } from "../../testing/index.js";
 
@@ -355,44 +355,6 @@ describe("compiler: using statements", () => {
       `
       namespace Foo;
       model test { x: int32 };
-    `
-    );
-
-    await testHost.compile("./");
-  });
-
-  it("Cadl namespace is automatically using'd in eval", async () => {
-    testHost.addJsFile("test.js", {
-      $eval({ program }: DecoratorContext) {
-        program.evalCadlScript(`namespace Bar; model A { a: int32 };`);
-      },
-    });
-    testHost.addCadlFile(
-      "main.cadl",
-      `
-      import "./test.js";
-
-      namespace Foo;
-      @eval model test { x: int32 };
-    `
-    );
-
-    await testHost.compile("./");
-  });
-
-  it("works with eval", async () => {
-    testHost.addJsFile("test.js", {
-      async $eval({ program }: DecoratorContext) {
-        await program.evalCadlScript(`using Foo; model A { a: X };`);
-      },
-    });
-    testHost.addCadlFile(
-      "main.cadl",
-      `
-      import "./test.js";
-      namespace Foo;
-      model X { };
-      @eval model test { };
     `
     );
 


### PR DESCRIPTION
Now that providerhub legacy code has been removed, there is nothing using `evalCadlScript` anymore. Removing it before it gets used.