### PR TITLE
Use configured cadl-server path in VS when using a solution

### DIFF
--- a/common/changes/cadl-vs/solution-settings_2022-08-24-18-47.json
+++ b/common/changes/cadl-vs/solution-settings_2022-08-24-18-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vs",
+      "comment": "Fix issue with configured cadl-server location not being found when opening a solution.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "cadl-vs"
+}

--- a/packages/cadl-vs/VS2019/Microsoft.Cadl.VS2019.csproj
+++ b/packages/cadl-vs/VS2019/Microsoft.Cadl.VS2019.csproj
@@ -7,10 +7,14 @@
     <VisualStudioMaxVersionExclusive>17.0</VisualStudioMaxVersionExclusive>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.VisualStudio.Workspace" Version="16.3.43" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="16.3.43" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.9.1050" PrivateAssets="All" />
+    <!-- Use 16.0.x here  for compatible API -->
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.208" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Workspace" Version="16.0.59" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="16.0.59" ExcludeAssets="Runtime" />
+    <!-- Use 16.latest for build tools -->
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.11.65" PrivateAssets="All" />
+    <!-- Align with VS 16.0 version here: https://devblogs.microsoft.com/visualstudio/using-newtonsoft-json-in-a-visual-studio-extension/-->
+    <PackageReference Include="NewtonSoft.JSON" Version="9.0.1" ExcludeAssets="Runtime" />
   </ItemGroup>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
   <Import Project="../Microsoft.Cadl.VS.targets" />

--- a/packages/cadl-vs/VS2022/Microsoft.Cadl.VS2022.csproj
+++ b/packages/cadl-vs/VS2022/Microsoft.Cadl.VS2022.csproj
@@ -7,10 +7,14 @@
     <VisualStudioMaxVersionExclusive>18.0</VisualStudioMaxVersionExclusive>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Use 17.0.x or latest 16.x if no 17.0.x for compatible API-->
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.VisualStudio.Workspace" Version="16.3.43" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="16.3.43" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4057" PrivateAssets="All" />
+    <!-- Use latest 17.x for build tools-->
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.3.2093" PrivateAssets="All" />
+    <!-- Align with VS 17.0 version here: https://devblogs.microsoft.com/visualstudio/using-newtonsoft-json-in-a-visual-studio-extension/-->
+    <PackageReference Include="NewtonSoft.JSON" Version="13.0.1" ExcludeAssets="Runtime" />
   </ItemGroup>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
   <Import Project="../Microsoft.Cadl.VS.targets" />

--- a/packages/cadl-vs/src/Exceptions.cs
+++ b/packages/cadl-vs/src/Exceptions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Cadl.VisualStudio
     [Serializable]
     internal sealed class CadlServerNotFoundException : CadlUserErrorException
     {
-        public CadlServerNotFoundException(string fileName, Exception? innerException = null) 
+        public CadlServerNotFoundException(string fileName, Exception? innerException = null)
             : base(string.Join("\n", new string[]
             {
                 $"Cadl server exectuable was not found: '{fileName}' is not found. Make sure either:",

--- a/packages/cadl-vs/src/Exceptions.cs
+++ b/packages/cadl-vs/src/Exceptions.cs
@@ -12,32 +12,25 @@ namespace Microsoft.Cadl.VisualStudio
 
 
     [Serializable]
-    public class CadlUserErrorException : Exception
+    internal class CadlUserErrorException : Exception
     {
-        public CadlUserErrorException() { }
-
-        public CadlUserErrorException(string message)
-            : base(message)
+        public CadlUserErrorException(string message, Exception? innerException = null)
+            : base(message, innerException)
         {
-
         }
     }
 
-
     [Serializable]
-    public class CadlServerNotFoundException : CadlUserErrorException
+    internal sealed class CadlServerNotFoundException : CadlUserErrorException
     {
-        public CadlServerNotFoundException() { }
-
-        public CadlServerNotFoundException(string name)
+        public CadlServerNotFoundException(string fileName, Exception? innerException = null) 
             : base(string.Join("\n", new string[]
             {
-            $"Cadl server exectuable was not found: '{name}' is not found. Make sure either:",
-            " - cadl is installed globally with `npm install -g @cadl-lang/compiler'.",
-            " - cadl server path is configured with https://github.com/microsoft/cadl/blob/main/packages/cadl-vs/README.md#configure-cadl-visual-studio-extension."
-            }))
+                $"Cadl server exectuable was not found: '{fileName}' is not found. Make sure either:",
+                " - cadl is installed globally with `npm install -g @cadl-lang/compiler'.",
+                " - cadl server path is configured with https://github.com/microsoft/cadl/blob/main/packages/cadl-vs/README.md#configure-cadl-visual-studio-extension."
+            }, innerException))
         {
-
         }
     }
 }

--- a/packages/cadl-vs/src/VSExtension.cs
+++ b/packages/cadl-vs/src/VSExtension.cs
@@ -1,22 +1,28 @@
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.Composition;
-using System.Diagnostics;
-using System.IO;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.Workspace;
-using Microsoft.VisualStudio.Workspace.Settings;
-using Microsoft.VisualStudio.Workspace.VSIntegration.Contracts;
+using EnvDTE;
+using Microsoft.Cadl.VisualStudio;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Utilities;
-using Task = System.Threading.Tasks.Task;
-using System.Linq;
+using Microsoft.VisualStudio.Workspace;
+using Microsoft.VisualStudio.Workspace.Settings;
+using Microsoft.VisualStudio.Workspace.VSIntegration.Contracts;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Debugger = System.Diagnostics.Debugger;
+using Process = System.Diagnostics.Process;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Cadl.VisualStudio
 {
@@ -41,59 +47,50 @@ namespace Microsoft.Cadl.VisualStudio
     [ContentType("cadl")]
     public sealed class LanguageClient : ILanguageClient
     {
-
         public string Name => "Cadl";
         public IEnumerable<string>? ConfigurationSections { get; } = new[] { "cadl" };
-
         public object? InitializationOptions => null;
         public bool ShowNotificationOnInitializeFailed => true;
         public IEnumerable<string> FilesToWatch { get; } = new[] { "**/*.cadl", "**/cadl-project.yaml", "**/package.json" };
         public event AsyncEventHandler<EventArgs>? StartAsync;
         public event AsyncEventHandler<EventArgs>? StopAsync { add { } remove { } } // unused
 
-        private readonly IVsFolderWorkspaceService workspaceService;
+        private readonly IVsFolderWorkspaceService _workspaceService;
+        private readonly SVsServiceProvider _serviceProvider;
+        private string? _workspaceFolder;
+        private string? _configuredCadlServerPath;
 
         [ImportingConstructor]
-        public LanguageClient([Import] IVsFolderWorkspaceService workspaceService)
+        public LanguageClient(
+            [Import] IVsFolderWorkspaceService workspaceService,
+            [Import] SVsServiceProvider serviceProvider)
         {
-            this.workspaceService = workspaceService;
+            _workspaceService = workspaceService;
+            _serviceProvider = serviceProvider;
         }
 
         public async Task<Connection?> ActivateAsync(CancellationToken token)
         {
-            await Task.Yield();
+            await LoadSettingsAsync();
 
-            var workspace = workspaceService.CurrentWorkspace;
-            var settingsManager = workspace?.GetSettingsManager();
-            var settings = settingsManager?.GetAggregatedSettings(SettingsTypes.Generic);
-            var options = Environment.GetEnvironmentVariable("CADL_SERVER_NODE_OPTIONS");
-            var (serverCommand, serverArgs, env) = resolveCadlServer(settings);
+            var (serverCommand, serverArgs, env) = resolveCadlServer();
             var info = new ProcessStartInfo
             {
-                // Use cadl-server on PATH in production
                 FileName = serverCommand,
-                Arguments = string.Join(" ", serverArgs),
+                Arguments = serverArgs,
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
-                Environment = { new("NODE_OPTIONS", options) },
-                WorkingDirectory = settings?.ScopePath,
+                WorkingDirectory = _workspaceFolder,
             };
 
             foreach (var entry in env)
             {
-                info.Environment[entry.Key] = entry.Value;
+                info.Environment.Add(entry.Key, entry.Value);
             }
-#if DEBUG
-            // Use local build of cadl-server in development (lauched from F5 in VS)
-            if (InDevelopmentMode())
-            {
-                // --nolazy isn't supported by NODE_OPTIONS so we pass these via CLI instead
-                info.Environment.Remove("NODE_OPTIONS");
-            }
-#endif
+
             try
             {
                 var process = Process.Start(info);
@@ -104,21 +101,16 @@ namespace Microsoft.Cadl.VisualStudio
                   process.StandardOutput.BaseStream,
                   process.StandardInput.BaseStream);
             }
-            catch (Win32Exception e)
+            catch (Win32Exception e) when (e.NativeErrorCode == Win32ErrorCodes.ERROR_FILE_NOT_FOUND)
             {
-                if (e.NativeErrorCode == Win32ErrorCodes.ERROR_FILE_NOT_FOUND)
-                {
-                    throw new CadlServerNotFoundException(info.FileName);
-                }
-                throw e;
+                throw new CadlServerNotFoundException(info.FileName, e);
             }
-
         }
 
         public async Task OnLoadedAsync()
         {
             var start = StartAsync;
-            if (start is not null)
+            if (start != null)
             {
                 await start.InvokeAsync(this, EventArgs.Empty);
             }
@@ -140,17 +132,23 @@ namespace Microsoft.Cadl.VisualStudio
 #endif
 
 #if VS2022
-    public Task<InitializationFailureContext?> OnServerInitializeFailedAsync(ILanguageClientInitializationInfo initializationState) {
-      var exception = initializationState.InitializationException;
-      var message = exception is CadlUserErrorException 
-        ? exception.Message 
-        : $"File issue at https://github.com/microsoft/cadl\r\n\r\n{exception}";
-      Debug.Assert(exception is CadlUserErrorException, "Unexpected error initializing cadl-server:\r\n\r\n" + exception);
-      return Task.FromResult<InitializationFailureContext?>(
-        new InitializationFailureContext {
-          FailureMessage = "Failed to activate Cadl language server!\r\n" + message
-      });
-    }
+        public Task<InitializationFailureContext?> OnServerInitializeFailedAsync(ILanguageClientInitializationInfo initializationState)
+        {
+            var exception = initializationState.InitializationException;
+            var message = exception is CadlUserErrorException
+              ? exception.Message
+              : $"File issue at https://github.com/microsoft/cadl\r\n\r\n{exception}";
+
+            Debug.Assert(
+                exception is CadlUserErrorException,
+                "Unexpected error initializing cadl-server:\r\n\r\n" + exception);
+
+            return Task.FromResult<InitializationFailureContext?>(
+              new InitializationFailureContext
+              {
+                  FailureMessage = "Failed to activate Cadl language server!\r\n" + message
+              });
+        }
 #endif
 
         public Task OnServerInitializedAsync()
@@ -160,7 +158,7 @@ namespace Microsoft.Cadl.VisualStudio
 
         private void LogStderrMessage(string? message)
         {
-            if (message is null || message.Length == 0)
+            if (message == null || message.Length == 0)
             {
                 return;
             }
@@ -185,35 +183,45 @@ namespace Microsoft.Cadl.VisualStudio
             // the source tree.
             var thisDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var srcDir = File.ReadAllText(Path.Combine(thisDir, "DebugSourceDirectory.txt")).Trim();
-            return Path.GetFullPath(Path.Combine(srcDir, "../compiler/cmd/cadl-server.js"));
+            return Path.GetFullPath(Path.Combine(srcDir, "..", "compiler", "cmd", "cadl-server.js"));
         }
 #endif
 
-        private (string, string[], IDictionary<string, string>) resolveCadlServer(IWorkspaceSettings? settings)
+        private (string command, string arguments, IDictionary<string, string> environment) resolveCadlServer()
         {
             var env = new Dictionary<string, string>();
-            var args = new string[] { "--stdio" };
+            var args = "--stdio";
+            var options = Environment.GetEnvironmentVariable("CADL_SERVER_NODE_OPTIONS");
+
 #if DEBUG
             // Use local build of cadl-server in development (lauched from F5 in VS)
             if (InDevelopmentMode())
             {
-               var options = Environment.GetEnvironmentVariable("CADL_SERVER_NODE_OPTIONS");
-               var module = GetDevelopmentCadlServerPath();
-               return ("node.exe", new string[] { module, options }.Concat(args).ToArray(), env);
+                // NOTE: --no-lazy is not supported as environment variable, so we pass it in command line.
+                var module = GetDevelopmentCadlServerPath();
+                return ("node.exe", $"{options} {module} {args}", env);
             }
 #endif
+            if (options != null && options.Length > 0)
+            {
+                env.Add("NODE_OPTIONS", options);
+            }
 
-            var serverPath = settings?.Property<string>("cadl.cadl-server.path");
-            if (serverPath == null)
+            var serverPath = _configuredCadlServerPath;
+            if (serverPath == null || serverPath.Length == 0)
             {
                 return ("cadl-server.cmd", args, env);
             }
 
             var variables = new Dictionary<string, string>();
-            variables.Add("workspaceFolder", workspaceService.CurrentWorkspace.Location);
-            var variableResolver = new VariableResolver(variables);
+            if (_workspaceFolder != null && _workspaceFolder.Length > 0)
+            {
+                variables.Add("workspaceFolder", _workspaceFolder);
+            }
 
-            serverPath = variableResolver.ResolveVariables(serverPath);
+            serverPath = VariableResolver.ResolveVariables(serverPath, variables);
+            serverPath = Path.GetFullPath(serverPath);
+
             if (!serverPath.EndsWith(".js"))
             {
                 if (File.Exists(serverPath))
@@ -223,13 +231,80 @@ namespace Microsoft.Cadl.VisualStudio
                 }
                 else
                 {
-                    serverPath = Path.Combine(serverPath, "cmd/cadl-server.js");
+                    serverPath = Path.Combine(serverPath, "cmd", "cadl-server.js");
                 }
             }
 
-            env["CADL_SKIP_COMPILER_RESOLVE"] = "1";
-            return ("node.exe", new string[] { serverPath }.Concat(args).ToArray(), env);
+            // We need to check this as the later check when process is started would
+            // only trigger if node.exe is not found, not if the .js file passed to it
+            // is not found.
+            if (!File.Exists(serverPath))
+            {
+                throw new CadlServerNotFoundException(serverPath);
+            }
 
+            env.Add("CADL_SKIP_COMPILER_RESOLVE", "1");
+            return ("node.exe", $"{serverPath} {args}", env);
+        }
+
+        private async Task LoadSettingsAsync()
+        {
+            var workspace = _workspaceService.CurrentWorkspace;
+            if (workspace != null)
+            {
+                // Use workspace manager when there is a workspace.
+                var settings = workspace.GetSettingsManager()?.GetAggregatedSettings(SettingsTypes.Generic);
+                _configuredCadlServerPath = settings?.Property<string>("cadl.cadl-server.path");
+                _workspaceFolder = workspace.Location;
+            }
+            else
+            {
+                // When a solution is open, read the settings ourselves.
+                _workspaceFolder = await GetSolutionFolderAsync();
+                var settings = ReadSettingsFromJson(_workspaceFolder);
+                settings.TryGetValue("cadl.cadl-server.path", out _configuredCadlServerPath);
+            }
+        }
+
+        private static Dictionary<string, string> ReadSettingsFromJson(string? workspaceFolder)
+        {
+            var empty = new Dictionary<string, string>();
+            if (workspaceFolder == null || workspaceFolder.Length == 0)
+            {
+                return empty;
+            }
+            
+            var settingsPath = Path.Combine(workspaceFolder, ".vs", "VSWorkspaceSettings.json");
+            if (!File.Exists(settingsPath))
+            {
+                return empty;
+            }
+
+            try
+            {
+                var text = File.ReadAllText(settingsPath);
+                var json = JsonConvert.DeserializeObject<Dictionary<string, object>>(text);
+                return json == null ? empty : json.Where((e) => e.Value is string).ToDictionary(e => e.Key, e => (string)e.Value);
+            }
+            catch (Exception e) when (e is IOException || e is UnauthorizedAccessException || e is JsonException)
+            {
+                throw new CadlUserErrorException($"Error reading {settingsPath}: {e.Message}", e);
+            }
+        }
+
+        private async Task<string?> GetSolutionFolderAsync()
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            var dte = (DTE)_serviceProvider.GetService(typeof(DTE));
+
+            string? folder = null;
+            if (dte != null && dte.Solution != null)
+            {
+                folder = Path.GetDirectoryName(dte.Solution.FullName);
+            }
+
+            await TaskScheduler.Default; //return to thread pool thread
+            return folder;
         }
     }
 }

--- a/packages/cadl-vs/src/VSExtension.cs
+++ b/packages/cadl-vs/src/VSExtension.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Cadl.VisualStudio
             {
                 return empty;
             }
-            
+
             var settingsPath = Path.Combine(workspaceFolder, ".vs", "VSWorkspaceSettings.json");
             if (!File.Exists(settingsPath))
             {

--- a/packages/cadl-vs/src/VSExtension.cs
+++ b/packages/cadl-vs/src/VSExtension.cs
@@ -136,18 +136,18 @@ namespace Microsoft.Cadl.VisualStudio
         {
             var exception = initializationState.InitializationException;
             var message = exception is CadlUserErrorException
-              ? exception.Message
-              : $"File issue at https://github.com/microsoft/cadl\r\n\r\n{exception}";
+                ? exception.Message
+                : $"File issue at https://github.com/microsoft/cadl\r\n\r\n{exception}";
 
             Debug.Assert(
                 exception is CadlUserErrorException,
                 "Unexpected error initializing cadl-server:\r\n\r\n" + exception);
 
             return Task.FromResult<InitializationFailureContext?>(
-              new InitializationFailureContext
-              {
-                  FailureMessage = "Failed to activate Cadl language server!\r\n" + message
-              });
+                new InitializationFailureContext
+                {
+                    FailureMessage = "Failed to activate Cadl language server!\r\n" + message
+                });
         }
 #endif
 

--- a/packages/cadl-vs/src/VariableResolver.cs
+++ b/packages/cadl-vs/src/VariableResolver.cs
@@ -1,52 +1,22 @@
-using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
-using System.Diagnostics;
-using System.IO;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.VisualStudio.Workspace;
-using Microsoft.VisualStudio.Workspace.Settings;
-using Microsoft.VisualStudio.Workspace.VSIntegration.Contracts;
-using Microsoft.VisualStudio.LanguageServer.Client;
-using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Threading;
-using Microsoft.VisualStudio.Utilities;
-using Task = System.Threading.Tasks.Task;
-using System.Linq;
-using System.ComponentModel;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.Cadl.VisualStudio
 {
-    public class VariableResolver
+    internal static class VariableResolver
     {
-        public const string VARIABLE_REGEXP = @"\$\{(.*?)\}";
-        private IDictionary<string, string> variables;
+        private const string VARIABLE_REGEXP = @"\$\{(.*?)\}";
 
-        public VariableResolver(IDictionary<string, string> variables)
-        {
-            this.variables = variables;
-        }
-        public string ResolveVariables(string value)
+        public static string ResolveVariables(string value, IDictionary<string, string> variables)
         {
             return Regex.Replace(value, VARIABLE_REGEXP, (match) =>
             {
                 var group = match.Groups[1];
-                if (group == null)
+                if (group != null && variables.TryGetValue(group.Value, out value))
                 {
-                    return match.Value;
+                    return value;
                 }
-                try
-                {
-                    return variables[group.Value];
-                }
-                catch (KeyNotFoundException)
-                {
-                    return match.Value;
-                }
+                return match.Value;
             });
         }
     }


### PR DESCRIPTION
Take 2 of #916. Did more cleanup (all documented below) and fixed bug where there are non-string values in the settings json file.

When a solution is open, there is no workspace, so we use the solution folder as the workspace folder and read the settings file ourselves.

Also fix an issue where there was not a good user-facing message when cadl-server was configured to a path that did not exist.

Finally, some general cleanup:
* Downgrade 16.x VS API packages to 16.0 for maximum compatibility
* Upgrade other packages to latest
* Run VS format command to format #if blocks not formatted by `dotnet format`
* Run VS remove-and-sort-usings
* Add inner exceptions to our exception types
* Convert VariableResolver to static class
* Avoid checking development mode in two places
* Make helper types internal
* Seal classes where possible
* Use Dictionary.Add instead of indexer to get exception on duplicates
* Use TryGetValue instead of catch KeyNotFoundException
* Use exception filter instead of if+rethrow
* Use string instead of string[] for process arguments
  * It was confusing me that we sometimes put more than one argument in a single array element.
* Use `==` or `!= null` throughout instead of `is` and `is not`
  * I could go either way on this, but chose what we had most for consistency.
* Use multiple args to Path.Combine instead of one with forward slashes to get OS-idiomatic paths.

Fix #660
