### PR TITLE
Fix variable reuse caused by typo

### DIFF
--- a/common/changes/cadl-vs/separate-var_2022-08-25-19-02.json
+++ b/common/changes/cadl-vs/separate-var_2022-08-25-19-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vs",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "cadl-vs"
+}

--- a/packages/cadl-vs/src/VariableResolver.cs
+++ b/packages/cadl-vs/src/VariableResolver.cs
@@ -12,9 +12,9 @@ namespace Microsoft.Cadl.VisualStudio
             return Regex.Replace(value, VARIABLE_REGEXP, (match) =>
             {
                 var group = match.Groups[1];
-                if (group != null && variables.TryGetValue(group.Value, out value))
+                if (group != null && variables.TryGetValue(group.Value, out var variable))
                 {
-                    return value;
+                    return variable;
                 }
                 return match.Value;
             });


### PR DESCRIPTION
The code works as is, but I did not intend to overwrite the value parameter and doing so is very confusing.