### PR TITLE
Remove restriction on keyword length

### DIFF
--- a/common/changes/@cadl-lang/compiler/remove-keyword-length-restriction_2022-08-25-20-41.json
+++ b/common/changes/@cadl-lang/compiler/remove-keyword-length-restriction_2022-08-25-20-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Internal: Make scanner capable of scanning future keywords that are longer than 10 characters.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}


### PR DESCRIPTION
We may need longer keywords for an upcoming feature. I micro-benchmarked and saw only ~3% difference on scanning petstore.cadl ten thousand times. But that's going from ~29us per scan to ~30us per scan and scanning is nowhere close to a bottleneck in any real larger scenarios.