### PR TITLE
Fix symbol mutation in namespace merging

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-merge-symbols_2022-08-30-21-47.json
+++ b/common/changes/@cadl-lang/compiler/fix-merge-symbols_2022-08-30-21-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix issue with ever-increasing duplicate symbol errors in IDE",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -2799,6 +2799,7 @@ export function createChecker(program: Program): Checker {
           mutate(targetBinding.declarations).push(...sourceBinding.declarations);
           mergeSymbolTable(sourceBinding.exports!, mutate(targetBinding.exports!));
         } else {
+          // this will set a duplicate error
           target.set(key, sourceBinding);
         }
       } else {

--- a/packages/compiler/test/server/reuse.test.ts
+++ b/packages/compiler/test/server/reuse.test.ts
@@ -43,7 +43,7 @@ describe("server: reuse", () => {
   });
 
   it("does not mutate symbols when reusing unchanged files", async () => {
-    // trigger features that add symbols during checking: using statements, member references.
+    // trigger features that add symbols during checking: using statements, member references, namespace merging
     const source = `
       import "./other.cadl";
 
@@ -81,6 +81,9 @@ describe("server: reuse", () => {
     const otherSource = `
       namespace OtherNamespace {
         model OtherModel {}
+      }
+      namespace N {
+        model MergedIntoNamespace {}
       }`;
 
     const host = await createTestServerHost();


### PR DESCRIPTION
This would cause duplicate symbol errors to pile up in IDE when reusing source files with merged namespace members.