### PR TITLE
Load swagger UI async

### DIFF
--- a/packages/playground/src/components/swagger-ui.tsx
+++ b/packages/playground/src/components/swagger-ui.tsx
@@ -7,12 +7,12 @@ export interface SwaggerUIProps {
 export const SwaggerUI: FunctionComponent<SwaggerUIProps> = (props) => {
   const uiRef = useRef(null);
   const uiInstance = useRef<any>(null);
-  const [swaggerUI, setSwaggerUILib] = useState<{createSwaggerUI: typeof import("swagger-ui")} | undefined>(
-    undefined
-  );
+  const [swaggerUI, setSwaggerUILib] = useState<
+    { createSwaggerUI: typeof import("swagger-ui") } | undefined
+  >(undefined);
   useEffect(() => {
     void import("swagger-ui").then((lib) => {
-      setSwaggerUILib({createSwaggerUI: lib.default});
+      setSwaggerUILib({ createSwaggerUI: lib.default });
     });
   }, [setSwaggerUILib]);
 

--- a/packages/playground/src/components/swagger-ui.tsx
+++ b/packages/playground/src/components/swagger-ui.tsx
@@ -1,22 +1,34 @@
-import { FunctionComponent, useEffect, useRef } from "react";
-import CreateSwaggerUI from "swagger-ui";
+import { FunctionComponent, useEffect, useRef, useState } from "react";
+
 export interface SwaggerUIProps {
   spec: string;
 }
+
 export const SwaggerUI: FunctionComponent<SwaggerUIProps> = (props) => {
   const uiRef = useRef(null);
   const uiInstance = useRef<any>(null);
+  const [swaggerUI, setSwaggerUILib] = useState<{createSwaggerUI: typeof import("swagger-ui")} | undefined>(
+    undefined
+  );
+  useEffect(() => {
+    void import("swagger-ui").then((lib) => {
+      setSwaggerUILib({createSwaggerUI: lib.default});
+    });
+  }, [setSwaggerUILib]);
 
   useEffect(() => {
+    if (swaggerUI === undefined) {
+      return;
+    }
     if (uiInstance.current === null) {
-      uiInstance.current = CreateSwaggerUI({
+      uiInstance.current = swaggerUI.createSwaggerUI({
         domNode: uiRef.current,
         spec: props.spec as any,
       });
     } else {
       uiInstance.current.specActions.updateSpec(props.spec);
     }
-  }, [props.spec]);
+  }, [swaggerUI, props.spec]);
 
   return <div className="swagger-ui-container" ref={uiRef}></div>;
 };


### PR DESCRIPTION
Improve a little bit the loading time Swagger ui is ~800kb wiich leaves 3.9kb for the main chunk(which is mostly monaco editor).

Feels however the storage account has gotten much much slower