### PR TITLE
Add website doc for openapi3 emitter

### DIFF
--- a/common/changes/@cadl-lang/compiler/openapi3-docs_2022-09-18-12-43.json
+++ b/common/changes/@cadl-lang/compiler/openapi3-docs_2022-09-18-12-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Minor improvemens to decorator definitions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi/openapi3-docs_2022-09-18-12-43.json
+++ b/common/changes/@cadl-lang/openapi/openapi3-docs_2022-09-18-12-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "Add/update docs for openapi3 emitter",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,5 +1,7 @@
 # Introduction to API Definition Language (Cadl)
 
+<!-- cspell:ignore cadl, etag, openapi -->
+
 Cadl is a language for describing cloud service APIs and generating other API description languages, client and service code, documentation, and other assets. Cadl provides highly extensible core language primitives that can describe API shapes common among REST, GraphQL, gRPC, and other protocols.
 
 Cadl is an object oriented dynamic language whose evaluation results in an object model describing service APIs. Unlike typical programming languages, Cadl consists primarily of declarations, however these declarations can be decorated to provide highly dynamic behavior.
@@ -15,15 +17,15 @@ Cadl's primary benefits include:
 
 Cadl consists of the following language features:
 
-- [Models](#Models): data shapes or schemas
-- [Type Literals](#Type-Literals): strings and numbers with specific values
-- [Type Operators](#Type-Operators): syntax for composing model types into other types
-- [Operations](#Operations): service endpoints with parameters and return values
+- [Models](#models): data shapes or schemas
+- [Type Literals](#type-literals): strings and numbers with specific values
+- [Type Operators](#type-operators): syntax for composing model types into other types
+- [Operations](#operations): service endpoints with parameters and return values
 - [Namespaces & Usings](#namespaces--usings): groups models and operations together into hierarchical groups with friendly names
-- [Interfaces](#Interfaces): groups operations
-- [Imports](#Imports): links declarations across multiple files and libraries together into a single program
-- [Decorators](#Decorators): bits of TypeScript code that add metadata or sometimes mutate declarations
-- [Libraries](#Libraries): encapsulate Cadl definitions into reusable components
+- [Interfaces](#interfaces): groups operations
+- [Imports](#imports): links declarations across multiple files and libraries together into a single program
+- [Decorators](#decorators): bits of TypeScript code that add metadata or sometimes mutate declarations
+- [Libraries](#libraries): encapsulate Cadl definitions into reusable components
 
 In addition, Cadl comes with a standard library for describing REST APIs and generating OpenAPI. Other protocol bindings are a work in progress!
 
@@ -110,7 +112,7 @@ model Dog extends Animal {}
 
 #### Is
 
-Sometimes you want to copy all aspects of a type without creating a nominal inheritance relationship. The `is` keyword can be used for this purpose. It is like spread, but also copies [decorators](#Decorators) in addition to properties. One common use case is to give a better name to a [template](#Templates) instantiation:
+Sometimes you want to copy all aspects of a type without creating a nominal inheritance relationship. The `is` keyword can be used for this purpose. It is like spread, but also copies [decorators](#decorators) in addition to properties. One common use case is to give a better name to a [template](#templates) instantiation:
 
 ```cadl
 @decorator
@@ -240,7 +242,7 @@ union GoodBreed {
 }
 ```
 
-The above example is equivalent to the `GoodBreed` alias above, except that emitters can actually see `GoodBreed` as a named entity and also see the `beagle`, `shepherd`, and `retriever` names for the options. It also becomes possible to apply [decorators](#Decorators) to each of the options when using this form.
+The above example is equivalent to the `GoodBreed` alias above, except that emitters can actually see `GoodBreed` as a named entity and also see the `beagle`, `shepherd`, and `retriever` names for the options. It also becomes possible to apply [decorators](#decorators) to each of the options when using this form.
 
 #### Intersections
 
@@ -437,7 +439,7 @@ model Dog {
 
 After running this Cadl program, the following will be printed to the console:
 
-```
+```text
 Name type: ModelProperty
 Dog type: Model
 ```
@@ -463,7 +465,7 @@ Cadl comes built-in with a number of decorators that are useful for defining ser
 - [@summary](#summary) - attach a documentation string, typically a short, single-line description.
 - [@tag](#tag) - attach a simple tag to a declaration
 - [@visibility/@withVisibility](#visibility-decorators)
-- [@withDefaultKeyVisibility](#withefaultkeyvisibility) - set the visibility of key properties in a model if not already set.
+- [@withDefaultKeyVisibility](#withdefaultkeyvisibility) - set the visibility of key properties in a model if not already set.
 - [@withOptionalProperties](#withoptionalproperties) - makes all properties of the target type optional.
 - [@withoutDefaultValues](#withoutdefaultvalues) - removes all read-only properties from the target type.
 - [@withoutOmittedProperties](#withoutomittedproperties) - removes all model properties that match a type.
@@ -473,7 +475,7 @@ Cadl comes built-in with a number of decorators that are useful for defining ser
 
 Syntax:
 
-```
+```cadl
 @inspectType(message)
 @inspectTypeName(message)
 ```
@@ -486,7 +488,7 @@ They can be specified on any language element -- a model, an operation, a namesp
 
 Syntax:
 
-```
+```cadl
 @deprecated(message)
 ```
 
@@ -516,7 +518,7 @@ alias B = List<Person>; // Instance friendly name would be `PersonList`
 
 Syntax:
 
-```
+```cadl
 @pattern(regularExpressionText)
 ```
 
@@ -526,7 +528,7 @@ Syntax:
 
 Syntax:
 
-```
+```cadl
 @summary(text [, object])
 ```
 
@@ -538,11 +540,24 @@ which are replaced with an attribute for the type (commonly "name") passed as th
 
 `@summary` can be specified on any language element -- a model, an operation, a namespace, etc.
 
+##### @tag
+
+Syntax:
+
+```cadl
+@tag(text)
+```
+
+`@tag` attaches a tag to an operation, interface, or namespace. Multiple `@tag` decorators can be specified
+to attach multiple tags to a Cadl element.
+
+The argument to `@tag` is a string tag value.
+
 ##### @doc
 
 Syntax:
 
-```
+```cadl
 @doc(text [, object])
 ```
 
@@ -557,7 +572,7 @@ which are replaced with an attribute for the type (commonly "name") passed as th
 
 Syntax:
 
-```
+```cadl
 @knownValues(enumTypeReference)
 ```
 
@@ -570,23 +585,22 @@ type accepts.
 
 Example:
 
-```
+```cadl
 enum OperationStateValues {
   Running,
   Completed,
-  Failed
+  Failed,
 }
 
 @knownValues(OperationStateValues)
-model OperationState extends string {
-}
+model OperationState extends string {}
 ```
 
 ##### @key
 
 Syntax:
 
-```
+```cadl
 @key([keyName])
 ```
 
@@ -601,16 +615,15 @@ Otherwise, the name of the target property will be used.
 
 Syntax:
 
-```
+```cadl
 @secret
 ```
 
 `@secret` mark a string as a secret value that should be treated carefully to avoid exposure
 
-```
+```cadl
 @secret
 model Password is string;
-
 ```
 
 `@secret` can only be applied to string model;
@@ -619,7 +632,7 @@ model Password is string;
 
 Syntax:
 
-```
+```cadl
 @format(formatName)
 ```
 
@@ -628,10 +641,8 @@ Syntax:
 The first argument is a string that identifies the format that the string type expects. Any string
 can be entered here, but a Cadl emitter must know how to interpret
 
-For Cadl specs that will be used with an OpenAPI emitter, the OpenAPI specification describes possible
-valid values for a string type's format:
-
-https://swagger.io/specification/#data-types
+For Cadl specs that will be used with an OpenAPI emitter, the OpenAPI specification describes
+possible valid values for a [string type's format](https://github.com/OAI/OpenAPI-Specification/blob/3.0.3/versions/3.0.3.md#dataTypes).
 
 `@format` can be applied to a type that extends from `string` or a `string`-typed model property.
 
@@ -639,11 +650,11 @@ https://swagger.io/specification/#data-types
 
 Syntax:
 
-```
+```cadl
 @error
 ```
 
-`@format` - specify that this model is an error type
+`@error` - specify that this model is an error type
 
 For HTTP API this can be used to represent a failure.
 
@@ -682,7 +693,7 @@ model WriteDog {
 
 Syntax:
 
-```
+```cadl
 @withDefaultKeyVisibility(string)
 ```
 
@@ -696,7 +707,7 @@ If a key property already has a `visibility` decorator then the default visibili
 
 Syntax:
 
-```
+```cadl
 @withOptionalProperties()
 ```
 
@@ -708,7 +719,7 @@ Syntax:
 
 Syntax:
 
-```
+```cadl
 @withoutDefaultValues()
 ```
 
@@ -720,7 +731,7 @@ Syntax:
 
 Syntax:
 
-```
+```cadl
 @withoutOmittedProperties(type)
 ```
 
@@ -732,7 +743,7 @@ Syntax:
 
 Syntax:
 
-```
+```cadl
 @withUpdateableProperties()
 ```
 
@@ -892,7 +903,7 @@ This is especially useful when reusing common parameter sets defined as model ty
 
 For example:
 
-```
+```cadl
 model CommonParameters {
   @path
   @segment("tenants")
@@ -915,7 +926,7 @@ interface UserOperations {
 
 This will result in the following route for both operations
 
-```
+```text
 /tenants/{tenantId}/users/{userName}
 ```
 
@@ -1050,7 +1061,7 @@ namespace Pets {
 
 Since status codes are so common for REST APIs, Cadl comes with some built-in types for common status codes so you don't need to declare status codes so frequently.
 
-There is also a Body<T> type, which can be used as a shorthand for { @body body: T } when an explicit body is required.
+There is also a `Body<T>` type, which can be used as a shorthand for { @body body: T } when an explicit body is required.
 
 Lets update our sample one last time to use these built-in types:
 

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -222,14 +222,25 @@ export function isNumericType(program: Program, target: Type): boolean {
 
 // -- @error decorator ----------------------
 
+const errorDecorator = createDecoratorDefinition({
+  name: "@error",
+  target: ["Model"],
+  args: [],
+} as const);
+
 const errorKey = createStateSymbol("error");
 
-export function $error(context: DecoratorContext, target: Type) {
-  if (!validateDecoratorTarget(context, target, "@error", "Model")) {
+/**
+ * `@error` decorator marks a model as an error type.
+ *
+ * `@error` can only be specified on a model.
+ */
+export function $error(context: DecoratorContext, entity: Model, args: readonly []) {
+  if (!errorDecorator.validate(context, entity, args || [])) {
     return;
   }
 
-  context.program.stateSet(errorKey).add(target);
+  context.program.stateSet(errorKey).add(entity);
 }
 
 export function isErrorModel(program: Program, target: Type): boolean {
@@ -249,7 +260,7 @@ const formatValuesKey = createStateSymbol("formatValues");
  * For Cadl specs that will be used with an OpenAPI emitter, the OpenAPI specification describes possible
  * valid values for a string type's format:
  *
- * https://swagger.io/specification/#data-types
+ * https://github.com/OAI/OpenAPI-Specification/blob/3.0.3/versions/3.0.3.md#dataTypes
  *
  * `@format` can be specified on a type that extends from `string` or a `string`-typed model property.
  */
@@ -561,8 +572,8 @@ export function isListOperation(program: Program, target: Operation): boolean {
 // -- @tag decorator ---------------------
 const tagPropertiesKey = createStateSymbol("tagProperties");
 
-// Set a tag on an operation or namespace.  There can be multiple tags on either an
-// operation or namespace.
+// Set a tag on an operation, interface, or namespace.  There can be multiple tags on an
+// operation, interface, or namespace.
 export function $tag(context: DecoratorContext, target: Type, tag: string) {
   if (!validateDecoratorTarget(context, target, "@tag", ["Operation", "Namespace", "Interface"])) {
     return;

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -43,7 +43,7 @@ op foo(): MyNonErrorResponse;
 ### `@extension`
 
 This decorator lets you specify custom key(starting with `x-`) value pair that will be added to the OpenAPI document.
-[OpenAPI reference on extensions](https://swagger.io/docs/specification/openapi-extensions/)
+[OpenAPI reference on extensions](https://github.com/OAI/OpenAPI-Specification/blob/3.0.3/versions/3.0.3.md#specificationExtensions)
 
 Arguments:
 
@@ -69,7 +69,7 @@ model Foo {}
 ### `@externalDocs`
 
 Decorator that can be used to provide the `externalDocs` property on OpenAPI elements.
-[OpenAPI spec for externalDocs](https://swagger.io/specification/#external-documentation-object)
+[OpenAPI spec for externalDocs](https://github.com/OAI/OpenAPI-Specification/blob/3.0.3/versions/3.0.3.md#externalDocumentationObject)
 
 Arguments:
 

--- a/packages/website/src/_data/docs.js
+++ b/packages/website/src/_data/docs.js
@@ -28,7 +28,7 @@ const toc = {
     "projected-names",
     // "built-in-decorators",
     // "http",
-    // "openapi",
+    "openapi",
   ],
   "Writing Cadl Libraries": [
     "basics",

--- a/packages/website/src/docs/standard-library/openapi.md
+++ b/packages/website/src/docs/standard-library/openapi.md
@@ -1,0 +1,306 @@
+---
+id: openapi
+title: The OpenAPI v3 emitter
+---
+
+<!-- cspell:ignore cadl, openapi -->
+
+# The Cadl OpenAPI v3 emitter
+
+Cadl has an OpenAPI emitter called `@cadl-lang/openapi3` that emits a standard OpenAPI v3 description from Cadl source.
+This can then be used as input in to any OpenAPI tooling.
+
+## Install
+
+In your Cadl project root
+
+```bash
+npm install @cadl-lang/openapi3
+```
+
+The OpenAPI emitter requires certain features of the Cadl HTTP library in the `@cadl-lang/rest` package, so this also
+needs to be installed and imported somewhere in your Cadl source.
+
+```bash
+npm install @cadl-lang/rest
+```
+
+## Emit OpenAPI 3.0 definition
+
+There are several ways to emit an OpenAPI 3.0 definition for your Cadl source file.
+
+1. Via the command line
+
+```bash
+cadl compile . --emit @cadl-lang/openapi3
+```
+
+2. Via the config
+
+Add the following to the `cadl-project.yaml` file.
+
+```yaml
+emitters:
+  @cadl-lang/openapi3: true
+```
+
+### Emitter options
+
+Emitter options can be passed on the command line with
+
+```bash
+--option "@cadl-lang/openapi3.<optionName>=<value>"
+
+# For example
+--option "@cadl-lang/openapi3.output-file=my-custom-openapi.json"
+```
+
+or configured via the `cadl-project.yaml` configuration:
+
+```yaml
+emitters:
+  '@cadl-lang/openapi3':
+    <optionName>: <value>
+
+# For example
+emitters:
+  '@cadl-lang/openapi3':
+    outputFile: my-custom-openapi.json
+```
+
+#### `output-file`
+
+Configure the name of the swagger output file relative to the compiler `output-path`.
+
+#### `new-line`
+
+Set the newline character for emitting files. Can be either:
+
+- `lf`(Default)
+- `crlf`
+
+## How the OpenAPI emitter interprets Cadl
+
+The OpenAPI emitter converts Cadl language elements into their natural OpenAPI expression as described below.
+
+### Operations
+
+Each Cadl operation becomes an OpenAPI operation.
+
+The HTTP method for the operation is either explicitly specified with an [(Http) `@get`, `@post`, `@put`, `@patch`, or `@delete` decorator][http-verb-decorators] on the operation or it is inferred from the operation name and signature.
+
+The path for the operation comes from the [(Http) `@route` decorator][http-route-decorator] on the operation.
+The `@route` decorator can also be specified on a namespace and/or an interface (group of operations).
+When specified, the route for the enclosing namespace(s) and interface are prefixed to the operation route.
+
+[http-verb-decorators]: https://github.com/microsoft/cadl/blob/main/packages/rest/README.md#decorators
+[http-route-decorator]: https://github.com/microsoft/cadl/blob/main/packages/rest/README.md#:~:text=%40-,route,-operations%2C%20namespaces%2C%20interfaces
+
+The fields of the [Operation object](https://github.com/OAI/OpenAPI-Specification/blob/3.0.3/versions/3.0.3.md#operationObject) are set as described below.
+
+#### description
+
+The description field is set from the [(built-in) `@doc` decorator][doc-decorator] on the Cadl operation, and omitted when `@doc` is not present.
+
+[doc-decorator]: https://github.com/microsoft/cadl/blob/main/docs/tutorial.md#doc
+
+#### summary
+
+The summary field is set from the [(built-in) `@summary` decorator][summary-decorator] on the Cadl operation, and omitted when `@summary` is not present.
+
+[summary-decorator]: https://github.com/microsoft/cadl/blob/main/docs/tutorial.md#summary
+
+#### operationId
+
+The operationId can be explicitly specified with the [(OpenAPI) `@operationId` decorator][openapi-operationid-decorator],
+and otherwise is simple the operation name, prefixed with "<interface*name>*" when the operation is within an interface.
+
+[openapi-operationid-decorator]: https://github.com/microsoft/cadl/blob/main/packages/openapi/README.md#operationid
+
+#### parameters and requestBody
+
+The parameters of the Cadl operation are translated into the parameter list and requestBody for the OpenAPI operation.
+
+The `in` field of a parameter is specified with an [(Http) `@query`, `@header`, or `@path` decorator][http-parameter-decorators].
+A parameter without one of these decorators is assumed to be passed in the request body.
+
+The request body parameter can also be explicitly decorated with an [(Http) `@body` decorator][http-body-decorator].
+In the absence of explicit `@body`, the set of parameters that are not marked @header, @query, or @path form the request body.
+
+[http-parameter-decorators]: https://github.com/microsoft/cadl/blob/main/packages/rest/README.md#decorators
+[http-body-decorator]: https://github.com/microsoft/cadl/blob/main/packages/rest/README.md#decorators
+
+A (built-in) `@doc` decorator on a parameter will be use in the description.
+
+The Cadl parameter type will be translated into an appropriate OpenAPI schema for the parameter.
+
+Likewise, the type of the body parameter(s) will be translated into an appropriate OpenAPI schema for the requestBody.
+The request body will use the "application/json" media type unless the body model includes an explicit `content-type`
+header.
+
+#### responses
+
+The return type(s) of the Cadl operation are translated into responses for the OpenAPI operation.
+The status code for a response can be specified as a property in the return type model with the [(Http) `@statusCode` decorator][http-statuscode-decorator] (the property name is ignored).
+If the [(built-in) `@error` decorator][error-decorator] is specified on a return type, this return type because the default response for the operation.
+The media type for a response will be "application/json" unless the return type model includes an explicit `content-type`
+header.
+Models with different status codes and/or media types can be unioned together to describe complex response designs.
+
+When a return type model has a property explicitly decorated with an [(Http) `@body` decorator][http-body-decorator], this
+is taken as the response body.
+In the absence of explicit `@body`, the properties that are not marked `@statusCode` or `@header` form the request body.
+
+[http-statuscode-decorator]: https://github.com/microsoft/cadl/blob/main/packages/rest/README.md#decorators
+[error-decorator]: https://github.com/microsoft/cadl/blob/main/docs/tutorial.md#error
+
+#### tags
+
+Any tags specified with the [(built-in) `@tag` decorator][tag-decorator] on the operation, interface, or
+enclosing namespace(s) are included in the OpenAPI operation's tags array.
+
+[tag-decorator]: https://github.com/microsoft/cadl/blob/main/docs/tutorial.md#tag
+
+#### deprecated
+
+If the [(built-in) `@deprecated` decorator][deprecated-decorator] is specified on the operation, then the operation's
+deprecated field is set to true.
+
+[deprecated-decorator]: https://github.com/microsoft/cadl/blob/main/docs/tutorial.md#deprecated
+
+#### externalDocs
+
+If the Cadl operation has an [(OpenAPI) `@externalDocs` decorator][openapi-externaldocs-decorator] this will produce
+an externalDocs field in the OpenAPI operation.
+
+[openapi-externaldocs-decorator]: https://github.com/microsoft/cadl/blob/main/packages/openapi/README.md#externaldocs
+
+#### Specification extensions
+
+Any extensions specified on the Cadl operation with the [(OpenAPI) `@extension` decorator][openapi-extension-decorator]
+are included in the emitted OpenAPI operation.
+
+[openapi-extension-decorator]: https://github.com/microsoft/cadl/blob/main/packages/openapi/README.md#extension
+
+### Models and enums
+
+Models and enums are converted into schemas in the generated OpenAPI definition. Intrinsic types in Cadl are represented
+with a JSON Schema type that most closely matches the semantics of the Cadl type.
+
+The following table shows how Cadl types are translated to JSON Schema types:
+
+| Cadl type       | OpenAPI `type`/`format`           | Notes                                                                     |
+| --------------- | --------------------------------- | ------------------------------------------------------------------------- |
+| `int32`         | `type: integer, format: int32`    |                                                                           |
+| `int64`         | `type: integer, format: int64`    |                                                                           |
+| `float32`       | `type: number, format: float`     |                                                                           |
+| `float64`       | `type: number, format: double`    |                                                                           |
+| `string`        | `type: string`                    |                                                                           |
+| `bytes`         | `type: string, format: byte`      | for content-type == 'application/json' or 'text/plain'                    |
+| `bytes`         | `type: string, format: binary`    | for "binary" content types, e.g. 'application/octet-stream', 'image/jpeg' |
+| `boolean`       | `type: boolean`                   |                                                                           |
+| `plainDate`     | `type: string, format: date`      |                                                                           |
+| `zonedDateTime` | `type: string, format: date-time` | RFC 3339 date                                                             |
+
+There are a variety of decorators that can modify or add metadata to the definitions produced in the generated OpenAPI.
+
+For a numeric element (integer or float):
+
+| Cadl decorator     | OpenAPI/JSON Schema keyword | Notes |
+| ------------------ | --------------------------- | ----- |
+| `@minValue(value)` | `minimum: value`            |       |
+| `@maxValue(value)` | `maximum: value`            |       |
+
+For any element defined as a `string` or a type that extends from `string`:
+
+| Cadl decorator      | OpenAPI/JSON Schema keyword | Notes                                                      |
+| ------------------- | --------------------------- | ---------------------------------------------------------- |
+| `@format(name)`     | `format: name`              | When format is not determined by type or another decorator |
+| `@minLength(value)` | `minLength: value`          |                                                            |
+| `@maxLength(value)` | `maxLength: value`          |                                                            |
+| `@pattern(regex)`   | `pattern: regex`            |                                                            |
+| `@secret`           | `format: password`          |                                                            |
+
+Enums can be defined in Cadl with the [`enum` statement](https://github.com/microsoft/cadl/blob/main/docs/tutorial.md#enums), e.g.:
+
+```cadl
+enum Color {
+  Red: "red",
+  Blue: "blue",
+  Green: "green",
+}
+```
+
+Another is to use the union operation to define the enum values inline, e.g.:
+
+```cadl
+status: "Running" | "Stopped" | "Failed"
+```
+
+The OpenAPI emitter converts both of these into a schema definition containing an "enum" with the list of defined values.
+
+### Model composition
+
+Cadl has several mechanisms for model composition and extension. The following describes how these are handled in the openapi3 emitter.
+
+#### Spread
+
+The spread operator does not convey any semantic relationship between the source and target models so the openapi3 emitter
+treats this as if the properties of the source model were explicitly included in the target model at the position where the
+spread appears.
+
+#### Extends
+
+When one model extends another model, this is intended to convey and inheritance relationship. While OpenAPI has no formal
+construct for inheritance, the openapi3 emitter represents this form of composition with an `allOf` in the schema of the child model
+that references the schema for the parent model.
+
+##### Extends with discriminator
+
+The openapi3 emitter supports the `@discriminator(propertyName)` decorator on a `model`. This will produce a `discriminator` object
+with the named property in the schema for this model.
+
+Models that extend this model must define this property with a literal string value, and these values must be distinct across all the
+models that extend this model. These values are used to construct a `mapping` for the discriminator.
+
+The `@discriminator` decorator can be used to create multi-level discriminated inheritance but must use a different discriminated property at each level.
+
+#### Is
+
+The `is` keyword provides a form of composition similar to the spread operator, where no semantic relationship is conveyed between
+the source and target models. The openapi3 emitter represents this form of composition with an independent schema that contains
+all the same properties as the model named by the `is` keyword, plus any properties defined directly on the model.
+
+#### Union
+
+Unions are another form of model composition.
+
+Unions can be defined in two different ways in Cadl. One way is with
+[the union type operator](https://github.com/microsoft/cadl/blob/main/docs/tutorial.md#unions), `|`:
+
+```cadl
+alias GoodBreed = Beagle | GermanShepherd | GoldenRetriever;
+```
+
+The second way is with [the `union` statement](https://github.com/microsoft/cadl/blob/main/docs/tutorial.md#unions)
+which not only declares the variant models but also assigns a name for each.
+
+```cadl
+union GoodBreed {
+  beagle: Beagle,
+  shepherd: GermanShepherd,
+  retriever: GoldenRetriever,
+}
+```
+
+The openapi3 emitter represents either form of union with an `anyOf` with an element for each option of the union.
+The openapi3 emitter ignores the "names" for variants in named unions.
+
+The openapi3 emitter also defines the `@oneOf` decorator which can be specified on a `union` statement to indicate
+that a union should be emitted as a `oneOf` rather than `anyOf`.
+
+## See also
+
+- [Cadl Getting Started](https://github.com/microsoft/cadl#getting-started)
+- [Cadl Tutorial](https://github.com/microsoft/cadl/blob/main/docs/tutorial.md)
+- [Cadl for the OpenAPI Developer](https://github.com/microsoft/cadl/blob/main/docs/cadl-for-openapi-dev.md)


### PR DESCRIPTION
fix #977 This PR is the start of the website docs for the openapi3 emitter, plus a passel of related fixes in related docs throughout the project. 