### PR TITLE
Detect unannotated path parameters that are specified in route path

### DIFF
--- a/common/changes/@cadl-lang/rest/route-path-params_2022-09-07-14-41.json
+++ b/common/changes/@cadl-lang/rest/route-path-params_2022-09-07-14-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Detect unannotated path parameters that are specified in route path",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/src/http/parameters.ts
+++ b/packages/rest/src/http/parameters.ts
@@ -12,7 +12,8 @@ import { HttpOperationParameters } from "./types.js";
 
 export function getOperationParameters(
   program: Program,
-  operation: Operation
+  operation: Operation,
+  knownPathParamNames: string[] = []
 ): [HttpOperationParameters, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
   const result: HttpOperationParameters = {
@@ -22,7 +23,9 @@ export function getOperationParameters(
 
   for (const param of operation.parameters.properties.values()) {
     const queryParam = getQueryParamName(program, param);
-    const pathParam = getPathParamName(program, param);
+    const pathParam =
+      getPathParamName(program, param) ??
+      (knownPathParamNames.indexOf(param.name) > -1 && param.name);
     const headerParam = getHeaderFieldName(program, param);
     const bodyParam = isBody(program, param);
 

--- a/packages/samples/grpc-kiosk-example/kiosk.cadl
+++ b/packages/samples/grpc-kiosk-example/kiosk.cadl
@@ -19,12 +19,12 @@ namespace Display {
 
   @doc("Get a kiosk.")
   @route("kiosks/{id}")
-  op getKiosk(@path id: KioskId): Kiosk | RpcStatus;
+  op getKiosk(id: KioskId): Kiosk | RpcStatus;
 
   @doc("Delete a kiosk.")
   @route("kiosks/{id}")
   @delete
-  op deleteKiosk(@path id: KioskId): Empty | RpcStatus;
+  op deleteKiosk(id: KioskId): Empty | RpcStatus;
 
   @doc("Create a sign. This enrolls the sign for sign display.")
   @route("signs")
@@ -37,12 +37,12 @@ namespace Display {
 
   @doc("Get a sign.")
   @route("signs/{id}")
-  op getSign(@path id: SignId): Sign | RpcStatus;
+  op getSign(id: SignId): Sign | RpcStatus;
 
   @doc("Delete a sign.")
   @route("signs/{id}")
   @delete
-  op deleteSign(@path id: SignId): Empty | RpcStatus;
+  op deleteSign(id: SignId): Empty | RpcStatus;
 
   @doc("Set a sign for display on one or more kiosks.")
   @route("signs/{sign_id}")
@@ -51,7 +51,7 @@ namespace Display {
 
   @doc("Get the sign that should be displayed on a kiosk.")
   @route("kiosks/{kiosk_id}/sign")
-  op getSignIdForKioskId(@path kiosk_id: int32): GetSignIdResponse | RpcStatus;
+  op getSignIdForKioskId(kiosk_id: int32): GetSignIdResponse | RpcStatus;
 
   //
   // TODO[JC]: Streaming ?
@@ -112,13 +112,10 @@ model ListSignsResponse {
 
 model SetSignIdForKioskIdsRequest {
   @body kiosk_ids: int32[];
-
-  @path
   sign_id: int32;
 }
 
 model GetSignIdForKioskIdRequest {
-  @path
   kiosk_id: int32;
 }
 

--- a/packages/samples/param-decorators/param-decorators.cadl
+++ b/packages/samples/param-decorators/param-decorators.cadl
@@ -11,7 +11,6 @@ namespace Operations {
   op getThing(
     @pattern("^[a-zA-Z0-9-]{3,24}$")
     @format("UUID")
-    @path
     name: string,
 
     @minValue(0)
@@ -36,6 +35,5 @@ model NameParameter {
   @doc("Name parameter")
   @pattern("^[a-zA-Z0-9-]{3,24}$")
   @format("UUID")
-  @path
   name: string;
 }

--- a/packages/samples/simple/simple.cadl
+++ b/packages/samples/simple/simple.cadl
@@ -3,7 +3,7 @@ import "@cadl-lang/rest";
 using Cadl.Http;
 
 @route("/alpha/{id}")
-op doAlpha(@path id: string): string;
+op doAlpha(id: string): string;
 
 @route("/beta/{id}")
-op doBeta(@path id: string): string;
+op doBeta(id: string): string;


### PR DESCRIPTION
This change fixes #306 which suggests that an operation with a route containing path parameters should not require the `@path` decorator to be applied to the corresponding operation parameters.  This works even for route paths composed from parent scopes.

This issue is still marked as "Cadl Design" but I'm sending a PR anyway since it seemed easy to implement.