### PR TITLE
chore: Adjust CSpell pattern to ignore auth tokens

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -70,7 +70,8 @@ patterns:
     pattern: /(.*)┆(.*)/g
   - name: Authorization_Basic
     description: Ignore Base64 authorization tokens
-    pattern: "/Authorization: Basic\\s+\\S+/g"
+    pattern: >-
+      /Authorization: Basic\s+\S+/g
 ignoreRegExpList:
   - cursortest
   - Authorization_Basic

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -68,8 +68,9 @@ enableFiletypes:
 patterns:
   - name: cursortest
     pattern: /(.*)┆(.*)/g
-  - name: base64
-    pattern: /\b(.*)==/g
+  - name: Authorization_Basic
+    description: Ignore Base64 authorization tokens
+    pattern: "/Authorization: Basic\\s+\\S+/g"
 ignoreRegExpList:
   - cursortest
-  - base64
+  - Authorization_Basic


### PR DESCRIPTION
@timotheeguerin,

I saw that you added CSpell to this repository.

After looking at the configuration, I realized that it possibly could ignore more than expected.

`/\b(.*)==/g` will match things like:

```ts
if (valuue === 'string') {
^------------^
```

This PR adjusts the Pattern to closer match its intent.

Kind regards,