### PR TITLE
New `@service` decorator replacing `@serviceTitle` and `@serviceVersion` (Deprecated)

### DIFF
--- a/common/changes/@cadl-lang/compiler/feature-service-decorator_2022-09-20-14-50.json
+++ b/common/changes/@cadl-lang/compiler/feature-service-decorator_2022-09-20-14-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Deprecation** Replace `@serviceTitle` and `@serviceVersion` with a single `@service` decorator. ",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi/feature-service-decorator_2022-09-20-14-50.json
+++ b/common/changes/@cadl-lang/openapi/feature-service-decorator_2022-09-20-14-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/openapi3/feature-service-decorator_2022-09-20-14-50.json
+++ b/common/changes/@cadl-lang/openapi3/feature-service-decorator_2022-09-20-14-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/feature-service-decorator_2022-09-20-14-50.json
+++ b/common/changes/@cadl-lang/rest/feature-service-decorator_2022-09-20-14-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/versioning/feature-service-decorator_2022-09-20-14-50.json
+++ b/common/changes/@cadl-lang/versioning/feature-service-decorator_2022-09-20-14-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/docs/cadl-for-openapi-dev.md
+++ b/docs/cadl-for-openapi-dev.md
@@ -294,13 +294,13 @@ In OpenAPI, the `info` object [[v2][v2-info], [v3][v3-info]] contains metadata a
 
 In Cadl this information is specified with [decorators on the namespace][cadl-service-metadata].
 
-| OpenAPI `info` field | Cadl decorator    | Notes                    |
-| -------------------- | ----------------- | ------------------------ |
-| `title`              | `@serviceTitle`   | Cadl built-in decorator  |
-| `version`            | `@serviceVersion` | Cadl built-in decorator  |
-| `description`        | `@doc`            | Cadl built-in decorator  |
-| `license`            |                   | Not currently supported. |
-| `contact`            |                   | Not currently supported. |
+| OpenAPI `info` field | Cadl decorator         | Notes                    |
+| -------------------- | ---------------------- | ------------------------ |
+| `title`              | `@service({title: }`   | Cadl built-in decorator  |
+| `version`            | `@service({version: }` | Cadl built-in decorator  |
+| `description`        | `@doc`                 | Cadl built-in decorator  |
+| `license`            |                        | Not currently supported. |
+| `contact`            |                        | Not currently supported. |
 
 [cadl-service-metadata]: https://github.com/microsoft/cadl/blob/main/docs/tutorial.md#service-definition-and-metadata
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -842,15 +842,15 @@ The following examples assume you have imported both `@cadl-lang/openapi3` and `
 
 A definition for a service is the namespace that contains all the operations for the service and carries top-level metadata like service name and version. Cadl offers the following decorators for providing this metadata, and all are optional.
 
-- @serviceTitle - the title of the service
-- @serviceVersion - the version of the service. Can be any string, but later version should lexicographically sort after earlier versions
-- @server - the host of the service. Can accept parameters.
+- @service - Mark a namespace as a service namespace. Takes in the following options:
+  - `title`: Name of the service
+  - `version`: Version of the service
+- @server - (In `Cadl.Http`) the host of the service. Can accept parameters.
 
 Here's an example that uses these to define a Pet Store service:
 
 ```cadl
-@serviceTitle("Pet Store Service")
-@serviceVersion("2021-03-25")
+@service({title: "Pet Store Service", version: "2021-03-25")
 @server("https://example.com", "Single server endpoint")
 @doc("This is a sample server Petstore server.")
 namespace PetStore;

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -537,7 +537,7 @@ const diagnostics = {
   "service-decorator-duplicate": {
     severity: "error",
     messages: {
-      default: paramMessage`Service ${"name"} can only be set once per Cadl document.`,
+      default: `@service can only be set once per Cadl document.`,
     },
   },
   "service-namespace-duplicate": {

--- a/packages/compiler/lib/service.ts
+++ b/packages/compiler/lib/service.ts
@@ -1,7 +1,8 @@
-import { validateDecoratorTarget } from "../core/decorator-utils.js";
-import { createDiagnostic } from "../core/messages.js";
+import { createDecoratorDefinition, validateDecoratorTarget } from "../core/decorator-utils.js";
+import { reportDeprecated } from "../core/index.js";
+import { createDiagnostic, reportDiagnostic } from "../core/messages.js";
 import { Program } from "../core/program.js";
-import { DecoratorContext, Namespace, Type } from "../core/types.js";
+import { DecoratorContext, Model, Namespace, Type } from "../core/types.js";
 
 interface ServiceDetails {
   namespace?: Namespace;
@@ -39,7 +40,60 @@ export function checkIfServiceNamespace(program: Program, namespace: Namespace):
   return serviceDetails.namespace === namespace;
 }
 
+const serviceDecorator = createDecoratorDefinition({
+  name: "@service",
+  target: "Namespace",
+  args: [{ kind: "Model" }],
+});
+export function $service(context: DecoratorContext, target: Namespace, options: Model) {
+  if (!serviceDecorator.validate(context, target, [options])) {
+    return;
+  }
+  const serviceDetails = getServiceDetails(context.program);
+
+  if (getServiceNamespace(context.program)) {
+    reportDiagnostic(context.program, {
+      code: "service-decorator-duplicate",
+      target,
+    });
+  }
+  setServiceNamespace(context.program, target);
+
+  const title = options.properties.get("title")?.type;
+  const version = options.properties.get("version")?.type;
+  if (title) {
+    if (title.kind === "String") {
+      serviceDetails.title = title.value;
+    } else {
+      reportDiagnostic(context.program, {
+        code: "unassignable",
+        format: { value: context.program.checker.getTypeName(title), targetType: "String" },
+        target: context.getArgumentTarget(0)!,
+      });
+    }
+  }
+  if (version) {
+    if (version.kind === "String") {
+      serviceDetails.version = version.value;
+    } else {
+      reportDiagnostic(context.program, {
+        code: "unassignable",
+        format: { value: context.program.checker.getTypeName(version), targetType: "String" },
+        target: context.getArgumentTarget(0)!,
+      });
+    }
+  }
+}
+
+/**
+ * @deprecated use `@service` instead
+ */
 export function $serviceTitle(context: DecoratorContext, target: Type, title: string) {
+  reportDeprecated(
+    context.program,
+    "@serviceTitle decorator has been deprecated use @service({title: _}) instead.",
+    context.decoratorTarget
+  );
   const serviceDetails = getServiceDetails(context.program);
   if (serviceDetails.title) {
     context.program.reportDiagnostic(
@@ -64,8 +118,16 @@ export function getServiceTitle(program: Program): string {
   return serviceDetails.title || "(title)";
 }
 
+/**
+ * @deprecated use `@service` instead
+ */
 export function $serviceVersion(context: DecoratorContext, target: Type, version: string) {
   const serviceDetails = getServiceDetails(context.program);
+  reportDeprecated(
+    context.program,
+    "@serviceTitle decorator has been deprecated use @service({title: _}) instead.",
+    context.decoratorTarget
+  );
   if (serviceDetails.version) {
     context.program.reportDiagnostic(
       createDiagnostic({

--- a/packages/compiler/lib/service.ts
+++ b/packages/compiler/lib/service.ts
@@ -51,7 +51,7 @@ export function $service(context: DecoratorContext, target: Namespace, options: 
   }
   const serviceDetails = getServiceDetails(context.program);
 
-  if (getServiceNamespace(context.program)) {
+  if (getServiceNamespace(context.program) !== context.program.getGlobalNamespaceType()) {
     reportDiagnostic(context.program, {
       code: "service-decorator-duplicate",
       target,
@@ -125,7 +125,7 @@ export function $serviceVersion(context: DecoratorContext, target: Type, version
   const serviceDetails = getServiceDetails(context.program);
   reportDeprecated(
     context.program,
-    "@serviceTitle decorator has been deprecated use @service({title: _}) instead.",
+    "@serviceVersion decorator has been deprecated use @service({title: _}) instead.",
     context.decoratorTarget
   );
   if (serviceDetails.version) {

--- a/packages/openapi/test/helpers.test.ts
+++ b/packages/openapi/test/helpers.test.ts
@@ -22,7 +22,7 @@ describe("OpenAPI3 Helpers", () => {
 
     it("return operation name if operation is defined under service namespace", async () => {
       const id = await testResolveOperationId(`
-        @serviceTitle("Abc")
+        @service({title: "Abc"})
         namespace MyService;
 
         @test op foo(): string;
@@ -41,7 +41,7 @@ describe("OpenAPI3 Helpers", () => {
 
     it("return group name and operation name if operation is defined under namespace that is not the service namespace", async () => {
       const id = await testResolveOperationId(`
-        @serviceTitle("Abc")
+        @service({title: "Abc"})
         namespace MyService;
 
         namespace Bar {

--- a/packages/openapi3/test/info.test.ts
+++ b/packages/openapi3/test/info.test.ts
@@ -2,10 +2,10 @@ import { deepStrictEqual, strictEqual } from "assert";
 import { openApiFor } from "./test-host.js";
 
 describe("openapi3: info", () => {
-  it("set the service title with @serviceTitle", async () => {
+  it("set the service title with @service", async () => {
     const res = await openApiFor(
       `
-      @serviceTitle("My Service")
+      @service({title: "My Service"})
       namespace Foo {
         op test(): string;
       }
@@ -14,10 +14,10 @@ describe("openapi3: info", () => {
     strictEqual(res.info.title, "My Service");
   });
 
-  it("set the service version with @serviceVersion", async () => {
+  it("set the service version with @service", async () => {
     const res = await openApiFor(
       `
-      @serviceVersion("1.2.3-test")
+      @service({version: "1.2.3-test"})
       namespace Foo {
         op test(): string;
       }
@@ -30,7 +30,7 @@ describe("openapi3: info", () => {
     const res = await openApiFor(
       `
       @doc("My service description")
-      @serviceTitle("My Service")
+      @service({title: "My Service"})
       namespace Foo {
         op test(): string;
       }
@@ -42,7 +42,7 @@ describe("openapi3: info", () => {
     const res = await openApiFor(
       `
       @externalDocs("https://example.com", "more info")
-      @serviceTitle("My Service")
+      @service({title: "My Service"})
       namespace Foo {
         op test(): string;
       }

--- a/packages/openapi3/test/security.test.ts
+++ b/packages/openapi3/test/security.test.ts
@@ -5,7 +5,7 @@ describe("openapi3: security", () => {
   it("set a basic auth", async () => {
     const res = await openApiFor(
       `
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @useAuth(BasicAuth)
       namespace MyService {}
       `
@@ -22,7 +22,7 @@ describe("openapi3: security", () => {
   it("set a bearer auth", async () => {
     const res = await openApiFor(
       `
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @useAuth(BearerAuth)
       namespace MyService {}
       `
@@ -39,7 +39,7 @@ describe("openapi3: security", () => {
   it("set a ApiKeyAuth ", async () => {
     const res = await openApiFor(
       `
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @useAuth(ApiKeyAuth<ApiKeyLocation.header, "x-my-header">)
       namespace MyService {}
       `
@@ -57,7 +57,7 @@ describe("openapi3: security", () => {
   it("set a oauth2 auth", async () => {
     const res = await openApiFor(
       `
-      @serviceTitle("My service")
+      @service({title: "My service"})
      
       @useAuth(OAuth2Auth<[MyFlow]>)
       namespace MyService {
@@ -91,7 +91,7 @@ describe("openapi3: security", () => {
   it("can specify custom auth name with description", async () => {
     const res = await openApiFor(
       `
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @useAuth(MyAuth)
       @test namespace Foo {
         @doc("My custom basic auth")
@@ -112,7 +112,7 @@ describe("openapi3: security", () => {
   it("can use multiple auth", async () => {
     const res = await openApiFor(
       `
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @useAuth(BearerAuth | [ApiKeyAuth<ApiKeyLocation.header, "x-my-header">, BasicAuth])
       namespace MyService {}
       `

--- a/packages/openapi3/test/servers.test.ts
+++ b/packages/openapi3/test/servers.test.ts
@@ -6,7 +6,7 @@ describe("openapi3: servers", () => {
   it("set a basic server", async () => {
     const res = await openApiFor(
       `
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @server("https://example.com", "Main server")
       namespace MyService {}
       `
@@ -23,7 +23,7 @@ describe("openapi3: servers", () => {
   it("emit diagnostic when parameter is not a string", async () => {
     const diagnostics = await diagnoseOpenApiFor(
       `
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @server("https://{region}.example.com", "Regional account endpoint", {region: int32})
       namespace MyService {}
       `
@@ -38,7 +38,7 @@ describe("openapi3: servers", () => {
   it("emit diagnostic when parameter is an enum of different types", async () => {
     const diagnostics = await diagnoseOpenApiFor(
       `
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @server("https://{region}.example.com", "Regional account endpoint", {region: Region})
       namespace MyService {}
 
@@ -58,7 +58,7 @@ describe("openapi3: servers", () => {
   it("emit diagnostic when parameter is a union of non string types", async () => {
     const diagnostics = await diagnoseOpenApiFor(
       `
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @server("https://{region}.example.com", "Regional account endpoint", {region: string | int32})
       namespace MyService {}
       `
@@ -73,7 +73,7 @@ describe("openapi3: servers", () => {
   it("set a server with parameters", async () => {
     const res = await openApiFor(
       `
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @server("https://{account}.{region}.example.com", "Regional account endpoint", {region: string, account: string})
       namespace MyService {}
       `
@@ -93,7 +93,7 @@ describe("openapi3: servers", () => {
   it("set a server with parameters with defaults", async () => {
     const res = await openApiFor(
       `
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @server("https://{account}.{region}.example.com", "Regional account endpoint", {
         region?: string = "westus", 
         account?: string = "default",
@@ -116,7 +116,7 @@ describe("openapi3: servers", () => {
   it("set a server with parameters with doc", async () => {
     const res = await openApiFor(
       `
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @server("https://{region}.example.com", "Regional account endpoint", {
         @doc("Region name")
         region: string,
@@ -138,7 +138,7 @@ describe("openapi3: servers", () => {
   it("set a server with parameters with extensions", async () => {
     const res = await openApiFor(
       `
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @server("https://{region}.example.com", "Regional account endpoint", {
         @extension("x-custom", "Foo")
         region: string,
@@ -161,7 +161,7 @@ describe("openapi3: servers", () => {
     const res = await openApiFor(
       `
       enum Region { westus, eastus }
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @server("https://{region}.example.com", "Regional account endpoint", {
         region: Region, 
       })
@@ -183,7 +183,7 @@ describe("openapi3: servers", () => {
     const res = await openApiFor(
       `
       enum Region {  }
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @server("https://{region}.example.com", "Regional account endpoint", {
         region: "westus", 
       })
@@ -205,7 +205,7 @@ describe("openapi3: servers", () => {
     const res = await openApiFor(
       `
       enum Region {  }
-      @serviceTitle("My service")
+      @service({title: "My service"})
       @server("https://{region}.example.com", "Regional account endpoint", {
         region: "westus" | "eastus", 
       })

--- a/packages/openapi3/test/test-host.ts
+++ b/packages/openapi3/test/test-host.ts
@@ -77,7 +77,7 @@ export async function checkFor(code: string) {
 export async function oapiForModel(name: string, modelDef: string) {
   const oapi = await openApiFor(`
     ${modelDef};
-    @serviceTitle("Testing model")
+    @service({title: "Testing model"})
     @route("/")
     namespace root {
       op read(): { @body body: ${name} };

--- a/packages/openapi3/test/versioning.test.ts
+++ b/packages/openapi3/test/versioning.test.ts
@@ -9,7 +9,7 @@ describe("openapi3: versioning", () => {
       `
       @versioned(Versions)
       @versionedDependency([[Versions.v1, MyLibrary.Versions.A], [Versions.v2, MyLibrary.Versions.B], [Versions.v3, MyLibrary.Versions.C]])
-      @serviceTitle("My Service")
+      @service({title: "My Service"})
       @serviceVersion("hi")
       namespace MyService {
         enum Versions {"v1", "v2", "v3"}
@@ -129,7 +129,7 @@ describe("openapi3: versioning", () => {
       enum Versions { v1 };
     }
     @armNamespace
-    @serviceTitle("Widgets 'r' Us")
+    @service({title: "Widgets 'r' Us"})
     @versionedDependency(Contoso.Library.Versions.v1)
     namespace Contoso.WidgetService {
       model Widget {
@@ -161,7 +161,7 @@ describe("openapi3: versioning", () => {
         }
       }
       
-      @serviceTitle("Service")
+      @service({title: "Service"})
       @versionedDependency(Library.Versions.v1)
       namespace Service {
         model Widget {

--- a/packages/openapi3/test/versioning.test.ts
+++ b/packages/openapi3/test/versioning.test.ts
@@ -9,8 +9,7 @@ describe("openapi3: versioning", () => {
       `
       @versioned(Versions)
       @versionedDependency([[Versions.v1, MyLibrary.Versions.A], [Versions.v2, MyLibrary.Versions.B], [Versions.v3, MyLibrary.Versions.C]])
-      @service({title: "My Service"})
-      @serviceVersion("hi")
+      @service({title: "My Service", version: "hi"})
       namespace MyService {
         enum Versions {"v1", "v2", "v3"}
         model Test {

--- a/packages/playground/samples/http.cadl
+++ b/packages/playground/samples/http.cadl
@@ -1,6 +1,8 @@
 import "@cadl-lang/rest";
 
-@serviceTitle("Widget Service")
+@service({
+  title: "Widget Service",
+})
 namespace DemoService;
 using Cadl.Http;
 

--- a/packages/playground/samples/rest.cadl
+++ b/packages/playground/samples/rest.cadl
@@ -1,6 +1,8 @@
 import "@cadl-lang/rest";
 
-@serviceTitle("Widget Service")
+@service({
+  title: "Widget Service",
+})
 namespace DemoService;
 
 using Cadl.Http;

--- a/packages/playground/samples/unions.cadl
+++ b/packages/playground/samples/unions.cadl
@@ -1,7 +1,9 @@
 import "@cadl-lang/rest";
 import "@cadl-lang/openapi3";
 
-@serviceTitle("Widget Service")
+@service({
+  title: "Widget Service",
+})
 namespace DemoService;
 using Cadl.Rest;
 using Cadl.Http;

--- a/packages/playground/samples/versioning.cadl
+++ b/packages/playground/samples/versioning.cadl
@@ -4,7 +4,9 @@ import "@cadl-lang/versioning";
 using Cadl.Versioning;
 
 @versioned(Versions)
-@serviceTitle("Widget Service")
+@service({
+  title: "Widget Service",
+})
 namespace DemoService;
 
 enum Versions {

--- a/packages/rest/test/routes.test.ts
+++ b/packages/rest/test/routes.test.ts
@@ -571,9 +571,10 @@ describe("rest: routes", () => {
         @route("/test")
         op get(): string;
     `);
-      strictEqual(diagnostics.length, 1);
-      strictEqual(diagnostics[0].code, "@cadl-lang/rest/duplicate-route-decorator");
-      strictEqual(diagnostics[0].message, "@route was defined twice on this operation.");
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/rest/duplicate-route-decorator",
+        message: "@route was defined twice on this operation.",
+      });
     });
 
     it("emit diagnostic if specifying route twice on interface", async () => {
@@ -584,9 +585,10 @@ describe("rest: routes", () => {
           get(): string
         }
     `);
-      strictEqual(diagnostics.length, 1);
-      strictEqual(diagnostics[0].code, "@cadl-lang/rest/duplicate-route-decorator");
-      strictEqual(diagnostics[0].message, "@route was defined twice on this interface.");
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/rest/duplicate-route-decorator",
+        message: "@route was defined twice on this interface.",
+      });
     });
 
     it("emit diagnostic if namespace have route but different values", async () => {
@@ -604,12 +606,10 @@ describe("rest: routes", () => {
         }
     `);
 
-      strictEqual(diagnostics.length, 1);
-      strictEqual(diagnostics[0].code, "@cadl-lang/rest/duplicate-route-decorator");
-      strictEqual(
-        diagnostics[0].message,
-        "@route was defined twice on this namespace and has different values."
-      );
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/rest/duplicate-route-decorator",
+        message: "@route was defined twice on this namespace and has different values.",
+      });
     });
 
     it("merge namespace if @route value is the same", async () => {

--- a/packages/rest/test/routes.test.ts
+++ b/packages/rest/test/routes.test.ts
@@ -70,7 +70,7 @@ describe("rest: routes", () => {
       it("operation in the service namespace are included", async () => {
         const routes = await getOperations(
           `
-          @serviceTitle("My Service")
+          @service({title: "My Service"})
           namespace MyService;
           @get op index(): void;
           `
@@ -85,7 +85,7 @@ describe("rest: routes", () => {
           @route("/not-included")
           @get op notIncluded(): void;
 
-          @serviceTitle("My Service")
+          @service({title: "My Service"})
           namespace MyService {
             @route("/included")
             @get op included(): void;
@@ -98,7 +98,7 @@ describe("rest: routes", () => {
       it("interface in the service namespace are included", async () => {
         const routes = await getOperations(
           `
-          @serviceTitle("My Service")
+          @service({title: "My Service"})
           namespace MyService;
           interface Foo {
             @get index(): void;
@@ -111,7 +111,7 @@ describe("rest: routes", () => {
       it("operation in namespace in the service namespace are be included", async () => {
         const routes = await getOperations(
           `
-          @serviceTitle("My Service")
+          @service({title: "My Service"})
           namespace MyService;
 
           namespace MyArea{ 
@@ -126,7 +126,7 @@ describe("rest: routes", () => {
       it("operation in a different namespace are not included", async () => {
         const routes = await getOperations(
           `
-          @serviceTitle("My Service")
+          @service({title: "My Service"})
           namespace MyService {
             @route("/included")
             @get op test(): string;

--- a/packages/rest/test/test-host.ts
+++ b/packages/rest/test/test-host.ts
@@ -102,7 +102,7 @@ export async function getOperationsWithServiceNamespace(
 ): Promise<[HttpOperation[], readonly Diagnostic[]]> {
   const runner = await createRestTestRunner();
   await runner.compileAndDiagnose(
-    `@serviceTitle("Test Service") namespace TestService;
+    `@service({title: "Test Service"}) namespace TestService;
     ${code}`,
     {
       noEmit: true,

--- a/packages/samples/authentication/main.cadl
+++ b/packages/samples/authentication/main.cadl
@@ -2,7 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
-@serviceTitle("Authenticated service")
+@service({
+  title: "Authenticated service",
+})
 @useAuth(
   // Here authentication can either be a
   // - ApiKey AND Basic Auth together

--- a/packages/samples/binary/binary.cadl
+++ b/packages/samples/binary/binary.cadl
@@ -2,7 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
-@serviceTitle("Binary sample")
+@service({
+  title: "Binary sample",
+})
 namespace BinarySample;
 
 model HasBytes {

--- a/packages/samples/documentation/docs.cadl
+++ b/packages/samples/documentation/docs.cadl
@@ -2,7 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
-@serviceTitle("Documentaion sample")
+@service({
+  title: "Documentaion sample",
+})
 namespace DocSample;
 
 @route("/foo")

--- a/packages/samples/grpc-kiosk-example/kiosk.cadl
+++ b/packages/samples/grpc-kiosk-example/kiosk.cadl
@@ -2,7 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
-@serviceTitle("Grpc Kiosk sample")
+@service({
+  title: "Grpc Kiosk sample",
+})
 namespace GrpcKioskSample;
 
 @route("/v1")

--- a/packages/samples/grpc-library-example/library.cadl
+++ b/packages/samples/grpc-library-example/library.cadl
@@ -8,7 +8,9 @@ import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
-@serviceTitle("Grpc Library sample")
+@service({
+  title: "Grpc Library sample",
+})
 namespace GrpcLibrarySample;
 
 @doc("""

--- a/packages/samples/multiple-types-union/main.cadl
+++ b/packages/samples/multiple-types-union/main.cadl
@@ -3,8 +3,8 @@ import "@cadl-lang/openapi";
 
 @service({
   title: "Pet Store Service",
+  version: "2021-03-25",
 })
-@serviceVersion("2021-03-25")
 namespace PetStore;
 using Cadl.Http;
 

--- a/packages/samples/multiple-types-union/main.cadl
+++ b/packages/samples/multiple-types-union/main.cadl
@@ -1,7 +1,9 @@
 import "@cadl-lang/rest";
 import "@cadl-lang/openapi";
 
-@serviceTitle("Pet Store Service")
+@service({
+  title: "Pet Store Service",
+})
 @serviceVersion("2021-03-25")
 namespace PetStore;
 using Cadl.Http;

--- a/packages/samples/nested/nested.cadl
+++ b/packages/samples/nested/nested.cadl
@@ -2,7 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
-@serviceTitle("Nested sample")
+@service({
+  title: "Nested sample",
+})
 namespace Root {
   @route("/sub/a")
   namespace SubA {

--- a/packages/samples/nullable/nullable.cadl
+++ b/packages/samples/nullable/nullable.cadl
@@ -3,7 +3,9 @@ import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
-@serviceTitle("Nullable sample")
+@service({
+  title: "Nullable sample",
+})
 namespace NullableSample;
 
 model HasNullables {

--- a/packages/samples/optional/optional.cadl
+++ b/packages/samples/optional/optional.cadl
@@ -2,7 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
-@serviceTitle("Optional sample")
+@service({
+  title: "Optional sample",
+})
 namespace OptionalSample;
 
 model HasOptional {

--- a/packages/samples/param-decorators/param-decorators.cadl
+++ b/packages/samples/param-decorators/param-decorators.cadl
@@ -1,6 +1,8 @@
 import "@cadl-lang/rest";
 
-@serviceTitle("Parameter Decorators")
+@service({
+  title: "Parameter Decorators",
+})
 namespace Cadl.Samples;
 
 using Cadl.Http;

--- a/packages/samples/petstore/petstore.cadl
+++ b/packages/samples/petstore/petstore.cadl
@@ -6,8 +6,8 @@ using Cadl.Http;
 
 @service({
   title: "Pet Store Service",
+  version: "2021-03-25",
 })
-@serviceVersion("2021-03-25")
 @doc("This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.")
 namespace PetStore;
 

--- a/packages/samples/petstore/petstore.cadl
+++ b/packages/samples/petstore/petstore.cadl
@@ -4,7 +4,9 @@ import "./decorators.js";
 
 using Cadl.Http;
 
-@serviceTitle("Pet Store Service")
+@service({
+  title: "Pet Store Service",
+})
 @serviceVersion("2021-03-25")
 @doc("This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.")
 namespace PetStore;

--- a/packages/samples/polymorphism/polymorphism.cadl
+++ b/packages/samples/polymorphism/polymorphism.cadl
@@ -3,7 +3,9 @@ import "@cadl-lang/rest";
 using Cadl.Http;
 using Cadl.Rest;
 
-@serviceTitle("Polymorphism sample")
+@service({
+  title: "Polymorphism sample",
+})
 namespace PolymorphismSample;
 
 @discriminator("kind")

--- a/packages/samples/projected-names/projected-names.cadl
+++ b/packages/samples/projected-names/projected-names.cadl
@@ -2,7 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
-@serviceTitle("Sample showcasing projected names")
+@service({
+  title: "Sample showcasing projected names",
+})
 namespace ProjectedNames;
 
 model WithProjectedNames {

--- a/packages/samples/rest/petstore/petstore.cadl
+++ b/packages/samples/rest/petstore/petstore.cadl
@@ -2,7 +2,9 @@ import "@cadl-lang/rest";
 import "@cadl-lang/openapi";
 
 @autoRoute
-@serviceTitle("Pet Store Service")
+@service({
+  title: "Pet Store Service",
+})
 @serviceVersion("2021-03-25")
 namespace PetStore;
 

--- a/packages/samples/rest/petstore/petstore.cadl
+++ b/packages/samples/rest/petstore/petstore.cadl
@@ -4,8 +4,8 @@ import "@cadl-lang/openapi";
 @autoRoute
 @service({
   title: "Pet Store Service",
+  version: "2021-03-25",
 })
-@serviceVersion("2021-03-25")
 namespace PetStore;
 
 using Cadl.Http;

--- a/packages/samples/tags/tagged-operations.cadl
+++ b/packages/samples/tags/tagged-operations.cadl
@@ -2,7 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
-@serviceTitle("Tags sample")
+@service({
+  title: "Tags sample",
+})
 namespace TagsSample;
 
 @route("/foo")

--- a/packages/samples/testserver/body-boolean/body-boolean.cadl
+++ b/packages/samples/testserver/body-boolean/body-boolean.cadl
@@ -4,7 +4,9 @@ import "@cadl-lang/openapi";
 using Cadl.Http;
 using OpenAPI;
 
-@serviceTitle("sample")
+@service({
+  title: "sample",
+})
 namespace Sample;
 
 @doc("Error")

--- a/packages/samples/testserver/body-complex/body-complex.cadl
+++ b/packages/samples/testserver/body-complex/body-complex.cadl
@@ -3,7 +3,9 @@ import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
-@serviceTitle("sample")
+@service({
+  title: "sample",
+})
 namespace Sample;
 
 @doc("Error")

--- a/packages/samples/testserver/body-string/body-string.cadl
+++ b/packages/samples/testserver/body-string/body-string.cadl
@@ -3,7 +3,9 @@ import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
-@serviceTitle("sample")
+@service({
+  title: "sample",
+})
 namespace Sample;
 
 @doc("Error")

--- a/packages/samples/testserver/body-time/body-time.cadl
+++ b/packages/samples/testserver/body-time/body-time.cadl
@@ -3,7 +3,9 @@ import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
-@serviceTitle("sample")
+@service({
+  title: "sample",
+})
 namespace Sample;
 
 @doc("Error")

--- a/packages/samples/testserver/media-types/media-types.cadl
+++ b/packages/samples/testserver/media-types/media-types.cadl
@@ -4,7 +4,9 @@ import "@cadl-lang/openapi";
 using Cadl.Http;
 using OpenAPI;
 
-@serviceTitle("sample")
+@service({
+  title: "sample",
+})
 namespace Sample;
 
 @doc("Uri or local path to source data.")

--- a/packages/samples/testserver/multiple-inheritance/multiple-inheritance.cadl
+++ b/packages/samples/testserver/multiple-inheritance/multiple-inheritance.cadl
@@ -3,7 +3,9 @@ import "@cadl-lang/openapi";
 
 using Cadl.Http;
 
-@serviceTitle("sample")
+@service({
+  title: "sample",
+})
 namespace Sample;
 
 model Pet {

--- a/packages/samples/use-versioned-lib/main.cadl
+++ b/packages/samples/use-versioned-lib/main.cadl
@@ -5,7 +5,9 @@ import "./library.cadl";
 using Cadl.Versioning;
 
 // Use version 1.0 of the Library
-@serviceTitle("Pet Store Service")
+@service({
+  title: "Pet Store Service",
+})
 @versionedDependency(Library.Versions.v1_0)
 namespace VersionedApi;
 using Cadl.Http;

--- a/packages/samples/versioning/main.cadl
+++ b/packages/samples/versioning/main.cadl
@@ -6,7 +6,9 @@ using Cadl.Versioning;
 using Cadl.Rest;
 
 @versionedDependency([[Versions.v1, Library.Versions.v1_0], [Versions.v2, Library.Versions.v1_1]])
-@serviceTitle("Pet Store Service")
+@service({
+  title: "Pet Store Service",
+})
 @versioned(Versions)
 namespace VersionedApi;
 using Cadl.Http;

--- a/packages/samples/visibility/visibility.cadl
+++ b/packages/samples/visibility/visibility.cadl
@@ -2,7 +2,9 @@ import "@cadl-lang/rest";
 
 using Cadl.Http;
 
-@serviceTitle("Visibility sample")
+@service({
+  title: "Visibility sample",
+})
 namespace VisibilitySample;
 
 model Person {

--- a/packages/versioning/test/versioned-dependencies.test.ts
+++ b/packages/versioning/test/versioned-dependencies.test.ts
@@ -369,7 +369,7 @@ describe("versioning: dependencies", () => {
   // Test for https://github.com/microsoft/cadl/issues/760
   it("have a nested service namespace", async () => {
     const { MyService } = (await runner.compile(`
-        @serviceTitle("Test")
+        @service({title: "Test"})
         @versionedDependency(Lib.Versions.v1)
         @test("MyService")
         namespace MyOrg.MyService {
@@ -391,7 +391,7 @@ describe("versioning: dependencies", () => {
   // Test for https://github.com/microsoft/cadl/issues/786
   it("have a nested service namespace and libraries sharing common parent namespace", async () => {
     const { MyService } = (await runner.compile(`
-        @serviceTitle("Test")
+        @service({title: "Test"})
         @versionedDependency(Lib.One.Versions.v1)
         @test("MyService")
         namespace MyOrg.MyService {


### PR DESCRIPTION
resolves #1003

Deprecation entry for october sprint https://github.com/microsoft/cadl/issues/1011#issuecomment-1252478012