### PR TITLE
Intersection belong to namespace they are declared in

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-intersection-namespace_2022-09-20-17-56.json
+++ b/common/changes/@cadl-lang/compiler/fix-intersection-namespace_2022-09-20-17-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix: Intersection types belong to namespace they are declared in.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -1076,6 +1076,7 @@ export function createChecker(program: Program): Checker {
       kind: "Model",
       node,
       name: "",
+      namespace: getParentNamespaceType(node),
       properties: properties,
       decorators: [],
       derivedModels: [],
@@ -1216,12 +1217,17 @@ export function createChecker(program: Program): Checker {
       | OperationStatementNode
       | EnumStatementNode
       | InterfaceStatementNode
+      | IntersectionExpressionNode
       | UnionStatementNode
       | ModelExpressionNode
+      | ProjectionModelExpressionNode
   ): Namespace | undefined {
     if (node === globalNamespaceType.node) return undefined;
 
-    if (node.kind === SyntaxKind.ModelExpression) {
+    if (
+      node.kind === SyntaxKind.ModelExpression ||
+      node.kind === SyntaxKind.IntersectionExpression
+    ) {
       let parent: Node | undefined = node.parent;
       while (parent !== undefined) {
         if (
@@ -1230,7 +1236,8 @@ export function createChecker(program: Program): Checker {
           parent.kind === SyntaxKind.EnumStatement ||
           parent.kind === SyntaxKind.InterfaceStatement ||
           parent.kind === SyntaxKind.UnionStatement ||
-          parent.kind === SyntaxKind.ModelExpression
+          parent.kind === SyntaxKind.ModelExpression ||
+          parent.kind === SyntaxKind.IntersectionExpression
         ) {
           return getParentNamespaceType(parent);
         } else {

--- a/packages/compiler/test/checker/intersections.test.ts
+++ b/packages/compiler/test/checker/intersections.test.ts
@@ -30,6 +30,27 @@ describe("compiler: intersections", () => {
     ok(prop.properties.has("b"));
   });
 
+  it("intersection type belong to namespace it is declared in", async () => {
+    const { Foo } = (await runner.compile(`
+      namespace A {
+        model ModelA {name: string}
+      }
+      namespace B {
+        model ModelB {age: int32}
+      }
+      namespace C {
+        @test model Foo {
+          prop: A.ModelA & B.ModelB;
+        }
+      }
+    `)) as { Foo: Model };
+
+    const prop = Foo.properties.get("prop")!.type as Model;
+    strictEqual(prop.kind, "Model");
+    ok(prop.namespace);
+    strictEqual(prop.namespace.name, "C");
+  });
+
   it("allow intersections of template params", async () => {
     const { Foo } = (await runner.compile(`
       model Bar<A, B> {


### PR DESCRIPTION
fix #1054

Like we have for model expression, intersection should have the namespace where they were declared be assigned.