### PR TITLE
Allow duplicate @service

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-service-dup_2022-09-20-21-13.json
+++ b/common/changes/@cadl-lang/compiler/fix-service-dup_2022-09-20-21-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/lib/service.ts
+++ b/packages/compiler/lib/service.ts
@@ -51,12 +51,6 @@ export function $service(context: DecoratorContext, target: Namespace, options: 
   }
   const serviceDetails = getServiceDetails(context.program);
 
-  if (getServiceNamespace(context.program) !== context.program.getGlobalNamespaceType()) {
-    reportDiagnostic(context.program, {
-      code: "service-decorator-duplicate",
-      target,
-    });
-  }
   setServiceNamespace(context.program, target);
 
   const title = options.properties.get("title")?.type;
@@ -95,16 +89,6 @@ export function $serviceTitle(context: DecoratorContext, target: Type, title: st
     context.decoratorTarget
   );
   const serviceDetails = getServiceDetails(context.program);
-  if (serviceDetails.title) {
-    context.program.reportDiagnostic(
-      createDiagnostic({
-        code: "service-decorator-duplicate",
-        format: { name: "title" },
-        target,
-      })
-    );
-  }
-
   if (!validateDecoratorTarget(context, target, "@serviceTitle", "Namespace")) {
     return;
   }
@@ -128,16 +112,6 @@ export function $serviceVersion(context: DecoratorContext, target: Type, version
     "@serviceVersion decorator has been deprecated use @service({title: _}) instead.",
     context.decoratorTarget
   );
-  if (serviceDetails.version) {
-    context.program.reportDiagnostic(
-      createDiagnostic({
-        code: "service-decorator-duplicate",
-        format: { name: "version" },
-        target,
-      })
-    );
-  }
-
   if (!validateDecoratorTarget(context, target, "@serviceVersion", "Namespace")) {
     return;
   }


### PR DESCRIPTION
Uptaking the `@service` change is actually causing a problem with `armProviderNamespace` as that decorator sets teh service namespace then runnning `@service` would assume there is another `@service` decorator. This remove the validation as ultimatately (Spcially with multi services coming) the only validation that we might want is checking the user didn't specify `@service` twice on the same node but that is nearly more of a syntax linting