### PR TITLE
Allow referencing global namespace as `global` for disambiguation

### DIFF
--- a/common/changes/@cadl-lang/compiler/global-disambiguation_2022-09-21-17-35.json
+++ b/common/changes/@cadl-lang/compiler/global-disambiguation_2022-09-21-17-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Allow referencing global namespace as `global` for disambiguation",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -2869,7 +2869,7 @@ export function createChecker(program: Program): Checker {
     };
 
     mutate(nsNode).symbol = createSymbol(nsNode, nsId.sv, SymbolFlags.Namespace);
-    mutate(nsNode.symbol.exports).set(nsNode.id.sv, nsNode.symbol);
+    mutate(nsNode.symbol.exports).set(nsId.sv, nsNode.symbol);
     return nsNode;
   }
 

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -2852,7 +2852,7 @@ export function createChecker(program: Program): Checker {
       kind: SyntaxKind.Identifier,
       pos: 0,
       end: 0,
-      sv: "__GLOBAL_NS",
+      sv: "global",
       symbol: undefined!,
       flags: NodeFlags.Synthetic,
     };
@@ -2867,7 +2867,9 @@ export function createChecker(program: Program): Checker {
       locals: createSymbolTable(),
       flags: NodeFlags.Synthetic,
     };
-    mutate(nsNode).symbol = createSymbol(nsNode, "__GLOBAL_NS", SymbolFlags.Namespace);
+
+    mutate(nsNode).symbol = createSymbol(nsNode, nsId.sv, SymbolFlags.Namespace);
+    mutate(nsNode.symbol.exports).set(nsNode.id.sv, nsNode.symbol);
     return nsNode;
   }
 


### PR DESCRIPTION
Fix #886 