### PR TITLE
Clean up test names

### DIFF
--- a/common/changes/@cadl-lang/compiler/test-reorg_2022-09-23-15-56.json
+++ b/common/changes/@cadl-lang/compiler/test-reorg_2022-09-23-15-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/html-program-viewer/test-reorg_2022-09-23-15-56.json
+++ b/common/changes/@cadl-lang/html-program-viewer/test-reorg_2022-09-23-15-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/html-program-viewer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/html-program-viewer"
+}

--- a/common/changes/@cadl-lang/internal-build-utils/test-reorg_2022-09-23-15-56.json
+++ b/common/changes/@cadl-lang/internal-build-utils/test-reorg_2022-09-23-15-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/internal-build-utils",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/internal-build-utils"
+}

--- a/common/changes/@cadl-lang/library-linter/test-reorg_2022-09-23-15-56.json
+++ b/common/changes/@cadl-lang/library-linter/test-reorg_2022-09-23-15-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/library-linter",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/library-linter"
+}

--- a/common/changes/@cadl-lang/openapi/test-reorg_2022-09-23-15-56.json
+++ b/common/changes/@cadl-lang/openapi/test-reorg_2022-09-23-15-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/rest/test-reorg_2022-09-23-15-56.json
+++ b/common/changes/@cadl-lang/rest/test-reorg_2022-09-23-15-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/versioning/test-reorg_2022-09-23-15-56.json
+++ b/common/changes/@cadl-lang/versioning/test-reorg_2022-09-23-15-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/packages/bundler/test/test.test.ts
+++ b/packages/bundler/test/test.test.ts
@@ -1,6 +1,6 @@
 import { ok } from "assert";
 
-describe("bundler:", () => {
+describe("bundler", () => {
   it("works", () => {
     ok(true);
   });

--- a/packages/compiler/test/checker/projection.test.ts
+++ b/packages/compiler/test/checker/projection.test.ts
@@ -19,7 +19,7 @@ import {
 import { getDoc } from "../../lib/decorators.js";
 import { createTestHost, TestHost } from "../../testing/index.js";
 
-describe("cadl: projections", () => {
+describe("compiler: projections", () => {
   let testHost: TestHost;
 
   beforeEach(async () => {

--- a/packages/compiler/test/server/reuse.test.ts
+++ b/packages/compiler/test/server/reuse.test.ts
@@ -7,7 +7,7 @@ import {
   resolveVirtualPath,
 } from "../../testing/index.js";
 
-describe("server: reuse", () => {
+describe("compiler: server: reuse", () => {
   it("reuses unchanged programs", async () => {
     const host = await createTestServerHost();
     const document = host.addOrUpdateDocument("main.cadl", "model M  {}");

--- a/packages/html-program-viewer/test/smoke-test.test.ts
+++ b/packages/html-program-viewer/test/smoke-test.test.ts
@@ -1,7 +1,7 @@
 import { BasicTestRunner } from "@cadl-lang/compiler/testing";
 import { createViewerTestRunner } from "./test-host.js";
 
-describe("Smoke tests", () => {
+describe("html-program-viewer: smoke tests", () => {
   let runner: BasicTestRunner;
 
   beforeEach(async () => {

--- a/packages/internal-build-utils/test/mics.test.ts
+++ b/packages/internal-build-utils/test/mics.test.ts
@@ -1,5 +1,5 @@
 import { ok } from "assert";
 
-describe("Test", () => {
+describe("internal-build-utils", () => {
   it("todo", () => ok(true));
 });

--- a/packages/library-linter/test/linter.test.ts
+++ b/packages/library-linter/test/linter.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@cadl-lang/compiler/testing";
 import { createLibraryLinterTestHost } from "./test-host.js";
 
-describe("cadl: library-linter", () => {
+describe("library-linter", () => {
   let runner: BasicTestRunner;
   let host: TestHost;
 

--- a/packages/openapi/test/helpers.test.ts
+++ b/packages/openapi/test/helpers.test.ts
@@ -3,7 +3,7 @@ import { BasicTestRunner, createTestRunner } from "@cadl-lang/compiler/testing";
 import { strictEqual } from "assert";
 import { resolveOperationId } from "../src/helpers.js";
 
-describe("OpenAPI3 Helpers", () => {
+describe("openapi: helpers", () => {
   let runner: BasicTestRunner;
 
   beforeEach(async () => {

--- a/packages/rest/test/responses.test.ts
+++ b/packages/rest/test/responses.test.ts
@@ -3,7 +3,7 @@ import { expectDiagnosticEmpty, expectDiagnostics } from "@cadl-lang/compiler/te
 import { deepStrictEqual, ok, strictEqual } from "assert";
 import { compileOperations, getOperationsWithServiceNamespace } from "./test-host.js";
 
-describe("cadl: rest: responses", () => {
+describe("rest: responses", () => {
   it("issues diagnostics for duplicate body decorator", async () => {
     const [_, diagnostics] = await compileOperations(
       `

--- a/packages/versioning/test/incompatible-versioning.test.ts
+++ b/packages/versioning/test/incompatible-versioning.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@cadl-lang/compiler/testing";
 import { createVersioningTestHost } from "./test-host.js";
 
-describe("versioning: validate incompatible references", () => {
+describe("compiler: versioning: validate incompatible references", () => {
   let runner: BasicTestRunner;
 
   beforeEach(async () => {

--- a/packages/versioning/test/versioned-dependencies.test.ts
+++ b/packages/versioning/test/versioned-dependencies.test.ts
@@ -10,7 +10,7 @@ import { buildVersionProjections } from "../src/versioning.js";
 import { createVersioningTestHost } from "./test-host.js";
 import { assertHasProperties } from "./utils.js";
 
-describe("versioning: reference versioned library", () => {
+describe("compiler: versioning: reference versioned library", () => {
   let runner: BasicTestRunner;
 
   beforeEach(async () => {
@@ -258,7 +258,7 @@ describe("versioning: reference versioned library", () => {
   });
 });
 
-describe("versioning: dependencies", () => {
+describe("compiler: versioning: dependencies", () => {
   let runner: BasicTestRunner;
 
   beforeEach(async () => {

--- a/packages/versioning/test/versioning.test.ts
+++ b/packages/versioning/test/versioning.test.ts
@@ -21,7 +21,7 @@ import {
   assertHasVariants,
 } from "./utils.js";
 
-describe("cadl: versioning", () => {
+describe("compiler: versioning", () => {
   let runner: BasicTestRunner;
 
   beforeEach(async () => {


### PR DESCRIPTION
Test explorer was getting quite messy. Standardize on leading project name throughout.