### PR TITLE
Fix: Content type header lookup should be case insensitive

### DIFF
--- a/common/changes/@cadl-lang/openapi3/fix-req-content-type-case-ins_2022-09-26-16-21.json
+++ b/common/changes/@cadl-lang/openapi3/fix-req-content-type-case-ins_2022-09-26-16-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Fix: `Content-Type` request header lookup is case insensitive",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/fix-req-content-type-case-ins_2022-09-26-16-21.json
+++ b/common/changes/@cadl-lang/rest/fix-req-content-type-case-ins_2022-09-26-16-21.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@cadl-lang/rest",
-      "comment": "Feature: Add `isContentTypeProperty` helper.",
+      "comment": "Feature: Add `isContentTypeHeader` helper.",
       "type": "minor"
     }
   ],

--- a/common/changes/@cadl-lang/rest/fix-req-content-type-case-ins_2022-09-26-16-21.json
+++ b/common/changes/@cadl-lang/rest/fix-req-content-type-case-ins_2022-09-26-16-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Feature: Add `isContentTypeProperty` helper.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -73,6 +73,7 @@ import {
   HttpOperationParameter,
   HttpOperationParameters,
   HttpOperationResponse,
+  isContentTypeProperty,
   MetadataInfo,
   reportIfNoRoutes,
   ServiceAuthentication,
@@ -679,8 +680,8 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
       content: {},
     };
 
-    const contentTypeParam = parameters.parameters.find(
-      (p) => p.type === "header" && p.name === "content-type"
+    const contentTypeParam = parameters.parameters.find((p) =>
+      isContentTypeProperty(program, p.param)
     );
     const contentTypes = contentTypeParam
       ? ignoreDiagnostics(getContentTypes(contentTypeParam.param))

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -73,7 +73,7 @@ import {
   HttpOperationParameter,
   HttpOperationParameters,
   HttpOperationResponse,
-  isContentTypeProperty,
+  isContentTypeHeader,
   MetadataInfo,
   reportIfNoRoutes,
   ServiceAuthentication,
@@ -659,7 +659,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
           emitParameter(param, "query", visibility);
           break;
         case "header":
-          if (!isContentTypeProperty(program, param)) {
+          if (!isContentTypeHeader(program, param)) {
             emitParameter(param, "header", visibility);
           }
           break;
@@ -681,7 +681,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     };
 
     const contentTypeParam = parameters.parameters.find((p) =>
-      isContentTypeProperty(program, p.param)
+      isContentTypeHeader(program, p.param)
     );
     const contentTypes = contentTypeParam
       ? ignoreDiagnostics(getContentTypes(contentTypeParam.param))

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -645,7 +645,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
   }
 
   function emitEndpointParameters(parameters: HttpOperationParameter[], visibility: Visibility) {
-    for (const { type, name, param } of parameters) {
+    for (const { type, param } of parameters) {
       if (params.has(param)) {
         currentEndpoint.parameters.push(params.get(param));
         continue;
@@ -659,7 +659,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
           emitParameter(param, "query", visibility);
           break;
         case "header":
-          if (name !== "content-type") {
+          if (!isContentTypeProperty(program, param)) {
             emitParameter(param, "header", visibility);
           }
           break;

--- a/packages/openapi3/test/parameters.test.ts
+++ b/packages/openapi3/test/parameters.test.ts
@@ -97,4 +97,49 @@ describe("openapi3: parameters", () => {
       },
     ]);
   });
+
+  describe("content type parameter", () => {
+    it("header named with 'Content-Type' gets resolved as content type for operation.", async () => {
+      const res = await openApiFor(
+        `
+        op test(
+          @header("Content-Type") explicitContentType: "application/octet-stream",
+          @body foo: string
+        ): void;
+        `
+      );
+      ok(res.paths["/"].post.requestBody.content["application/octet-stream"]);
+      deepStrictEqual(res.paths["/"].post.requestBody.content["application/octet-stream"].schema, {
+        type: "string",
+      });
+    });
+
+    it("header named contentType gets resolved as content type for operation.", async () => {
+      const res = await openApiFor(
+        `
+        op test(
+          @header contentType: "application/octet-stream",
+          @body foo: string
+        ): void;
+        `
+      );
+      ok(res.paths["/"].post.requestBody.content["application/octet-stream"]);
+      deepStrictEqual(res.paths["/"].post.requestBody.content["application/octet-stream"].schema, {
+        type: "string",
+      });
+    });
+
+    it("query named contentType doesn't get resolved as the content type parmaeter.", async () => {
+      const res = await openApiFor(
+        `
+        op test(
+          @query contentType: "application/octet-stream",
+          @body foo: string
+        ): void;
+        `
+      );
+      strictEqual(res.paths["/"].post.requestBody.content["application/octet-stream"], undefined);
+      ok(res.paths["/"].post.requestBody.content["application/json"]);
+    });
+  });
 });

--- a/packages/rest/src/http/parameters.ts
+++ b/packages/rest/src/http/parameters.ts
@@ -145,7 +145,7 @@ function getOperationParametersForVerb(
  * @param property Model property.
  * @returns True if the model property is marked as a header and has the name `content-type`(case insensitive.)
  */
-export function isContentTypeProperty(program: Program, property: ModelProperty): boolean {
+export function isContentTypeHeader(program: Program, property: ModelProperty): boolean {
   const headerName = getHeaderFieldName(program, property);
   return Boolean(headerName && headerName.toLowerCase() === "content-type");
 }

--- a/packages/rest/src/http/parameters.ts
+++ b/packages/rest/src/http/parameters.ts
@@ -139,6 +139,17 @@ function getOperationParametersForVerb(
   return diagnostics.wrap(result);
 }
 
+/**
+ * Check if the given model property is the content type header.
+ * @param program Program
+ * @param property Model property.
+ * @returns True if the model property is marked as a header and has the name `content-type`(case insensitive.)
+ */
+export function isContentTypeProperty(program: Program, property: ModelProperty): boolean {
+  const headerName = getHeaderFieldName(program, property);
+  return Boolean(headerName && headerName.toLowerCase() === "content-type");
+}
+
 function getExplicitVerbForOperation(program: Program, operation: Operation): HttpVerb | undefined {
   const resourceOperation = getResourceOperation(program, operation);
   const verb =

--- a/packages/rest/src/http/responses.ts
+++ b/packages/rest/src/http/responses.ts
@@ -25,7 +25,7 @@ import {
   isStatusCode,
 } from "./decorators.js";
 import { gatherMetadata, isApplicableMetadata, Visibility } from "./metadata.js";
-import { isContentTypeProperty } from "./parameters.js";
+import { isContentTypeHeader } from "./parameters.js";
 import { HttpOperationResponse } from "./types.js";
 
 /**
@@ -173,7 +173,7 @@ function getResponseContentTypes(
 ): string[] {
   const contentTypes: string[] = [];
   for (const prop of metadata) {
-    if (isHeader(program, prop) && isContentTypeProperty(program, prop)) {
+    if (isHeader(program, prop) && isContentTypeHeader(program, prop)) {
       contentTypes.push(...diagnostics.pipe(getContentTypes(prop)));
     }
   }

--- a/packages/rest/src/http/responses.ts
+++ b/packages/rest/src/http/responses.ts
@@ -25,6 +25,7 @@ import {
   isStatusCode,
 } from "./decorators.js";
 import { gatherMetadata, isApplicableMetadata, Visibility } from "./metadata.js";
+import { isContentTypeProperty } from "./parameters.js";
 import { HttpOperationResponse } from "./types.js";
 
 /**
@@ -38,12 +39,12 @@ export function getResponsesForOperation(
   const responseType = operation.returnType;
   const responses: Record<string | symbol, HttpOperationResponse> = {};
   if (responseType.kind === "Union") {
-    for (const option of responseType.options) {
-      if (isNullType(program, option)) {
+    for (const option of responseType.variants.values()) {
+      if (isNullType(program, option.type)) {
         // TODO how should we treat this? https://github.com/microsoft/cadl/issues/356
         continue;
       }
-      processResponseType(program, diagnostics, responses, option);
+      processResponseType(program, diagnostics, responses, option.type);
     }
   } else {
     processResponseType(program, diagnostics, responses, responseType);
@@ -172,11 +173,8 @@ function getResponseContentTypes(
 ): string[] {
   const contentTypes: string[] = [];
   for (const prop of metadata) {
-    if (isHeader(program, prop)) {
-      const headerName = getHeaderFieldName(program, prop);
-      if (headerName && headerName.toLowerCase() === "content-type") {
-        contentTypes.push(...diagnostics.pipe(getContentTypes(prop)));
-      }
+    if (isHeader(program, prop) && isContentTypeProperty(program, prop)) {
+      contentTypes.push(...diagnostics.pipe(getContentTypes(prop)));
     }
   }
   return contentTypes;
@@ -193,9 +191,9 @@ export function getContentTypes(property: ModelProperty): [string[], readonly Di
     return [[property.type.value], []];
   } else if (property.type.kind === "Union") {
     const contentTypes = [];
-    for (const option of property.type.options) {
-      if (option.kind === "String") {
-        contentTypes.push(option.value);
+    for (const option of property.type.variants.values()) {
+      if (option.type.kind === "String") {
+        contentTypes.push(option.type.value);
       } else {
         diagnostics.add(
           createDiagnostic({


### PR DESCRIPTION
fix [#607](https://github.com/microsoft/cadl/issues/607)

```cadl
import "@cadl-lang/rest";

using Cadl.Http;

@Cadl.Http.post op doesnotwork(
  @header("Content-Type") contentType: "application/octet-stream",
  @body foo: string
): void;


@Cadl.Http.put op works(
  @header("content-type") contentType: "application/octet-stream",
  @body foo: string
): void;

```

[Playground fixed](https://cadlplayground.z22.web.core.windows.net/prs/1082/?c=aW1wb3J0ICJAY2FkbC1sYW5nL3Jlc3QiOwoKdXNpbmcgQ2FkbC5IdHRwOwoKQMkNLnBvc3Qgb3AgZG9lc25vdHdvcmsoCiAgQGhlYWRlcigiQ29udGVudC1UeXBlIikgY8YPxA46ICJhcHBsaWNhdGlvbi9vY3RldC1zdHJlYW0iLMRDYm9keSBmb286IHN0cmluZwopOiB2b2lkOwruAIJ15QCBxHpzzXvHbC1033vfe857) showing `doesnotwork` working