### PR TITLE
Fix incorrect extends string syntax in decorator example.

### DIFF
--- a/packages/website/src/docs/standard-library/built-in-decorators.md
+++ b/packages/website/src/docs/standard-library/built-in-decorators.md
@@ -194,7 +194,7 @@ enum OperationStateValues {
 }
 
 @knownValues(OperationStateValues)
-model OperationState extends string {}
+model OperationState is string;
 ```
 
 ### `@secret`


### PR DESCRIPTION
Example used old model extends string {} syntax. Fixed to use is string.