### PR TITLE
Exclude properties of type `never` when emitting model schemas

### DIFF
--- a/common/changes/@cadl-lang/openapi3/skip-never_2022-10-05-13-09.json
+++ b/common/changes/@cadl-lang/openapi3/skip-never_2022-10-05-13-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Exclude properties of type `never` when emitting model schemas",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1046,6 +1046,11 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
         continue;
       }
 
+      if (isNeverType(prop.type)) {
+        // If the property has a type of 'never', don't include it in the schema
+        continue;
+      }
+
       if (!prop.optional) {
         if (!modelSchema.required) {
           modelSchema.required = [];

--- a/packages/openapi3/test/models.test.ts
+++ b/packages/openapi3/test/models.test.ts
@@ -779,4 +779,34 @@ describe("openapi3: models", () => {
 
     expectDiagnostics(diagnostics, [{ code: "@cadl-lang/openapi3/inline-cycle" }]);
   });
+
+  it("excludes properties with type 'never'", async () => {
+    const res = await oapiForModel(
+      "Bar",
+      `
+      model Foo {
+        y: int32;
+        nope: never;
+      };
+      model Bar extends Foo {
+        x: int32;
+      }`
+    );
+
+    ok(res.isRef);
+    ok(res.schemas.Foo, "expected definition named Foo");
+    ok(res.schemas.Bar, "expected definition named Bar");
+    deepStrictEqual(res.schemas.Bar, {
+      type: "object",
+      properties: { x: { type: "integer", format: "int32" } },
+      allOf: [{ $ref: "#/components/schemas/Foo" }],
+      required: ["x"],
+    });
+
+    deepStrictEqual(res.schemas.Foo, {
+      type: "object",
+      properties: { y: { type: "integer", format: "int32" } },
+      required: ["y"],
+    });
+  });
 });


### PR DESCRIPTION
This came up while working on https://github.com/Azure/cadl-azure/pull/2022#discussion_r984714147: 

In some library authoring cases, it would be nice if a templated type could have a property that can be discarded when the `never` type is passed in.  For example:

```
model OperationStatus<TResult> {
  id: string;
  result?: TResult;
}

op getOperationStatus<TResult = never>(id: string): OperationStatus<TResult>;
```

This would enable spec authors to use `getOperationStatus` or `getOperationStatus<MyResultType>` without the need for two separate operation signatures.  When the `OperationStatus` type is emitted in OpenAPI, the `result` property will be elided when `never` is used in the operation signature.