### PR TITLE
Add support for referencing model property

### DIFF
--- a/common/changes/@cadl-lang/openapi3/model-property-reference_2022-10-06-19-06.json
+++ b/common/changes/@cadl-lang/openapi3/model-property-reference_2022-10-06-19-06.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@cadl-lang/openapi3",
-      "comment": "Add support for referencing model properites",
+      "comment": "Add support for referencing model properties.",
       "type": "minor"
     }
   ],

--- a/common/changes/@cadl-lang/openapi3/model-property-reference_2022-10-06-19-06.json
+++ b/common/changes/@cadl-lang/openapi3/model-property-reference_2022-10-06-19-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Add support for referencing model properites",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -552,6 +552,10 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
       }
     }
 
+    if (type.kind === "ModelProperty") {
+      return resolveProperty(type, visibility);
+    }
+
     type = getEffectiveSchemaType(type, visibility);
 
     const name = getTypeName(program, type, typeNameOptions);

--- a/packages/openapi3/test/models.test.ts
+++ b/packages/openapi3/test/models.test.ts
@@ -809,4 +809,86 @@ describe("openapi3: models", () => {
       required: ["y"],
     });
   });
+
+  describe("referencing another property as type", () => {
+    it("use the type of the other property", async () => {
+      const res = await oapiForModel(
+        "Bar",
+        `
+        model Foo {
+          name: string;
+        }
+        model Bar {
+          x: Foo.name
+        }`
+      );
+
+      ok(res.schemas.Bar, "expected definition named Bar");
+      deepStrictEqual(res.schemas.Bar.properties.x, {
+        type: "string",
+      });
+    });
+
+    it("use the type of the other property with ref", async () => {
+      const res = await oapiForModel(
+        "Bar",
+        `
+        model Name {first: string}
+        model Foo {
+          name: Name;
+        }
+        model Bar {
+          x: Foo.name
+        }`
+      );
+
+      ok(res.schemas.Bar, "expected definition named Bar");
+      deepStrictEqual(res.schemas.Bar.properties.x, {
+        $ref: "#/components/schemas/Name",
+      });
+    });
+
+    it("should include decorators on both referenced property and source property itself", async () => {
+      const res = await oapiForModel(
+        "Bar",
+        `
+        model Foo {
+          @format("uri")
+          name: string;
+        }
+        model Bar {
+          @doc("My doc")
+          x: Foo.name
+        }`
+      );
+
+      ok(res.schemas.Bar, "expected definition named Bar");
+      deepStrictEqual(res.schemas.Bar.properties.x, {
+        type: "string",
+        format: "uri",
+        description: "My doc",
+      });
+    });
+
+    it("decorators on the property should override the value of referenced property", async () => {
+      const res = await oapiForModel(
+        "Bar",
+        `
+        model Foo {
+          @doc("Default doc")
+          name: string;
+        }
+        model Bar {
+          @doc("My doc override")
+          x: Foo.name
+        }`
+      );
+
+      ok(res.schemas.Bar, "expected definition named Bar");
+      deepStrictEqual(res.schemas.Bar.properties.x, {
+        type: "string",
+        description: "My doc override",
+      });
+    });
+  });
 });


### PR DESCRIPTION
fix [#649](https://github.com/microsoft/cadl/issues/649)

Lets you use model property reference as a valid type in openapi

```cadl
model Foo {
   name: string
}

op foo(): Foo.name;
```