### PR TITLE
Add support for overloads in Http and Openapi3 

### DIFF
--- a/common/changes/@cadl-lang/compiler/overload-in-progress_2022-10-07-16-02.json
+++ b/common/changes/@cadl-lang/compiler/overload-in-progress_2022-10-07-16-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add additional validation for `@overload` decorator: Make sure overloads are in the same container and that return types are compatible",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi3/overload-in-progress_2022-10-07-16-02.json
+++ b/common/changes/@cadl-lang/openapi3/overload-in-progress_2022-10-07-16-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Add support for overloads(Using `@overload` decorator)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/overload-in-progress_2022-10-07-16-02.json
+++ b/common/changes/@cadl-lang/rest/overload-in-progress_2022-10-07-16-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add support for overloads(Using `@overload` decorator)",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -390,6 +390,12 @@ const diagnostics = {
       default: paramMessage`Decorator ${"decoratorName"} failed!\n\n${"error"}`,
     },
   },
+  "overload-same-parent": {
+    severity: "error",
+    messages: {
+      default: `Overload must be in the same interface or namespace.`,
+    },
+  },
 
   /**
    * Program

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -927,12 +927,19 @@ export function $overload(context: DecoratorContext, target: Operation, overload
   }
 
   // Ensure that the overloaded method arguments are a subtype of the original operation.
-  const [valid, diagnostics] = context.program.checker.isTypeAssignableTo(
+  const [paramValid, paramDiagnostics] = context.program.checker.isTypeAssignableTo(
     target.parameters,
     overloads.parameters,
     target
   );
-  if (!valid) context.program.reportDiagnostics(diagnostics);
+  if (!paramValid) context.program.reportDiagnostics(paramDiagnostics);
+
+  const [returnTypeValid, returnTypeDiagnostics] = context.program.checker.isTypeAssignableTo(
+    target.returnType,
+    overloads.returnType,
+    target
+  );
+  if (!returnTypeValid) context.program.reportDiagnostics(returnTypeDiagnostics);
 
   // Save the information about the overloaded operation
   context.program.stateMap(overloadsOperationKey).set(target, overloads);
@@ -942,11 +949,11 @@ export function $overload(context: DecoratorContext, target: Operation, overload
 
 /**
  * Get all operations that are marked as overloads of the given operation
- * @param context
- * @param operation
+ * @param program Program
+ * @param operation Operation
  * @returns An array of operations that overload the given operation.
  */
-export function getOverloads(program: Program, operation: Operation): Array<Operation> | undefined {
+export function getOverloads(program: Program, operation: Operation): Operation[] | undefined {
   return program.stateMap(overloadedByKey).get(operation);
 }
 

--- a/packages/compiler/lib/decorators.ts
+++ b/packages/compiler/lib/decorators.ts
@@ -941,7 +941,7 @@ export function $overload(context: DecoratorContext, target: Operation, overload
   );
   if (!returnTypeValid) context.program.reportDiagnostics(returnTypeDiagnostics);
 
-  if (!areOperationParentSame(target, overloadBase)) {
+  if (!areOperationsInSameContainer(target, overloadBase)) {
     reportDiagnostic(context.program, {
       code: "overload-same-parent",
       target: context.decoratorTarget,
@@ -953,8 +953,10 @@ export function $overload(context: DecoratorContext, target: Operation, overload
   context.program.stateMap(overloadedByKey).set(overloadBase, existingOverloads.concat(target));
 }
 
-function areOperationParentSame(op1: Operation, op2: Operation): boolean {
-  return op1.interface ? op1.interface === op2.interface : op1.namespace === op2.namespace;
+function areOperationsInSameContainer(op1: Operation, op2: Operation): boolean {
+  return op1.interface || op2.interface
+    ? op1.interface === op2.interface
+    : op1.namespace === op2.namespace;
 }
 
 /**

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -80,6 +80,7 @@ import {
   HttpOperationParameters,
   HttpOperationResponse,
   isContentTypeHeader,
+  isOverloadSameEndpoint,
   MetadataInfo,
   reportIfNoRoutes,
   ServiceAuthentication,
@@ -366,21 +367,10 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
       reportIfNoRoutes(program, service.operations);
 
       for (const operation of service.operations) {
-        if (!operation.overloading) {
-          if (operation.overloads) {
-            const routeDiffer = operation.overloads.some(
-              (x) => x.path !== operation.path || x.verb !== operation.verb
-            );
-            if (routeDiffer) {
-              for (const overload of operation.overloads) {
-                emitOperation(overload);
-              }
-            } else {
-              emitOperation(operation);
-            }
-          } else {
-            emitOperation(operation);
-          }
+        if (operation.overloading !== undefined && isOverloadSameEndpoint(operation as any)) {
+          continue;
+        } else {
+          emitOperation(operation);
         }
       }
       emitParameters();

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -366,7 +366,22 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
       reportIfNoRoutes(program, service.operations);
 
       for (const operation of service.operations) {
-        emitOperation(operation);
+        if (!operation.overloading) {
+          if (operation.overloads) {
+            const routeDiffer = operation.overloads.some(
+              (x) => x.path !== operation.path || x.verb !== operation.verb
+            );
+            if (routeDiffer) {
+              for (const overload of operation.overloads) {
+                emitOperation(overload);
+              }
+            } else {
+              emitOperation(operation);
+            }
+          } else {
+            emitOperation(operation);
+          }
+        }
       }
       emitParameters();
       emitUnreferencedSchemas(serviceNamespace);

--- a/packages/openapi3/test/overloads.test.ts
+++ b/packages/openapi3/test/overloads.test.ts
@@ -1,0 +1,98 @@
+import { deepStrictEqual, ok, strictEqual } from "assert";
+import { OpenAPI3Document } from "../src/types.js";
+import { openApiFor } from "./test-host.js";
+
+describe("openapi3: overloads", () => {
+  context("overloads use same endpoint", () => {
+    let res: OpenAPI3Document;
+    beforeEach(async () => {
+      res = await openApiFor(
+        `
+        @route("/upload")
+        op upload(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
+        @overload(upload)
+        op uploadString(data: string, @header contentType: "text/plain" ): void;
+        @overload(upload)
+        op uploadBytes(data: bytes, @header contentType: "application/octet-stream"): void;
+      `
+      );
+    });
+
+    it("should create a single path using the overload base name", async () => {
+      strictEqual(Object.keys(res.paths).length, 1);
+      const operation = res.paths["/upload"].post;
+      ok(operation);
+      strictEqual(operation.operationId, "upload");
+      deepStrictEqual(Object.keys(operation.requestBody.content), [
+        "text/plain",
+        "application/octet-stream",
+      ]);
+    });
+  });
+
+  context("overloads all use different endpoint", () => {
+    let res: OpenAPI3Document;
+    beforeEach(async () => {
+      res = await openApiFor(
+        `
+        @route("/upload")
+        op upload(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
+        @overload(upload)
+        @route("/uploadString")
+        op uploadString(data: string, @header contentType: "text/plain" ): void;
+        @overload(upload)
+        @route("/uploadBytes")
+        op uploadBytes(data: bytes, @header contentType: "application/octet-stream"): void;
+      `
+      );
+    });
+
+    it("should create an endpoint for each overload", () => {
+      const stringOperation = res.paths["/uploadString"].post;
+      const bytesOperation = res.paths["/uploadBytes"].post;
+      ok(stringOperation);
+      ok(bytesOperation);
+      strictEqual(stringOperation.operationId, "uploadString");
+      strictEqual(bytesOperation.operationId, "uploadBytes");
+
+      deepStrictEqual(Object.keys(stringOperation.requestBody.content), ["text/plain"]);
+      deepStrictEqual(Object.keys(bytesOperation.requestBody.content), [
+        "application/octet-stream",
+      ]);
+    });
+
+    it("should still create endpoint for operation overload base", async () => {
+      const baseOperation = res.paths["/upload"].post;
+      ok(baseOperation);
+      strictEqual(baseOperation.operationId, "upload");
+
+      deepStrictEqual(Object.keys(baseOperation.requestBody.content), [
+        "text/plain",
+        "application/octet-stream",
+      ]);
+    });
+  });
+
+  context("some overload all use different endpoint", () => {
+    let res: OpenAPI3Document;
+    beforeEach(async () => {
+      res = await openApiFor(
+        `
+        @route("/upload")
+        op upload(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
+        @overload(upload)
+        @route("/uploadString")
+        op uploadString(data: string, @header contentType: "text/plain" ): void;
+        @overload(upload)
+        op uploadBytes(data: bytes, @header contentType: "application/octet-stream"): void;
+      `
+      );
+    });
+
+    it("should only create an endpoint for overloads with a different route", () => {
+      strictEqual(Object.keys(res.paths).length, 2);
+      ok(res.paths["/upload"].post);
+      ok(res.paths["/uploadString"].post);
+    });
+  });
+});

--- a/packages/rest/src/http/operations.ts
+++ b/packages/rest/src/http/operations.ts
@@ -103,10 +103,11 @@ export function validateRouteUnique(diagnostics: DiagnosticCollector, operations
   const grouped = new Map<string, Map<HttpVerb, HttpOperation[]>>();
 
   for (const operation of operations) {
-    if (operation.overloading) {
+    const { verb, path } = operation;
+
+    if (operation.overloading !== undefined && isOverloadSameEndpoint(operation as any)) {
       continue;
     }
-    const { verb, path } = operation;
     let map = grouped.get(path);
     if (map === undefined) {
       map = new Map<HttpVerb, HttpOperation[]>();
@@ -137,6 +138,10 @@ export function validateRouteUnique(diagnostics: DiagnosticCollector, operations
       }
     }
   }
+}
+
+export function isOverloadSameEndpoint(overload: HttpOperation & { overloading: HttpOperation }) {
+  return overload.path === overload.overloading.path && overload.verb === overload.overloading.verb;
 }
 
 function getHttpOperationInternal(

--- a/packages/rest/src/http/operations.ts
+++ b/packages/rest/src/http/operations.ts
@@ -47,8 +47,9 @@ export function listHttpOperationsIn(
 ): [HttpOperation[], readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
   const operations = listOperationsIn(container, options?.listOptions);
+  const cache = new Map();
   const httpOperations = operations.map((x) =>
-    diagnostics.pipe(getHttpOperation(program, x, options))
+    diagnostics.pipe(getHttpOperationInternal(program, x, options, cache))
   );
   return diagnostics.wrap(httpOperations);
 }

--- a/packages/rest/src/http/parameters.ts
+++ b/packages/rest/src/http/parameters.ts
@@ -16,16 +16,25 @@ import {
   isBody,
 } from "./decorators.js";
 import { gatherMetadata, getRequestVisibility, isMetadata } from "./metadata.js";
-import { HttpOperationParameters, HttpVerb } from "./types.js";
+import { HttpOperation, HttpOperationParameters, HttpVerb } from "./types.js";
 
 export function getOperationParameters(
   program: Program,
   operation: Operation,
+  overloadBase?: HttpOperation,
   knownPathParamNames: string[] = []
 ): [HttpOperationParameters, readonly Diagnostic[]] {
   const verb = getExplicitVerbForOperation(program, operation);
   if (verb) {
     return getOperationParametersForVerb(program, operation, verb, knownPathParamNames);
+  }
+  if (overloadBase) {
+    return getOperationParametersForVerb(
+      program,
+      operation,
+      overloadBase.verb,
+      knownPathParamNames
+    );
   }
 
   // If no verb is explicitly specified, it is POST if there is a body and

--- a/packages/rest/src/http/types.ts
+++ b/packages/rest/src/http/types.ts
@@ -218,6 +218,11 @@ export interface HttpOperation {
   path: string;
 
   /**
+   * Path segments
+   */
+  pathSegments: string[];
+
+  /**
    * Route verb.
    */
   verb: HttpVerb;
@@ -241,6 +246,16 @@ export interface HttpOperation {
    * Operation type reference.
    */
   operation: Operation;
+
+  /**
+   * Overload this operation
+   */
+  overloading?: HttpOperation;
+
+  /**
+   * List of operations that overloads this one.
+   */
+  overloads?: HttpOperation[];
 }
 
 export interface RoutePath {

--- a/packages/rest/test/overloads.test.ts
+++ b/packages/rest/test/overloads.test.ts
@@ -1,0 +1,84 @@
+import { Operation } from "@cadl-lang/compiler";
+import { BasicTestRunner } from "@cadl-lang/compiler/testing";
+import { strictEqual } from "assert";
+import { getHttpOperation, listHttpOperationsIn } from "../src/http/index.js";
+import { createHttpTestRunner } from "./test-host.js";
+
+describe("rest: overloads", () => {
+  let runner: BasicTestRunner;
+
+  beforeEach(async () => {
+    runner = await createHttpTestRunner();
+  });
+
+  it("overloads inherit base overload route and verb", async () => {
+    const { uploadString, uploadBytes } = (await runner.compile(`
+      @route("/upload")
+      @put
+      op upload(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
+      @overload(upload)
+      @test op uploadString(data: string, @header contentType: "text/plain" ): void;
+      @overload(upload)
+      @test  op uploadBytes(data: bytes, @header contentType: "application/octet-stream"): void;
+    `)) as { uploadString: Operation; uploadBytes: Operation };
+
+    const [uploadStringHttp] = getHttpOperation(runner.program, uploadString);
+    const [uploadBytesHttp] = getHttpOperation(runner.program, uploadBytes);
+
+    strictEqual(uploadStringHttp.path, "/upload");
+    strictEqual(uploadStringHttp.verb, "put");
+    strictEqual(uploadBytesHttp.path, "/upload");
+    strictEqual(uploadBytesHttp.verb, "put");
+  });
+
+  it("overloads can change their route or verb", async () => {
+    const { upload, uploadString, uploadBytes } = (await runner.compile(`
+      @route("/upload")
+      @put
+      @test op upload(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
+      @overload(upload)
+      @route("/uploadString")
+      @test op uploadString(data: string, @header contentType: "text/plain" ): void;
+      @overload(upload)
+      @post
+      @test  op uploadBytes(data: bytes, @header contentType: "application/octet-stream"): void;
+    `)) as { upload: Operation; uploadString: Operation; uploadBytes: Operation };
+
+    const [uploadHttp] = getHttpOperation(runner.program, upload);
+    const [uploadStringHttp] = getHttpOperation(runner.program, uploadString);
+    const [uploadBytesHttp] = getHttpOperation(runner.program, uploadBytes);
+
+    strictEqual(uploadHttp.path, "/upload");
+    strictEqual(uploadHttp.verb, "put");
+
+    // Change to /uploadString
+    strictEqual(uploadStringHttp.path, "/uploadString");
+    strictEqual(uploadStringHttp.verb, "put");
+
+    // Changed to post
+    strictEqual(uploadBytesHttp.path, "/upload");
+    strictEqual(uploadBytesHttp.verb, "post");
+  });
+
+  it("links overloads", async () => {
+    await runner.compile(`
+      @route("/upload")
+      @put
+      op upload(data: string | bytes, @header contentType: "text/plain" | "application/octet-stream"): void;
+      @overload(upload)
+      op uploadString(data: string, @header contentType: "text/plain" ): void;
+      @overload(upload)
+      op uploadBytes(data: bytes, @header contentType: "application/octet-stream"): void;
+    `);
+
+    const [[overload, uploadString, uploadBytes]] = listHttpOperationsIn(
+      runner.program,
+      runner.program.getGlobalNamespaceType()
+    );
+
+    strictEqual(uploadString.overloading, overload);
+    strictEqual(uploadBytes.overloading, overload);
+    strictEqual(overload.overloads?.[0], uploadString);
+    strictEqual(overload.overloads?.[1], uploadBytes);
+  });
+});


### PR DESCRIPTION
fix #756
Johan already implemented the decorator but there wasn't any uses of it in http library and OpenAPI3.

Http behavior for overloads:
- overloaded operation will inherit the overload base route and verb automatically
- each overload can override the overload base route and/or verb


OpenAPI3 behavior:
- If all overloads use the same path as the base overload then openapi3 generate only a single operation using the overload base(Basically comes down to ignoring all the overloads.
- If 1 or more overload change the route or verb then they will also get their own endpoint.