### PR TITLE
Fix: Deprecated `output-path` is not being respected

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-output-path_2022-10-11-18-46.json
+++ b/common/changes/@cadl-lang/compiler/fix-output-path_2022-10-11-18-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix: Deprecated `output-path` not being respected",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/cli.ts
+++ b/packages/compiler/core/cli.ts
@@ -64,13 +64,11 @@ async function main() {
           })
           .option("output-path", {
             type: "string",
-            default: "./cadl-output",
             deprecated: "Use `output-dir` instead.",
             hidden: true,
           })
           .option("output-dir", {
             type: "string",
-            default: "./cadl-output",
             describe:
               "The output path for generated artifacts.  If it does not exist, it will be created.",
           })
@@ -336,8 +334,8 @@ function createCLICompilerHost(args: { pretty?: boolean }): CompilerHost {
 }
 
 interface CompileCliArgs {
-  "output-dir": string;
-  "output-path": string;
+  "output-dir"?: string;
+  "output-path"?: string;
   nostdlib?: boolean;
   options?: string[];
   import?: string[];
@@ -353,8 +351,7 @@ async function getCompilerOptions(
   host: CompilerHost,
   args: CompileCliArgs
 ): Promise<CompilerOptions> {
-  // Workaround for https://github.com/npm/cli/issues/3680
-  const pathArg = args["output-dir"] ?? args["output-path"];
+  const pathArg = args["output-dir"] ?? args["output-path"] ?? "./cadl-output";
   const outputPath = resolvePath(process.cwd(), pathArg);
   await mkdirp(outputPath);
 


### PR DESCRIPTION
Problem is that yargs was always setting the default for `output-dir` so it would never override with `output-path` if specifed