### PR TITLE
(Patch) Fix: Augment decorators on namespace 

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-augment-decorators-namespace_2022-10-19-17-57.json
+++ b/common/changes/@cadl-lang/compiler/fix-augment-decorators-namespace_2022-10-19-17-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Fix** augment decorators can be applied on namespace",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -2,6 +2,9 @@
 
 trigger:
   - main
+  # For patch releases
+  - release/*
+
 pr: none
 
 jobs:

--- a/eng/pipelines/pr.yml
+++ b/eng/pipelines/pr.yml
@@ -2,6 +2,7 @@ trigger:
   - main
 pr:
   - main
+  - release/*
 
 jobs:
   - job: Build_And_Test

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -397,7 +397,15 @@ export function createChecker(program: Program): Checker {
     for (const decNode of augmentDecorators) {
       const ref = resolveTypeReference(decNode.targetType, undefined);
       if (ref) {
-        if (ref.flags & SymbolFlags.LateBound) {
+        if (ref.flags & SymbolFlags.Namespace) {
+          const decApp = checkDecorator(decNode, undefined);
+          if (decApp) {
+            const links = getSymbolLinks(getMergedSymbol(ref));
+            const type: Type & DecoratedType = links.type! as any;
+            type.decorators.push(decApp);
+            applyDecoratorToType(program, decApp, type);
+          }
+        } else if (ref.flags & SymbolFlags.LateBound) {
           const decApp = checkDecorator(decNode, undefined);
           if (decApp) {
             const type: Type & DecoratedType = ref.type! as any;

--- a/packages/compiler/test/checker/augment-decorators.test.ts
+++ b/packages/compiler/test/checker/augment-decorators.test.ts
@@ -150,6 +150,8 @@ describe("compiler: checker: augment decorators", () => {
       strictEqual(customName, "FooCustom");
     }
 
+    it("namespace", () => expectTarget(`@test("target") namespace Foo {}`, "Foo"));
+
     it("model", () => expectTarget(`@test("target") model Foo {}`, "Foo"));
     it("model property", () =>
       expectTarget(


### PR DESCRIPTION
fix #1182

Making this a patch release as this is a scenario needed for the dpg demo next week.