### PR TITLE
Don't require a global install of cadl for the IDE extension to work

### DIFF
--- a/common/changes/@cadl-lang/compiler/global-cadl-not-req_2022-10-20-15-06.json
+++ b/common/changes/@cadl-lang/compiler/global-cadl-not-req_2022-10-20-15-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Added a new export to only import the module resolver",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/cadl-vs/global-cadl-not-req_2022-10-20-15-06.json
+++ b/common/changes/cadl-vs/global-cadl-not-req_2022-10-20-15-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vs",
+      "comment": "Extension lookup for a local cadl compiler first instead of a global",
+      "type": "minor"
+    }
+  ],
+  "packageName": "cadl-vs"
+}

--- a/common/changes/cadl-vscode/global-cadl-not-req_2022-10-20-15-06.json
+++ b/common/changes/cadl-vscode/global-cadl-not-req_2022-10-20-15-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "cadl-vscode",
+      "comment": "Extension lookup for a local cadl compiler first instead of a global",
+      "type": "minor"
+    }
+  ],
+  "packageName": "cadl-vscode"
+}

--- a/packages/cadl-vs/src/Exceptions.cs
+++ b/packages/cadl-vs/src/Exceptions.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Cadl.VisualStudio
         public CadlServerNotFoundException(string fileName, Exception? innerException = null)
             : base(string.Join("\n", new string[]
             {
-                $"Cadl server exectuable was not found: '{fileName}' is not found. Make sure either:",
+                $"Cadl server executable was not found: '{fileName}' is not found. Make sure either:",
+                " - cadl is installed locally at the root of this workspace.",
                 " - cadl is installed globally with `npm install -g @cadl-lang/compiler'.",
                 " - cadl server path is configured with https://github.com/microsoft/cadl/blob/main/packages/cadl-vs/README.md#configure-cadl-visual-studio-extension."
             }, innerException))

--- a/packages/cadl-vs/src/Exceptions.cs
+++ b/packages/cadl-vs/src/Exceptions.cs
@@ -27,10 +27,10 @@ namespace Microsoft.Cadl.VisualStudio
             : base(string.Join("\n", new string[]
             {
                 $"Cadl server executable was not found: '{fileName}' is not found. Make sure either:",
-                " - cadl is installed locally at the root of this workspace.",
+                " - cadl is installed locally at the root of this workspace or in a parent directory.",
                 " - cadl is installed globally with `npm install -g @cadl-lang/compiler'.",
                 " - cadl server path is configured with https://github.com/microsoft/cadl/blob/main/packages/cadl-vs/README.md#configure-cadl-visual-studio-extension."
-            }, innerException))
+            }), innerException)
         {
         }
     }

--- a/packages/cadl-vs/src/VSExtension.cs
+++ b/packages/cadl-vs/src/VSExtension.cs
@@ -254,10 +254,15 @@ namespace Microsoft.Cadl.VisualStudio
 
         private string? ResolveLocalCompiler(string baseDir)
         {
-            var potentialLocation = Path.Combine(baseDir, "node_modules/@cadl-lang/compiler");
-            if (Directory.Exists(potentialLocation))
+            var current = baseDir;
+            while (current != null)
             {
-                return potentialLocation;
+                var potentialInstallDir = Path.Combine(current, "node_modules", "@cadl-lang", "compiler");
+                if (Directory.Exists(potentialInstallDir))
+                {
+                    return potentialInstallDir;
+                }
+                current = Path.GetDirectoryName(current);
             }
             return null;
         }

--- a/packages/cadl-vs/src/VSExtension.cs
+++ b/packages/cadl-vs/src/VSExtension.cs
@@ -208,6 +208,11 @@ namespace Microsoft.Cadl.VisualStudio
             }
 
             var serverPath = _configuredCadlServerPath;
+            if ((serverPath == null || serverPath.Length == 0) && _workspaceFolder != null && _workspaceFolder.Length > 0)
+            {
+                serverPath = ResolveLocalCompiler(_workspaceFolder);
+            }
+
             if (serverPath == null || serverPath.Length == 0)
             {
                 return ("cadl-server.cmd", args, env);
@@ -245,6 +250,16 @@ namespace Microsoft.Cadl.VisualStudio
 
             env.Add("CADL_SKIP_COMPILER_RESOLVE", "1");
             return ("node.exe", $"{serverPath} {args}", env);
+        }
+
+        private string? ResolveLocalCompiler(string baseDir)
+        {
+            var potentialLocation = Path.Combine(baseDir, "node_modules/@cadl-lang/compiler");
+            if (Directory.Exists(potentialLocation))
+            {
+                return potentialLocation;
+            }
+            return null;
         }
 
         private async Task LoadSettingsAsync()

--- a/packages/cadl-vscode/src/extension.ts
+++ b/packages/cadl-vscode/src/extension.ts
@@ -1,4 +1,5 @@
-import { stat } from "fs/promises";
+import { resolveModule, ResolveModuleHost } from "@cadl-lang/compiler/module-resolver";
+import { readFile, realpath, stat } from "fs/promises";
 import { join } from "path";
 import vscode, { commands, ExtensionContext, workspace } from "vscode";
 import {
@@ -54,9 +55,12 @@ async function launchLanguageClient(context: ExtensionContext) {
     await client.start();
   } catch (e) {
     if (typeof e === "string" && e.startsWith("Launching server using command")) {
+      const workspaceFolder = workspace.workspaceFolders?.[0]?.uri?.fsPath ?? "";
+
       client?.error(
         [
           `Cadl server executable was not found: '${exe.command}' is not found. Make sure either:`,
+          ` - cadl is installed locally at the root of this workspace ("${workspaceFolder}") or in a parent directory.`,
           " - cadl is installed globally with `npm install -g @cadl-lang/compiler'.",
           " - cadl server path is configured with https://github.com/microsoft/cadl#installing-vs-code-extension.",
         ].join("\n"),
@@ -92,18 +96,21 @@ async function resolveCadlServer(context: ExtensionContext): Promise<Executable>
 
   // In production, first try VS Code configuration, which allows a global machine
   // location that is not on PATH, or a workspace-specific installation.
-  let serverPath = workspace.getConfiguration().get("cadl.cadl-server.path") as string;
+  let serverPath: string | undefined = workspace.getConfiguration().get("cadl.cadl-server.path");
   if (serverPath && typeof serverPath !== "string") {
     throw new Error("VS Code configuration option 'cadl.cadl-server.path' must be a string");
   }
+  const workspaceFolder = workspace.workspaceFolders?.[0]?.uri?.fsPath ?? "";
 
   // Default to cadl-server on PATH, which would come from `npm install -g
   // @cadl-lang/compiler` in a vanilla setup.
   if (!serverPath) {
+    serverPath = await resolveLocalCompiler(workspaceFolder);
+  }
+  if (!serverPath) {
     const executable = process.platform === "win32" ? "cadl-server.cmd" : "cadl-server";
     return { command: executable, args, options };
   }
-  const workspaceFolder = workspace.workspaceFolders?.[0]?.uri?.fsPath ?? "";
   const variableResolver = new VSCodeVariableResolver({
     workspaceFolder,
     workspaceRoot: workspaceFolder, // workspaceRoot is deprecated but we still support it for backwards compatibility.
@@ -127,6 +134,26 @@ async function resolveCadlServer(context: ExtensionContext): Promise<Executable>
 
   options.env["CADL_SKIP_COMPILER_RESOLVE"] = "1";
   return { command: "node", args: [serverPath, ...args], options };
+}
+
+async function resolveLocalCompiler(baseDir: string): Promise<string | undefined> {
+  const host: ResolveModuleHost = {
+    realpath,
+    readFile: (path: string) => readFile(path, "utf-8"),
+    stat,
+  };
+  try {
+    const executable = await resolveModule(host, "@cadl-lang/compiler", {
+      baseDir,
+    });
+    if (executable.type === "module") {
+      return executable.path;
+    }
+  } catch (e) {
+    // Couldn't find the module
+  }
+
+  return undefined;
 }
 
 async function isFile(path: string) {

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -22,13 +22,26 @@
   "cadlMain": "lib/main.cadl",
   "exports": {
     ".": "./dist/core/index.js",
-    "./testing": "./dist/testing/index.js"
+    "./testing": "./dist/testing/index.js",
+    "./module-resolver": "./dist/core/module-resolver.js"
   },
   "browser": {
     "./dist/core/node-host.js": "./dist/core/node-host.browser.js",
     "./dist/core/logger/console-sink.js": "./dist/core/logger/console-sink.browser.js"
   },
-  "types": "dist/core/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/core/index.d.ts"
+      ],
+      "testing": [
+        "./dist/testing/index.d.ts"
+      ],
+      "module-resolver": [
+        "./dist/core/module-resolver.d.ts"
+      ]
+    }
+  },
   "engines": {
     "node": ">=16.0.0"
   },

--- a/packages/samples/.vscode/settings.json
+++ b/packages/samples/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "cadl.cadl-server.path": "${workspaceFolder}/node_modules/@cadl-lang/compiler"
-}

--- a/packages/samples/.vscode/settings.json
+++ b/packages/samples/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cadl.cadl-server.path": "${workspaceFolder}/node_modules/@cadl-lang/compiler"
+  // "cadl.cadl-server.path": "${workspaceFolder}/node_modules/@cadl-lang/compiler"
 }

--- a/packages/samples/.vscode/settings.json
+++ b/packages/samples/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  // "cadl.cadl-server.path": "${workspaceFolder}/node_modules/@cadl-lang/compiler"
+  "cadl.cadl-server.path": "${workspaceFolder}/node_modules/@cadl-lang/compiler"
 }

--- a/packages/samples/use-versioned-lib/main.cadl
+++ b/packages/samples/use-versioned-lib/main.cadl
@@ -13,8 +13,3 @@ namespace VersionedApi;
 using Cadl.Http;
 
 op read(): Library.PetToy;
-
-
-model Broken {
-  type: str
-}

--- a/packages/samples/use-versioned-lib/main.cadl
+++ b/packages/samples/use-versioned-lib/main.cadl
@@ -13,3 +13,8 @@ namespace VersionedApi;
 using Cadl.Http;
 
 op read(): Library.PetToy;
+
+
+model Broken {
+  type: str
+}


### PR DESCRIPTION
fix #1116

Vscode extension calls out to resolveModule to get a better result(lookup in parent dir)
VS is more basic and only lookup in `./node_modules/@cadl-lang/compiler`