### PR TITLE
Fix crash when referencing `global` in augment decorator

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-global-ref-crash_2022-10-21-22-45.json
+++ b/common/changes/@cadl-lang/compiler/fix-global-ref-crash_2022-10-21-22-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix: crash with referencing global namespace",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -2909,7 +2909,7 @@ export function createChecker(program: Program): Checker {
   }
 
   function createGlobalNamespaceType(): Namespace {
-    return createAndFinishType({
+    const type = createAndFinishType({
       kind: "Namespace",
       name: "",
       node: globalNamespaceNode,
@@ -2921,6 +2921,8 @@ export function createChecker(program: Program): Checker {
       enums: new Map(),
       decorators: [],
     });
+    getSymbolLinks(globalNamespaceNode.symbol).type = type;
+    return type;
   }
 
   /**

--- a/packages/compiler/test/checker/augment-decorators.test.ts
+++ b/packages/compiler/test/checker/augment-decorators.test.ts
@@ -152,6 +152,8 @@ describe("compiler: checker: augment decorators", () => {
 
     it("namespace", () => expectTarget(`@test("target") namespace Foo {}`, "Foo"));
 
+    it("global namespace", () => expectTarget(`@@test(global, "target")`, "global"));
+
     it("model", () => expectTarget(`@test("target") model Foo {}`, "Foo"));
     it("model property", () =>
       expectTarget(


### PR DESCRIPTION
doesn't actrually resolve the `@service(global, {title})` not working as this is its own seperate issue with how `@service` works but I think that might just get resolved when we allow multi service anyway.