### PR TITLE
Fix duplicate key check

### DIFF
--- a/common/changes/@cadl-lang/rest/fix-dup-key-check_2022-10-24-19-18.json
+++ b/common/changes/@cadl-lang/rest/fix-dup-key-check_2022-10-24-19-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Fix: Issue with duplicate key in spread models",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/packages/rest/src/validate.ts
+++ b/packages/rest/src/validate.ts
@@ -14,6 +14,9 @@ function checkForDuplicateResourceKeyNames(program: Program) {
   const seenTypes = new Set<string>();
 
   function checkResourceModelKeys(model: Model) {
+    if (model.name === "") {
+      return;
+    }
     let currentType: Model | undefined = model;
     const keyProperties = new DuplicateTracker<string, ResourceKey>();
     while (currentType) {

--- a/packages/rest/test/resource.test.ts
+++ b/packages/rest/test/resource.test.ts
@@ -185,6 +185,27 @@ describe("rest: resources", () => {
     ]);
   });
 
+  it("resources: emit diagnostic if using 2 @key on the same model", async () => {
+    const [_, diagnostics] = await compileOperations(`
+      using Cadl.Rest.Resource;
+
+      model Thing {
+        @key("thingId")
+        id: string;
+
+        @key("anotherId")
+        secondId: string;
+      }
+      `);
+
+    expectDiagnostics(diagnostics, [
+      {
+        code: "@cadl-lang/rest/duplicate-key",
+        message: `More than one key found on model type Thing`,
+      },
+    ]);
+  });
+
   it("resources: resources with parents must not have duplicate their parents' key names", async () => {
     const [_, diagnostics] = await compileOperations(`
       using Cadl.Rest.Resource;


### PR DESCRIPTION
This is a workaround that resolve a problem of using intersection of the resource type and keysof the resource.

This is blocking the merge into cad-azure/