### PR TITLE
Skip playground UI tests on windows

### DIFF
--- a/packages/playground/e2e/ui.e2e.ts
+++ b/packages/playground/e2e/ui.e2e.ts
@@ -2,7 +2,6 @@ import { expect, test } from "@playwright/test";
 
 const host = `http://localhost:3000`;
 const ctrlOrCmd = process.platform === "darwin" ? "Meta" : "Control";
-const onWindows = process.platform === "win32";
 
 test.describe("playground UI tests", () => {
   test.skip(process.platform === "win32", "https://github.com/microsoft/cadl/issues/1223");

--- a/packages/playground/e2e/ui.e2e.ts
+++ b/packages/playground/e2e/ui.e2e.ts
@@ -2,32 +2,37 @@ import { expect, test } from "@playwright/test";
 
 const host = `http://localhost:3000`;
 const ctrlOrCmd = process.platform === "darwin" ? "Meta" : "Control";
+const onWindows = process.platform === "win32";
 
-test("compiled http sample", async ({ page }) => {
-  await page.goto(host);
-  const samplesDropDown = page.locator("select.sample-dropdown");
-  await samplesDropDown.selectOption({ label: "Http service" });
-  const outputContainer = page.locator(".output-content");
-  await expect(outputContainer).toContainText(`"title": "Widget Service"`);
-});
+test.describe("playground UI tests", () => {
+  test.skip(process.platform === "win32", "https://github.com/microsoft/cadl/issues/1223");
 
-test("shared link works", async ({ page }) => {
-  // Pass code "op sharedCode(): string;"
-  // cspell:disable-next-line
-  await page.goto(`${host}/?c=b3Agc2hhcmVkQ29kZSgpOiBzdHJpbmc7`);
-  const outputContainer = page.locator(".output-content");
-  await expect(outputContainer).toContainText(`"operationId": "sharedCode"`);
-});
+  test("compiled http sample", async ({ page }) => {
+    await page.goto(host);
+    const samplesDropDown = page.locator("select.sample-dropdown");
+    await samplesDropDown.selectOption({ label: "Http service" });
+    const outputContainer = page.locator(".output-content");
+    await expect(outputContainer).toContainText(`"title": "Widget Service"`);
+  });
 
-test("save code with ctrl/cmd+S", async ({ page }) => {
-  await page.goto(host);
-  const cadlEditorContainer = page.locator("_react=CadlEditor");
-  await cadlEditorContainer.click();
-  await cadlEditorContainer.type("op sharedCode(): string;");
-  await Promise.all([
-    // It is important to call waitForNavigation before click to set up waiting.
+  test("shared link works", async ({ page }) => {
+    // Pass code "op sharedCode(): string;"
     // cspell:disable-next-line
-    page.waitForNavigation({ url: `${host}/?c=b3Agc2hhcmVkQ29kZSgpOiBzdHJpbmc7` }),
-    page.keyboard.press(`${ctrlOrCmd}+KeyS`),
-  ]);
+    await page.goto(`${host}/?c=b3Agc2hhcmVkQ29kZSgpOiBzdHJpbmc7`);
+    const outputContainer = page.locator(".output-content");
+    await expect(outputContainer).toContainText(`"operationId": "sharedCode"`);
+  });
+
+  test("save code with ctrl/cmd+S", async ({ page }) => {
+    await page.goto(host);
+    const cadlEditorContainer = page.locator("_react=CadlEditor");
+    await cadlEditorContainer.click();
+    await cadlEditorContainer.type("op sharedCode(): string;");
+    await Promise.all([
+      // It is important to call waitForNavigation before click to set up waiting.
+      // cspell:disable-next-line
+      page.waitForNavigation({ url: `${host}/?c=b3Agc2hhcmVkQ29kZSgpOiBzdHJpbmc7` }),
+      page.keyboard.press(`${ctrlOrCmd}+KeyS`),
+    ]);
+  });
 });


### PR DESCRIPTION
Disable playground UI tests on Windows as the flakiness persists. #1223 tracks fixing this or deciding it's OK for this to be permanent.