### PR TITLE
Make `emitFile` ensure the folders exists prior to writing to path

### DIFF
--- a/common/changes/@cadl-lang/compiler/fixEmitFile_2022-10-25-20-15.json
+++ b/common/changes/@cadl-lang/compiler/fixEmitFile_2022-10-25-20-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "`emitFile` now ensures that the folder exists prior to writing to the path.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/emitter-utils.ts
+++ b/packages/compiler/core/emitter-utils.ts
@@ -1,4 +1,6 @@
 import { Program } from "./program.js";
+import path from "path";
+import mkdirp from "mkdirp";
 
 export type NewLine = "lf" | "crlf";
 export interface EmitFileOptions {
@@ -13,6 +15,13 @@ export interface EmitFileOptions {
  * @param options File Emitter options
  */
 export async function emitFile(program: Program, options: EmitFileOptions): Promise<void> {
+  // ensure path exists
+  const outputFolder = path.dirname(options.path);
+  try {
+    await mkdirp(outputFolder);
+  } catch {
+    // mkdirp fails during tests
+  }
   const content =
     options.newLine && options.newLine === "crlf"
       ? options.content.replace(/(\r\n|\n|\r)/gm, "\r\n")

--- a/packages/compiler/core/emitter-utils.ts
+++ b/packages/compiler/core/emitter-utils.ts
@@ -17,11 +17,7 @@ export interface EmitFileOptions {
 export async function emitFile(program: Program, options: EmitFileOptions): Promise<void> {
   // ensure path exists
   const outputFolder = path.dirname(options.path);
-  try {
-    await mkdirp(outputFolder);
-  } catch {
-    // mkdirp fails during tests
-  }
+  await program.host.mkdirp(outputFolder);
   const content =
     options.newLine && options.newLine === "crlf"
       ? options.content.replace(/(\r\n|\n|\r)/gm, "\r\n")

--- a/packages/compiler/core/emitter-utils.ts
+++ b/packages/compiler/core/emitter-utils.ts
@@ -1,6 +1,5 @@
+import { getDirectoryPath } from "./path-utils.js";
 import { Program } from "./program.js";
-import path from "path";
-import mkdirp from "mkdirp";
 
 export type NewLine = "lf" | "crlf";
 export interface EmitFileOptions {
@@ -16,7 +15,7 @@ export interface EmitFileOptions {
  */
 export async function emitFile(program: Program, options: EmitFileOptions): Promise<void> {
   // ensure path exists
-  const outputFolder = path.dirname(options.path);
+  const outputFolder = getDirectoryPath(options.path);
   await program.host.mkdirp(outputFolder);
   const content =
     options.newLine && options.newLine === "crlf"


### PR DESCRIPTION
Fixes #1178.

This is just a port of what I did in Cadl APIView.