### PR TITLE
Export `findStatementsIn` method

### DIFF
--- a/common/changes/@cadl-lang/compiler/ExportAstUtils_2022-10-26-21-38.json
+++ b/common/changes/@cadl-lang/compiler/ExportAstUtils_2022-10-26-21-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix issues where `findStatementsIn` was not exported.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/helpers/index.ts
+++ b/packages/compiler/core/helpers/index.ts
@@ -1,3 +1,4 @@
+export * from "./ast-utils.js";
 export { DiscriminatedUnion, getDiscriminatedUnion } from "./discriminator-utils.js";
 export * from "./operation-utils.js";
 export * from "./projected-names-utils.js";


### PR DESCRIPTION
PR #1085 added the `findStatementsIn` method, but it was not exported and thus is not importable. This PR makes this API consumable.