### PR TITLE
Improve shared code so cadl-autorest can implement metadata features

### DIFF
--- a/common/changes/@cadl-lang/openapi3/oa2-metadata_2022-10-31-19-51.json
+++ b/common/changes/@cadl-lang/openapi3/oa2-metadata_2022-10-31-19-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/oa2-metadata_2022-10-31-19-51.json
+++ b/common/changes/@cadl-lang/rest/oa2-metadata_2022-10-31-19-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Add MetadataInfo.getEffectivePayloadType helper",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/common/changes/@cadl-lang/rest/oa2-metadata_2022-10-31-19-52.json
+++ b/common/changes/@cadl-lang/rest/oa2-metadata_2022-10-31-19-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Deprecate write visibility",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -62,7 +62,7 @@ words:
   - xplat
   - segmentof
   - createsorreplacesresource
-  - createsorudatesresource
+  - createsorupdatesresource
 ignorePaths:
   - "**/node_modules/**"
   - "**/dist/**"

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -60,6 +60,9 @@ words:
   - vswhere
   - westus
   - xplat
+  - segmentof
+  - createsorreplacesresource
+  - createsorudatesresource
 ignorePaths:
   - "**/node_modules/**"
   - "**/dist/**"

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -10,7 +10,6 @@ import {
   getDiscriminatedUnion,
   getDiscriminator,
   getDoc,
-  getEffectiveModelType,
   getFormat,
   getIntrinsicModelName,
   getKnownValues,
@@ -573,7 +572,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
       return resolveProperty(type, visibility);
     }
 
-    type = getEffectiveSchemaType(type, visibility);
+    type = metadataInfo.getEffectivePayloadType(type, visibility);
 
     const name = getTypeName(program, type, typeNameOptions);
     if (shouldInline(program, type)) {
@@ -617,22 +616,6 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
     const schema = getSchemaForType(type, visibility);
     inProgressInlineTypes.delete(type);
     return schema;
-  }
-
-  /**
-   * If type is an anonymous model, tries to find a named model that has the same
-   * set of properties when non-schema properties are excluded.
-   */
-  function getEffectiveSchemaType(type: Type, visibility: Visibility): Type {
-    if (type.kind === "Model" && !type.name) {
-      const effective = getEffectiveModelType(program, type, (p) =>
-        metadataInfo.isPayloadProperty(p, visibility)
-      );
-      if (effective.name) {
-        return effective;
-      }
-    }
-    return type;
   }
 
   function getParamPlaceholder(property: ModelProperty) {

--- a/packages/rest/lib/http-decorators.cadl
+++ b/packages/rest/lib/http-decorators.cadl
@@ -18,3 +18,5 @@ extern dec head(target: Operation);
 extern dec server(target: Namespace, url: string, description: string, parameters?: object);
 
 extern dec useAuth(target: Namespace, auth: object | Union | object[]);
+
+extern dec includeInapplicableMetadataInPayload(target: unknown, value: boolean);

--- a/packages/rest/src/http/decorators.ts
+++ b/packages/rest/src/http/decorators.ts
@@ -580,3 +580,61 @@ export function getRoutePath(
 ): RoutePath | undefined {
   return program.stateMap(routesKey).get(entity);
 }
+
+const includeInapplicableMetadataInPayloadKey = createStateSymbol(
+  "includeInapplicableMetadataInPayload"
+);
+
+/**
+ * Specifies if inapplicable metadata should be included in the payload for
+ * the given entity. This is true by default unless changed by this
+ * decorator.
+ *
+ * @param entity Target model, namespace, or model property. If applied to a
+ *               model or namespace, applies recursively to child models,
+ *               namespaces, and model properties unless overridden by
+ *               applying this decorator to a child.
+ *
+ * @param value `true` to include inapplicable metadata in payload, false to
+ *               exclude it.
+ *
+ * @see isApplicableMetadata
+ */
+export function $includeInapplicableMetadataInPayload(
+  context: DecoratorContext,
+  entity: Type,
+  value: boolean
+) {
+  if (
+    !validateDecoratorTarget(context, entity, "@includeInapplicableMetadataInPayload", [
+      "Namespace",
+      "Model",
+      "ModelProperty",
+    ])
+  ) {
+    return;
+  }
+  const state = context.program.stateMap(includeInapplicableMetadataInPayloadKey);
+  state.set(entity, value);
+}
+
+/**
+ * Determines if the given model property should be included in the payload if it is
+ * inapplicable metadata.
+ *
+ * @see isApplicableMetadata
+ * @see $includeInapplicableMetadataInPayload
+ */
+export function includeInapplicableMetadataInPayload(
+  program: Program,
+  property: ModelProperty
+): boolean {
+  let e: ModelProperty | Namespace | Model | undefined;
+  for (e = property; e; e = e.kind === "ModelProperty" ? e.model : e.namespace) {
+    const value = program.stateMap(includeInapplicableMetadataInPayloadKey).get(e);
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  return true;
+}

--- a/packages/rest/src/http/metadata.ts
+++ b/packages/rest/src/http/metadata.ts
@@ -1,6 +1,7 @@
 import {
   compilerAssert,
   DiagnosticCollector,
+  getEffectiveModelType,
   isVisible as isVisibleCore,
   Model,
   ModelProperty,
@@ -11,7 +12,14 @@ import {
   Union,
   walkPropertiesInherited,
 } from "@cadl-lang/compiler";
-import { isBody, isHeader, isPathParam, isQueryParam, isStatusCode } from "./decorators.js";
+import {
+  includeInapplicableMetadataInPayload,
+  isBody,
+  isHeader,
+  isPathParam,
+  isQueryParam,
+  isStatusCode,
+} from "./decorators.js";
 import { HttpVerb } from "./types.js";
 
 /**
@@ -292,6 +300,12 @@ export interface MetadataInfo {
    * filtered out by the given visibility.
    */
   isPayloadProperty(property: ModelProperty, visibility: Visibility): boolean;
+
+  /**
+   * If type is an anonymous model, tries to find a named model that has the
+   * same set of properties when non-payload properties are excluded.
+   */
+  getEffectivePayloadType(type: Type, visibility: Visibility): Type;
 }
 
 export interface MetadataInfoOptions {
@@ -321,6 +335,7 @@ export function createMetadataInfo(program: Program, options?: MetadataInfoOptio
     isEmptied,
     isTransformed,
     isPayloadProperty,
+    getEffectivePayloadType,
   };
 
   function isEmptied(type: Type | undefined, visibility: Visibility): boolean {
@@ -408,7 +423,7 @@ export function createMetadataInfo(program: Program, options?: MetadataInfoOptio
       return false;
     }
     for (const property of model.properties.values()) {
-      if (isPayloadProperty(property, visibility)) {
+      if (isPayloadProperty(property, visibility, /* keep shared */ true)) {
         return false;
       }
     }
@@ -421,8 +436,9 @@ export function createMetadataInfo(program: Program, options?: MetadataInfoOptio
     keepShareableProperties?: boolean
   ): boolean {
     if (
+      isEmptied(property.type, visibility) ||
       isApplicableMetadata(program, property, visibility) ||
-      isEmptied(property.type, visibility)
+      (isMetadata(program, property) && !includeInapplicableMetadataInPayload(program, property))
     ) {
       return false;
     }
@@ -442,5 +458,21 @@ export function createMetadataInfo(program: Program, options?: MetadataInfoOptio
     }
 
     return true;
+  }
+
+  /**
+   * If the type is an anonymous model, tries to find a named model that has the same
+   * set of properties when non-payload properties are excluded.
+   */
+  function getEffectivePayloadType(type: Type, visibility: Visibility): Type {
+    if (type.kind === "Model" && !type.name) {
+      const effective = getEffectiveModelType(program, type, (p) =>
+        isPayloadProperty(p, visibility)
+      );
+      if (effective.name) {
+        return effective;
+      }
+    }
+    return type;
   }
 }

--- a/packages/rest/src/lib.ts
+++ b/packages/rest/src/lib.ts
@@ -132,18 +132,22 @@ const libDefinition = {
           "Current spec is not exposing any routes. This could be to not having the service namespace marked with @serviceTitle.",
       },
     },
-
     "invalid-type-for-auth": {
       severity: "error",
       messages: {
         default: paramMessage`@useAuth ${"kind"} only accept Auth model, Tuple of auth model or union of auth model.`,
       },
     },
-
     "shared-boolean": {
       severity: "error",
       messages: {
         default: "shared parameter must be a boolean.",
+      },
+    },
+    "write-visibility-not-supported": {
+      severity: "warning",
+      messages: {
+        default: `@visibility("write") is not supported. Use @visibility("update"), @visibility("create") or @visibility("create", "update") as appropriate.`,
       },
     },
   },

--- a/packages/rest/test/http-decorators.test.ts
+++ b/packages/rest/test/http-decorators.test.ts
@@ -606,7 +606,7 @@ describe("rest: http decorators", () => {
     });
   });
 
-  describe("@visiblity", () => {
+  describe("@visibility", () => {
     it("warns on unsupported write visibility", async () => {
       const diagnostics = await runner.diagnose(`
         @test model M {

--- a/packages/rest/test/rest-decorators.test.ts
+++ b/packages/rest/test/rest-decorators.test.ts
@@ -4,7 +4,7 @@ import { ok, strictEqual } from "assert";
 import { getResourceLocationType } from "../src/rest.js";
 import { createRestTestRunner } from "./test-host.js";
 
-describe("rest: http decorators", () => {
+describe("rest: rest decorators", () => {
   let runner: BasicTestRunner;
 
   beforeEach(async () => {

--- a/packages/website/src/docs/standard-library/built-in-decorators.md
+++ b/packages/website/src/docs/standard-library/built-in-decorators.md
@@ -389,7 +389,7 @@ model Dog {
   // the service will generate an ID, so you don't need to send it.
   @visibility("read") id: int32;
   // the service will store this secret name, but won't ever return it
-  @visibility("write") secretName: string;
+  @visibility("create") secretName: string;
   // no flags are like specifying all flags at once, so in this case
   // equivalent to @visibility("read", "write")
   name: string;
@@ -403,13 +403,13 @@ model ReadDog {
   ...Dog;
 }
 
-@withVisibility("write")
-model WriteDog {
+@withVisibility("create")
+model CreateDog {
   ...Dog;
 }
 ```
 
-Note that the OpenAPI v3 emitter applies visibility automatically without needing explicit `@withVisibility`. See [metadata]({%doc "http/operations"%}#metadata) for more information.
+Note that the OpenAPI v3 emitter applies visibility automatically without needing explicit `@withVisibility`. See [automatic visibility]({%doc "http/operations"%}#automatic-visibility) for more information.
 
 ## Advanced decorators
 

--- a/packages/website/src/docs/standard-library/rest/decorators.md
+++ b/packages/website/src/docs/standard-library/rest/decorators.md
@@ -37,7 +37,7 @@ title: Decorators
     - [@readsResource](#readsresource)
     - [@createsResource](#createsresource)
     - [@createsOrReplacesResource](#createsorreplacesresource)
-    - [@createsOrUpdatesResource](#createsorudatesresource)
+    - [@createsOrUpdatesResource](#createsorupdatesresource)
     - [@updatesResource](#updatesresource)
     - [@deletesResource](#deletesresource)
     - [@listsResource](#listsresource)

--- a/packages/website/src/docs/standard-library/rest/decorators.md
+++ b/packages/website/src/docs/standard-library/rest/decorators.md
@@ -19,26 +19,28 @@ title: Decorators
     - [@query](#query)
     - [@path](#path)
     - [@body](#body)
-    - [@statusCode](#statusCode)
+    - [@statusCode](#statuscode)
   - [Service decorators](#service-decorators)
     - [@server](#server)
-    - [@useAuth](#useAuth)
+    - [@useAuth](#useauth)
+  - [Metadata decorators](#metadata-decorators)
+    - [@includeInapplicableMetadataInPayload](#includeinapplicablemetadatainpayload)
 
 - [Rest decorators](#rest-decorators) (`Cadl.Rest` namespace)
   - [Routing](#rest-routing)
     - [@autoRoute](#autoroute)
     - [@segment](#segment)
-    - [@segmentOf](#segmentOf)
-    - [@segmentSeperator](#segmentseparator)
+    - [@segmentOf](#segmentof)
+    - [@segmentSeparator](#segmentseparator)
   - [Resource](#resource-decorators)
     - [@resource](#resource)
     - [@readsResource](#readsresource)
     - [@createsResource](#createsresource)
-    - [@createsOrReplacesResource](#createsOrReplacesResource)
-    - [@createsOrUpdatesResource](#createsOrUpdatesResource)
-    - [@updatesResource](#updatesResource)
-    - [@deletesResource](#deletesResource)
-    - [@listsResource](#listsResource)
+    - [@createsOrReplacesResource](#createsorreplacesresource)
+    - [@createsOrUpdatesResource](#createsorudatesresource)
+    - [@updatesResource](#updatesresource)
+    - [@deletesResource](#deletesresource)
+    - [@listsResource](#listsresource)
 
 ## Http decorators
 
@@ -191,7 +193,16 @@ Specify the authentication for the service.
 namespace PetStore;
 ```
 
-To see more information on how to define authentication see [authentication docs]({%doc "http/authentication"%})
+### Metadata decorators
+
+#### `@includeInapplicableMetadataInPayload`
+
+Specify if inapplicable [metadata]({%doc "http/operations"%}#metadata) should be included in the payload for the given entity.
+
+This is true by default unless changed by this decorator.
+
+Can be applied to namespaces, models, and model properties. If applied to a model or namespace, applies recursively to child models,
+namespaces, and model properties unless overridden by applying this decorator to a child.
 
 ## Rest decorators
 

--- a/packages/website/src/docs/standard-library/rest/operations.md
+++ b/packages/website/src/docs/standard-library/rest/operations.md
@@ -285,7 +285,7 @@ namespace Pets {
 }
 ```
 
-### Automatic visibility
+## Automatic visibility
 
 The `@cadl-lang/rest` library understands the following well-known [visibilities]({%doc "built-in-decorators"%}#visibility-decorators) and provides functionality for emitters to apply them based on whether on request vs. response and HTTP method usage as detailed in the table below. Currently, only the `@cadl-lang/openapi3` emitter uses this, but it is expected that other REST-based emitters will do so as well in the near future.
 
@@ -316,7 +316,9 @@ interface Users {
 
 There is a single logical user entity represented by the single Cadl type `User`, but the HTTP payload for this entity varies based on context. When returned in a response, the `id` property is included, but when sent in a request, it is not. Similarly, the `password` property is only included in create requests, but not present in responses.
 
-The OpenAPI v3 emitter will apply these visibilities automatically, without explicit use of `@withVisibility`, and it will generate separate schemas as necessary. However, another emitter such as one generating client code can see and preserve a single logical type and deal with these HTTP payload differences by means other than type proliferation.
+The OpenAPI v3 emitter will apply these visibilities automatically, without explicit use of `@withVisibility`, and it will generate separate schemas suffixed by visibility when necessary. `@visibility("read")` can be expressed in OpenAPI without generating additional schema by specifying `readOnly: true` and the OpenAPI v3 emitter will leverage this a an optimization, but other visibilities will generate additional schemas. For example, `@visibility("create")` applied to a model property of a type named Widget will generate a WidgetCreate schema.
+
+Another emitter such as one generating client code can see and preserve a single logical type and deal with these HTTP payload differences by means other than type proliferation.
 
 Modeling with logical entities rather than HTTP-specific shapes also keeps the Cadl spec decoupled from HTTP and REST and can allow the same spec to be used with multiple protocols.
 
@@ -335,7 +337,7 @@ Metadata is determined to be applicable or inapplicable based on the context tha
 
 Additionally metadata that appears in an array element type always inapplicable.
 
-When metadata is deemed "inapplicable", for example, if a `@path` property is seen in a response, it becomes part of the payload instead.
+When metadata is deemed "inapplicable", for example, if a `@path` property is seen in a response, it becomes part of the payload instead unless the [@includeInapplicableMetadataInPayload][metadata]({%doc "http/decorators"%}#includeinapplicablemetadatainpayload) decorator is used and given a value of `false`.
 
 The handling of metadata applicability furthers the goal of keeping a single logical model in Cadl. For example, this defines a logical `User` entity that has a name, ID and password, but further annotates that the ID is sent in the HTTP path and the HTTP body in responses. Also, using automatically visibility as before, we further indicate that the password is only present in create requests.
 


### PR DESCRIPTION
* Move emitter-specifric getEffectiveType to MetadataInfo for reuse
* Deprecate "write" visibility due to inconsistency in its interpretation
* Add decorator to allow opting out of inapplicable metadata -> payload
* Add more documentation and fix some broken doc links

Contributes to #1070 