### PR TITLE
Add tracing for JS decorator loading

### DIFF
--- a/common/changes/@cadl-lang/compiler/log-dec-loading_2022-11-09-22-19.json
+++ b/common/changes/@cadl-lang/compiler/log-dec-loading_2022-11-09-22-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Debugging: adding tracing information for JS decorators and function binding",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/binder.ts
+++ b/packages/compiler/core/binder.ts
@@ -107,6 +107,8 @@ export function createBinder(program: Program): Binder {
     if ((sourceFile.symbol as any) !== undefined) {
       return;
     }
+    const tracer = program.tracer.sub("bind.js");
+
     fileNamespace = undefined;
     mutate(sourceFile).symbol = createSymbol(
       sourceFile,
@@ -171,6 +173,10 @@ export function createBinder(program: Program): Binder {
         }
         let sym;
         if (kind === "decorator") {
+          tracer.trace(
+            "decorator",
+            `Bind decorator "@${name}" in namespace "${nsParts.join(".")}".`
+          );
           sym = createSymbol(
             sourceFile,
             "@" + name,
@@ -178,6 +184,7 @@ export function createBinder(program: Program): Binder {
             containerSymbol
           );
         } else {
+          tracer.trace("function", `Bind function "${name}" in namespace "${nsParts.join(".")}".`);
           sym = createSymbol(
             sourceFile,
             name,

--- a/packages/compiler/core/binder.ts
+++ b/packages/compiler/core/binder.ts
@@ -175,7 +175,7 @@ export function createBinder(program: Program): Binder {
         if (kind === "decorator") {
           tracer.trace(
             "decorator",
-            `Bind decorator "@${name}" in namespace "${nsParts.join(".")}".`
+            `Bound decorator "@${name}" in namespace "${nsParts.join(".")}".`
           );
           sym = createSymbol(
             sourceFile,
@@ -184,7 +184,7 @@ export function createBinder(program: Program): Binder {
             containerSymbol
           );
         } else {
-          tracer.trace("function", `Bind function "${name}" in namespace "${nsParts.join(".")}".`);
+          tracer.trace("function", `Bound function "${name}" in namespace "${nsParts.join(".")}".`);
           sym = createSymbol(
             sourceFile,
             name,

--- a/packages/compiler/test/binder.test.ts
+++ b/packages/compiler/test/binder.test.ts
@@ -1,6 +1,8 @@
 import { ok, strictEqual } from "assert";
 import { Binder, createBinder } from "../core/binder.js";
 import { createSourceFile } from "../core/diagnostics.js";
+import { createLogger } from "../core/logger/logger.js";
+import { createTracer } from "../core/logger/tracer.js";
 import { parse } from "../core/parser.js";
 import { Program } from "../core/program.js";
 import {
@@ -482,6 +484,7 @@ function assertBindings(path: string, table: SymbolTable, descriptor: BindTest, 
 
 function createProgramShim(): Program {
   return {
+    tracer: createTracer(createLogger({ sink: { log: () => {} } })),
     reportDuplicateSymbols() {},
     onValidate() {},
   } as any;

--- a/packages/website/src/docs/extending-cadl/create-decorators.md
+++ b/packages/website/src/docs/extending-cadl/create-decorators.md
@@ -173,3 +173,14 @@ export function $customName(context: DecoratorContext, name: string) {}
 export function $tableName(context: DecoratorContext, name: string) {}
 setCadlNamespace("MyLib", $tableName);
 ```
+
+## Troubleshooting
+
+### Extern declation must have an implementation in JS file
+
+Potential issues:
+
+- JS function is not prefixed with `$`. For a decorator called `@decorate` the JS function must be called `$decoratate`
+- JS function is not in the same namespace as the the `extern dec`
+
+You can use `--trace bind.js.decorator` to log debug information about decorator loading in JS file that should help pinning down which of those is the issue.

--- a/packages/website/src/docs/extending-cadl/create-decorators.md
+++ b/packages/website/src/docs/extending-cadl/create-decorators.md
@@ -182,5 +182,6 @@ Potential issues:
 
 - JS function is not prefixed with `$`. For a decorator called `@decorate` the JS function must be called `$decoratate`
 - JS function is not in the same namespace as the the `extern dec`
+- Error is only showing in the IDE? Restart the Cadl server or the IDE.
 
 You can use `--trace bind.js.decorator` to log debug information about decorator loading in JS file that should help pinning down which of those is the issue.

--- a/packages/website/src/docs/introduction/configuration/tracing.md
+++ b/packages/website/src/docs/introduction/configuration/tracing.md
@@ -63,6 +63,7 @@ This is a list of the trace area used in the compiler
 | --------------------------- | -------------------------------------------------------------------- |
 | `import-resolution.library` | Information related to the resolution of import libraries            |
 | `projection.log`            | Debug information logged by the `log()` function used in projections |
+| `bind.js`                   | Information when binding JS files                                    |
 
 ## Tracing in Cadl library
 


### PR DESCRIPTION
The connecting of decorator declaration and implementation can be a bit tricky to debug right now. Adding a new trace that should help figuring out problems on where JS decorators are declared.