### PR TITLE
Include @key properties when gathering metadata fields

### DIFF
--- a/packages/rest/src/http/metadata.ts
+++ b/packages/rest/src/http/metadata.ts
@@ -2,6 +2,7 @@ import {
   compilerAssert,
   DiagnosticCollector,
   getEffectiveModelType,
+  isKey,
   isVisible as isVisibleCore,
   Model,
   ModelProperty,
@@ -154,7 +155,7 @@ export function gatherMetadata(
     visited.add(model);
 
     for (const property of walkPropertiesInherited(model)) {
-      if (!isVisible(program, property, visibility)) {
+      if (!isKey(program, property) && !isVisible(program, property, visibility)) {
         continue;
       }
 
@@ -245,6 +246,10 @@ function isApplicableMetadataCore(
   treatBodyAsMetadata: boolean,
   isMetadataCallback: (program: Program, property: ModelProperty) => boolean
 ) {
+  if (isKey(program, property)) {
+    return true;
+  }
+
   if (visibility & Visibility.Item) {
     return false; // no metadata is applicable to collection items
   }

--- a/packages/rest/src/http/parameters.ts
+++ b/packages/rest/src/http/parameters.ts
@@ -2,6 +2,8 @@ import {
   createDiagnosticCollector,
   Diagnostic,
   filterModelProperties,
+  getKeyName,
+  isKey,
   ModelProperty,
   Operation,
   Program,
@@ -60,12 +62,12 @@ function getOperationParametersForVerb(
     diagnostics,
     operation.parameters,
     visibility,
-    (_, param) => isMetadata(program, param) || isImplicitPathParam(param)
+    (_, param) => isMetadata(program, param) || isImplicitPathParam(program, param)
   );
 
-  function isImplicitPathParam(param: ModelProperty) {
+  function isImplicitPathParam(program: Program, param: ModelProperty) {
     const isTopLevel = param.model === operation.parameters;
-    return isTopLevel && knownPathParamNames.includes(param.name);
+    return isKey(program, param) || (isTopLevel && knownPathParamNames.includes(param.name));
   }
 
   const result: HttpOperationParameters = {
@@ -76,7 +78,8 @@ function getOperationParametersForVerb(
   for (const param of metadata) {
     const queryParam = getQueryParamName(program, param);
     const pathParam =
-      getPathParamName(program, param) ?? (isImplicitPathParam(param) && param.name);
+      getPathParamName(program, param) ??
+      (isImplicitPathParam(program, param) && (getKeyName(program, param) ?? param.name));
     const headerParam = getHeaderFieldName(program, param);
     const bodyParam = isBody(program, param);
 

--- a/packages/rest/src/http/route.ts
+++ b/packages/rest/src/http/route.ts
@@ -66,7 +66,7 @@ function generatePathFromParameters(
 ) {
   const filteredParameters: HttpOperationParameter[] = [];
   for (const httpParam of parameters.parameters) {
-    const { type, param } = httpParam;
+    const { type, name, param } = httpParam;
     if (type === "path") {
       addSegmentFragment(program, param, pathFragments);
 
@@ -84,7 +84,7 @@ function generatePathFromParameters(
           pathFragments.push(`/${param.type.value}`);
           continue; // Skip adding to the parameter list
         } else {
-          pathFragments.push(`/{${param.name}}`);
+          pathFragments.push(`/{${name}}`);
         }
       }
     }


### PR DESCRIPTION
This PR makes it possible for resource model types in `Azure.Core` (and potentially `Azure.ResourceManager`) to be passed directly into operation signatures without using a wrapper type like `ItemKeysOf<TResource>` to convert the property marked `@key` into a `@path` parameter.  

Ultimately what it does is allow the `@key` property to be included with metadata properties so that it can be identified and used as an implicit `@path` parameter when being processed by the `route` logic.  I'm not sure that this is the best way to accomplish it, so let me know if there's a more appropriate way!

After we decide that this is a good thing to do, I'll add some unit tests.