### PR TITLE
Add option to parse JSDoc-like developer doc comments

### DIFF
--- a/common/changes/@cadl-lang/compiler/devdoc_2022-11-28-18-08.json
+++ b/common/changes/@cadl-lang/compiler/devdoc_2022-11-28-18-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Improve error recovery in the presence of merge conflict markers",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/compiler/devdoc_2022-11-28-18-09.json
+++ b/common/changes/@cadl-lang/compiler/devdoc_2022-11-28-18-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add opt-in support for parsing JSDoc-like developer documentation",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/charcode.ts
+++ b/packages/compiler/core/charcode.ts
@@ -173,6 +173,25 @@ export function isWhiteSpaceSingleLine(ch: number) {
   );
 }
 
+export function trim(str: string): string {
+  let start = 0;
+  let end = str.length - 1;
+
+  if (!isWhiteSpace(str.charCodeAt(start)) && !isWhiteSpace(str.charCodeAt(end))) {
+    return str;
+  }
+
+  while (isWhiteSpace(str.charCodeAt(start))) {
+    start++;
+  }
+
+  while (isWhiteSpace(str.charCodeAt(end))) {
+    end--;
+  }
+
+  return str.substring(start, end + 1);
+}
+
 export function isDigit(ch: number) {
   return ch >= CharCode._0 && ch <= CharCode._9;
 }

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -702,6 +702,12 @@ const diagnostics = {
       default: paramMessage`Alias type '${"typeName"}' recursively references itself.`,
     },
   },
+  "conflict-marker": {
+    severity: "error",
+    messages: {
+      default: "Conflict marker encountered.",
+    },
+  },
 } as const;
 
 export type CompilerDiagnostics = TypeOfDiagnostics<typeof diagnostics>;

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -2111,7 +2111,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
   }
 
   function parseDocList(): [pos: number, nodes: DocNode[]] {
-    if (docRanges.length == 0 || !options.docs) {
+    if (docRanges.length === 0 || !options.docs) {
       return [tokenPos(), []];
     }
     const docs: DocNode[] = [];

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -1,3 +1,4 @@
+import { trim } from "./charcode.js";
 import { compilerAssert } from "./diagnostics.js";
 import { CompilerDiagnostics, createDiagnostic } from "./messages.js";
 import {
@@ -9,6 +10,7 @@ import {
   isTrivia,
   Token,
   TokenDisplay,
+  TokenFlags,
 } from "./scanner.js";
 import {
   AliasStatementNode,
@@ -24,6 +26,13 @@ import {
   DiagnosticReport,
   DirectiveArgument,
   DirectiveExpressionNode,
+  DocContent,
+  DocNode,
+  DocParamTagNode,
+  DocReturnsTagNode,
+  DocTag,
+  DocTemplateTagNode,
+  DocUnknownTagNode,
   EmptyStatementNode,
   EnumMemberNode,
   EnumSpreadMemberNode,
@@ -97,7 +106,7 @@ import { isArray, mutate } from "./util.js";
  * @param decorators The decorators that were applied to the list element and
  *                   parsed before entering the callback.
  */
-type ParseListItem<K, T> = K extends UndecoratedListKind
+type ParseListItem<K, T> = K extends UnannotatedListKind
   ? () => T
   : (pos: number, decorators: DecoratorExpressionNode[]) => T;
 
@@ -117,7 +126,7 @@ interface ListKind {
   readonly toleratedDelimiter: DelimiterToken;
   readonly toleratedDelimiterIsValid: boolean;
   readonly trailingDelimiterIsValid: boolean;
-  readonly invalidDecoratorTarget?: string;
+  readonly invalidAnnotationTarget?: string;
   readonly allowedStatementKeyword: Token;
 }
 
@@ -126,8 +135,8 @@ interface SurroundedListKind extends ListKind {
   readonly close: CloseToken;
 }
 
-interface UndecoratedListKind extends ListKind {
-  invalidDecoratorTarget: string;
+interface UnannotatedListKind extends ListKind {
+  invalidAnnotationTarget: string;
 }
 
 /**
@@ -152,7 +161,7 @@ namespace ListKind {
 
   export const DecoratorArguments = {
     ...OperationParameters,
-    invalidDecoratorTarget: "expression",
+    invalidAnnotationTarget: "expression",
   } as const;
 
   export const ModelProperties = {
@@ -192,7 +201,7 @@ namespace ListKind {
     toleratedDelimiter: Token.Semicolon,
     toleratedDelimiterIsValid: false,
     trailingDelimiterIsValid: false,
-    invalidDecoratorTarget: "expression",
+    invalidAnnotationTarget: "expression",
     allowedStatementKeyword: Token.None,
   } as const;
 
@@ -201,7 +210,7 @@ namespace ListKind {
     allowEmpty: false,
     open: Token.LessThan,
     close: Token.GreaterThan,
-    invalidDecoratorTarget: "template parameter",
+    invalidAnnotationTarget: "template parameter",
   } as const;
 
   export const TemplateArguments = {
@@ -234,7 +243,7 @@ namespace ListKind {
     allowEmpty: true,
     open: Token.OpenParen,
     close: Token.CloseParen,
-    invalidDecoratorTarget: "expression",
+    invalidAnnotationTarget: "expression",
   } as const;
 
   export const ProjectionExpression = {
@@ -250,6 +259,11 @@ namespace ListKind {
     open: Token.OpenParen,
     close: Token.CloseParen,
   } as const;
+}
+
+const enum ParseMode {
+  Syntax,
+  Doc,
 }
 
 export function parse(code: string | SourceFile, options: ParseOptions = {}): CadlScriptNode {
@@ -278,9 +292,11 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
   let missingIdentifierCounter = 0;
   let treePrintable = true;
   let newLineIsTrivia = true;
+  let currentMode = ParseMode.Syntax;
   const parseDiagnostics: Diagnostic[] = [];
   const scanner = createScanner(code, reportDiagnostic);
   const comments: Comment[] = [];
+  let docRanges: TextRange[] = [];
 
   nextToken();
   return {
@@ -320,7 +336,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
     let seenDecl = false;
     let seenUsing = false;
     while (token() !== Token.EndOfFile) {
-      const pos = tokenPos();
+      const [pos, docs] = parseDocList();
       const directives = parseDirectiveList();
       const decorators = parseDecoratorList();
       const tok = token();
@@ -354,25 +370,25 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
           break;
         case Token.AliasKeyword:
           reportInvalidDecorators(decorators, "alias statement");
-          item = parseAliasStatement();
+          item = parseAliasStatement(pos);
           break;
         case Token.UsingKeyword:
           reportInvalidDecorators(decorators, "using statement");
-          item = parseUsingStatement();
+          item = parseUsingStatement(pos);
           break;
         case Token.ProjectionKeyword:
           reportInvalidDecorators(decorators, "projection statement");
-          item = parseProjectionStatement();
+          item = parseProjectionStatement(pos);
           break;
         case Token.Semicolon:
           reportInvalidDecorators(decorators, "empty statement");
-          item = parseEmptyStatement();
+          item = parseEmptyStatement(pos);
           break;
         // Start of declaration with modifiers
         case Token.ExternKeyword:
         case Token.FnKeyword:
         case Token.DecKeyword:
-          item = parseDeclaration();
+          item = parseDeclaration(pos);
           break;
         default:
           item = parseInvalidStatement(pos, decorators);
@@ -380,6 +396,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
       }
 
       mutate(item).directives = directives;
+      mutate(item).docs = docs;
 
       if (isBlocklessNamespace(item)) {
         if (seenBlocklessNs) {
@@ -409,7 +426,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
     const stmts: Statement[] = [];
 
     while (token() !== Token.CloseBrace) {
-      const pos = tokenPos();
+      const [pos, docs] = parseDocList();
       const directives = parseDirectiveList();
       const decorators = parseDecoratorList();
       const tok = token();
@@ -450,33 +467,34 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
           break;
         case Token.AliasKeyword:
           reportInvalidDecorators(decorators, "alias statement");
-          item = parseAliasStatement();
+          item = parseAliasStatement(pos);
           break;
         case Token.UsingKeyword:
           reportInvalidDecorators(decorators, "using statement");
-          item = parseUsingStatement();
+          item = parseUsingStatement(pos);
           break;
         case Token.ExternKeyword:
         case Token.FnKeyword:
         case Token.DecKeyword:
-          item = parseDeclaration();
+          item = parseDeclaration(pos);
           break;
         case Token.ProjectionKeyword:
           reportInvalidDecorators(decorators, "project statement");
-          item = parseProjectionStatement();
+          item = parseProjectionStatement(pos);
           break;
         case Token.EndOfFile:
           parseExpected(Token.CloseBrace);
           return stmts;
         case Token.Semicolon:
           reportInvalidDecorators(decorators, "empty statement");
-          item = parseEmptyStatement();
+          item = parseEmptyStatement(pos);
           break;
         default:
           item = parseInvalidStatement(pos, decorators);
           break;
       }
       mutate(item).directives = directives;
+      mutate(item).docs = docs;
       stmts.push(item);
     }
 
@@ -633,8 +651,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
     };
   }
 
-  function parseUsingStatement(): UsingStatementNode {
-    const pos = tokenPos();
+  function parseUsingStatement(pos: number): UsingStatementNode {
     parseExpected(Token.UsingKeyword);
     const name = parseIdentifierOrMemberExpression(undefined, true);
     parseExpected(Token.Semicolon);
@@ -903,8 +920,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
     };
   }
 
-  function parseAliasStatement(): AliasStatementNode {
-    const pos = tokenPos();
+  function parseAliasStatement(pos: number): AliasStatementNode {
     parseExpected(Token.AliasKeyword);
     const id = parseIdentifier();
     const templateParameters = parseTemplateParameterList();
@@ -1324,11 +1340,9 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
     };
   }
 
-  function parseDeclaration():
-    | DecoratorDeclarationStatementNode
-    | FunctionDeclarationStatementNode
-    | InvalidStatementNode {
-    const pos = tokenPos();
+  function parseDeclaration(
+    pos: number
+  ): DecoratorDeclarationStatementNode | FunctionDeclarationStatementNode | InvalidStatementNode {
     const modifiers = parseModifiers();
     switch (token()) {
       case Token.DecKeyword:
@@ -1474,8 +1488,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
     return flags;
   }
 
-  function parseProjectionStatement(): ProjectionStatementNode {
-    const pos = tokenPos();
+  function parseProjectionStatement(pos: number): ProjectionStatementNode {
     parseExpected(Token.ProjectionKeyword);
     const selector = parseProjectionSelector();
     parseExpected(Token.Hash);
@@ -2078,9 +2091,178 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
     }
   }
 
+  function parseRange<T>(mode: ParseMode, range: TextRange, callback: () => T): T {
+    const savedMode = currentMode;
+    const result = scanner.scanRange(range, () => {
+      currentMode = mode;
+      nextToken();
+      return callback();
+    });
+    currentMode = savedMode;
+    return result;
+  }
+
+  /** Remove leading slash-star-star and trailing  star-slash (if terminated) from doc comment range. */
+  function innerDocRange(range: TextRange): TextRange {
+    return {
+      pos: range.pos + 3,
+      end: tokenFlags() & TokenFlags.Unterminated ? range.end : range.end - 2,
+    };
+  }
+
+  function parseDocList(): [pos: number, nodes: DocNode[]] {
+    if (docRanges.length == 0 || !options.docs) {
+      return [tokenPos(), []];
+    }
+    const docs: DocNode[] = [];
+    for (const range of docRanges) {
+      const doc = parseRange(ParseMode.Doc, innerDocRange(range), parseDoc);
+      docs.push(doc);
+    }
+
+    return [docRanges[0].pos, docs];
+  }
+
+  function parseDoc(): DocNode {
+    const pos = tokenPos();
+    const content: DocContent[] = [];
+    const tags: DocTag[] = [];
+
+    loop: while (true) {
+      switch (token()) {
+        case Token.EndOfFile:
+          break loop;
+        case Token.At:
+          tags.push(parseDocTag());
+          break;
+        default:
+          content.push(...parseDocContent());
+          break;
+      }
+    }
+
+    return {
+      kind: SyntaxKind.Doc,
+      content,
+      tags,
+      ...finishNode(pos),
+    };
+  }
+
+  function parseDocContent(): DocContent[] {
+    const parts: string[] = [];
+    const source = scanner.file.text;
+    const pos = tokenPos();
+
+    let start = pos;
+    let inCodeFence = false;
+
+    loop: while (true) {
+      switch (token()) {
+        case Token.DocCodeFenceDelimiter:
+          inCodeFence = !inCodeFence;
+          nextDocToken();
+          break;
+        case Token.NewLine:
+          parts.push(source.substring(start, tokenPos()));
+          parts.push("\n"); // normalize line endings
+          nextDocToken();
+          start = tokenPos();
+          while (parseOptional(Token.Whitespace));
+          if (parseOptional(Token.Star)) {
+            parseOptional(Token.Whitespace);
+            start = tokenPos();
+            break;
+          }
+          break;
+        case Token.EndOfFile:
+          break loop;
+        case Token.At:
+          if (!inCodeFence) {
+            break loop;
+          }
+          nextDocToken();
+          break;
+        default:
+          nextDocToken();
+          break;
+      }
+    }
+
+    parts.push(source.substring(start, tokenPos()));
+    const text = trim(parts.join(""));
+
+    return [
+      {
+        kind: SyntaxKind.DocText,
+        text,
+        ...finishNode(pos),
+      },
+    ];
+  }
+
+  type ParamLikeTag = DocTemplateTagNode | DocParamTagNode;
+  type SimpleTag = DocReturnsTagNode | DocUnknownTagNode;
+
+  function parseDocTag(): DocTag {
+    const pos = tokenPos();
+    parseExpected(Token.At);
+    const tagName = parseIdentifier();
+    switch (tagName.sv) {
+      case "param":
+        return parseDocParamLikeTag(pos, tagName, SyntaxKind.DocParamTag);
+      case "template":
+        return parseDocParamLikeTag(pos, tagName, SyntaxKind.DocTemplateTag);
+      case "return":
+      case "returns":
+        return parseDocSimpleTag(pos, tagName, SyntaxKind.DocReturnsTag);
+      default:
+        return parseDocSimpleTag(pos, tagName, SyntaxKind.DocUnknownTag);
+    }
+  }
+
+  function parseDocParamLikeTag(
+    pos: number,
+    tagName: IdentifierNode,
+    kind: ParamLikeTag["kind"]
+  ): ParamLikeTag {
+    const name = parseDocIdentifier();
+    const content = parseDocContent();
+    return {
+      kind,
+      tagName,
+      name,
+      content,
+      ...finishNode(pos),
+    };
+  }
+
+  function parseDocIdentifier() {
+    while (parseOptional(Token.Whitespace));
+    return parseIdentifier();
+  }
+
+  function parseDocSimpleTag(
+    pos: number,
+    tagName: IdentifierNode,
+    kind: SimpleTag["kind"]
+  ): SimpleTag {
+    const content = parseDocContent();
+    return {
+      kind,
+      tagName,
+      content,
+      ...finishNode(pos),
+    };
+  }
+
   // utility functions
   function token() {
     return scanner.token;
+  }
+
+  function tokenFlags() {
+    return scanner.tokenFlags;
   }
 
   function tokenValue() {
@@ -2100,12 +2282,23 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
     // position as these will differ when the previous token had trailing
     // trivia, and we don't want to squiggle the trivia.
     previousTokenEnd = scanner.position;
+    return currentMode === ParseMode.Syntax ? nextSyntaxToken() : nextDocToken();
+  }
+
+  function nextSyntaxToken() {
+    docRanges = [];
 
     for (;;) {
       scanner.scan();
       if (isTrivia(token())) {
         if (!newLineIsTrivia && token() === Token.NewLine) {
           break;
+        }
+        if (tokenFlags() & TokenFlags.DocComment) {
+          docRanges.push({
+            pos: tokenPos(),
+            end: tokenEnd(),
+          });
         }
         if (options.comments && isComment(token())) {
           comments.push({
@@ -2121,6 +2314,11 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
         break;
       }
     }
+  }
+
+  function nextDocToken() {
+    // NOTE: trivia tokens are always significant in doc comments.
+    scanner.scanDoc();
   }
 
   function createMissingIdentifier(): IdentifierNode {
@@ -2175,12 +2373,17 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
 
     const items: T[] = [];
     while (true) {
-      const pos = tokenPos();
+      let pos = tokenPos();
+      let docs: DocNode[] | undefined;
+
+      if (!kind.invalidAnnotationTarget) {
+        [pos, docs] = parseDocList();
+      }
       const directives = parseDirectiveList();
       const decorators = parseDecoratorList();
-
-      if (kind.invalidDecoratorTarget) {
-        reportInvalidDecorators(decorators, kind.invalidDecoratorTarget);
+      if (kind.invalidAnnotationTarget) {
+        reportInvalidDecorators(decorators, kind.invalidAnnotationTarget);
+        reportInvalidDirective(directives, kind.invalidAnnotationTarget);
       }
 
       if (directives.length === 0 && decorators.length === 0 && atEndOfListWithError(kind)) {
@@ -2193,14 +2396,15 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
       }
 
       let item: T;
-      if (kind.invalidDecoratorTarget) {
-        item = (parseItem as ParseListItem<UndecoratedListKind, T>)();
+      if (kind.invalidAnnotationTarget) {
+        item = (parseItem as ParseListItem<UnannotatedListKind, T>)();
       } else {
         item = parseItem(pos, decorators);
+        mutate(item).docs = docs;
+        mutate(item).directives = directives;
       }
 
       items.push(item);
-      mutate(item).directives = directives;
       const delimiter = token();
       const delimiterPos = tokenPos();
 
@@ -2303,8 +2507,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
     );
   }
 
-  function parseEmptyStatement(): EmptyStatementNode {
-    const pos = tokenPos();
+  function parseEmptyStatement(pos: number): EmptyStatementNode {
     parseExpected(Token.Semicolon);
     return { kind: SyntaxKind.EmptyStatement, ...finishNode(pos) };
   }
@@ -2475,8 +2678,14 @@ export type NodeCallback<T> = (c: Node) => T;
 
 export function visitChildren<T>(node: Node, cb: NodeCallback<T>): T | undefined {
   if (node.directives) {
-    visitEach(cb, node.directives);
+    const result = visitEach(cb, node.directives);
+    if (result) return result;
   }
+  if (node.docs) {
+    const result = visitEach(cb, node.docs);
+    if (result) return result;
+  }
+
   switch (node.kind) {
     case SyntaxKind.CadlScript:
       return visitNode(cb, node.id) || visitEach(cb, node.statements);
@@ -2643,7 +2852,6 @@ export function visitChildren<T>(node: Node, cb: NodeCallback<T>): T | undefined
       return visitNode(cb, node.target);
     case SyntaxKind.Return:
       return visitNode(cb, node.value);
-    // no children for the rest of these.
     case SyntaxKind.InvalidStatement:
       return visitEach(cb, node.decorators);
     case SyntaxKind.TemplateParameterDeclaration:
@@ -2654,6 +2862,16 @@ export function visitChildren<T>(node: Node, cb: NodeCallback<T>): T | undefined
       return visitNode(cb, node.id);
     case SyntaxKind.ProjectionParameterDeclaration:
       return visitNode(cb, node.id);
+    case SyntaxKind.Doc:
+      return visitEach(cb, node.content) || visitEach(cb, node.tags);
+    case SyntaxKind.DocParamTag:
+    case SyntaxKind.DocTemplateTag:
+      return visitNode(cb, node.tagName) || visitNode(cb, node.name) || visitEach(cb, node.content);
+    case SyntaxKind.DocReturnsTag:
+    case SyntaxKind.DocUnknownTag:
+      return visitNode(cb, node.tagName) || visitEach(cb, node.content);
+
+    // no children for the rest of these.
     case SyntaxKind.StringLiteral:
     case SyntaxKind.NumericLiteral:
     case SyntaxKind.BooleanLiteral:
@@ -2669,7 +2887,9 @@ export function visitChildren<T>(node: Node, cb: NodeCallback<T>): T | undefined
     case SyntaxKind.ExternKeyword:
     case SyntaxKind.UnknownKeyword:
     case SyntaxKind.JsSourceFile:
+    case SyntaxKind.DocText:
       return;
+
     default:
       // Dummy const to ensure we handle all node types.
       // If you get an error here, add a case for the new node type

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -2231,7 +2231,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
     return {
       kind,
       tagName,
-      name,
+      paramName: name,
       content,
       ...finishNode(pos),
     };
@@ -2866,7 +2866,9 @@ export function visitChildren<T>(node: Node, cb: NodeCallback<T>): T | undefined
       return visitEach(cb, node.content) || visitEach(cb, node.tags);
     case SyntaxKind.DocParamTag:
     case SyntaxKind.DocTemplateTag:
-      return visitNode(cb, node.tagName) || visitNode(cb, node.name) || visitEach(cb, node.content);
+      return (
+        visitNode(cb, node.tagName) || visitNode(cb, node.paramName) || visitEach(cb, node.content)
+      );
     case SyntaxKind.DocReturnsTag:
     case SyntaxKind.DocUnknownTag:
       return visitNode(cb, node.tagName) || visitEach(cb, node.content);

--- a/packages/compiler/core/scanner.ts
+++ b/packages/compiler/core/scanner.ts
@@ -269,11 +269,6 @@ export const enum KeywordLimit {
   MaxLength = 10,
 }
 
-export enum ScanMode {
-  Syntax,
-  Doc,
-}
-
 export interface Scanner {
   /** The source code being scanned. */
   readonly file: SourceFile;
@@ -354,7 +349,6 @@ export function createScanner(
 ): Scanner {
   const file = typeof source === "string" ? createSourceFile(source, "<anonymous file>") : source;
   const input = file.text;
-  let mode = ScanMode.Syntax;
   let position = 0;
   let endPosition = input.length;
   let token = Token.None;
@@ -640,24 +634,20 @@ export function createScanner(
     const savedToken = token;
     const savedTokenPosition = tokenPosition;
     const savedTokenFlags = tokenFlags;
-    const savedMode = mode;
 
-    let result: T;
-    try {
-      position = range.pos;
-      endPosition = range.end;
-      token = Token.None;
-      tokenPosition = -1;
-      tokenFlags = TokenFlags.None;
-      result = callback();
-    } finally {
-      mode = savedMode;
-      position = savedPosition;
-      endPosition = savedEndPosition;
-      token = savedToken;
-      tokenPosition = savedTokenPosition;
-      tokenFlags = savedTokenFlags;
-    }
+    position = range.pos;
+    endPosition = range.end;
+    token = Token.None;
+    tokenPosition = -1;
+    tokenFlags = TokenFlags.None;
+
+    const result = callback();
+
+    position = savedPosition;
+    endPosition = savedEndPosition;
+    token = savedToken;
+    tokenPosition = savedTokenPosition;
+    tokenFlags = savedTokenFlags;
 
     return result;
   }

--- a/packages/compiler/core/scanner.ts
+++ b/packages/compiler/core/scanner.ts
@@ -6,6 +6,7 @@ import {
   isDigit,
   isHexDigit,
   isIdentifierContinue,
+  isIdentifierStart,
   isLineBreak,
   isLowercaseAsciiLetter,
   isNonAsciiIdentifierCharacter,
@@ -16,7 +17,7 @@ import {
 } from "./charcode.js";
 import { compilerAssert, createSourceFile, DiagnosticHandler } from "./diagnostics.js";
 import { CompilerDiagnostics, createDiagnostic } from "./messages.js";
-import { DiagnosticReport, SourceFile } from "./types.js";
+import { DiagnosticReport, SourceFile, TextRange } from "./types.js";
 
 // All conflict markers consist of the same character repeated seven times.  If it is
 // a <<<<<<< or >>>>>>> marker then it is also followed by a space.
@@ -29,7 +30,6 @@ export enum Token {
   Identifier,
   NumericLiteral,
   StringLiteral,
-  ConflictMarker,
   // Add new tokens above if they don't fit any of the categories below
 
   ///////////////////////////////////////////////////////////////
@@ -40,14 +40,24 @@ export enum Token {
   MultiLineComment,
   NewLine,
   Whitespace,
+  ConflictMarker,
   // Add new trivia above
 
   /** @internal */ __EndTrivia,
   ///////////////////////////////////////////////////////////////
 
   ///////////////////////////////////////////////////////////////
+  // Doc comment content
+  /** @internal */ __StartDocComment = __EndTrivia,
+  DocText = __StartDocComment,
+  DocCodeSpan,
+  DocCodeFenceDelimiter,
+  /** @internal */ __EndDocComment,
+  ///////////////////////////////////////////////////////////////
+
+  ///////////////////////////////////////////////////////////////
   // Punctuation
-  /** @internal */ __StartPunctuation = __EndTrivia,
+  /** @internal */ __StartPunctuation = __EndDocComment,
 
   OpenBrace = __StartPunctuation,
   CloseBrace,
@@ -139,6 +149,19 @@ export enum Token {
   /** @internal */ __Count = __EndKeyword,
 }
 
+export type DocToken =
+  | Token.NewLine
+  | Token.Whitespace
+  | Token.ConflictMarker
+  | Token.Star
+  | Token.At
+  | Token.CloseBrace
+  | Token.Identifier
+  | Token.DocText
+  | Token.DocCodeSpan
+  | Token.DocCodeFenceDelimiter
+  | Token.EndOfFile;
+
 /** @internal */
 export const TokenDisplay = getTokenDisplayTable([
   [Token.None, "none"],
@@ -151,6 +174,9 @@ export const TokenDisplay = getTokenDisplayTable([
   [Token.StringLiteral, "string literal"],
   [Token.NewLine, "newline"],
   [Token.Whitespace, "whitespace"],
+  [Token.DocCodeFenceDelimiter, "doc code fence delimiter"],
+  [Token.DocCodeSpan, "doc code span"],
+  [Token.DocText, "doc text"],
   [Token.OpenBrace, "'{'"],
   [Token.CloseBrace, "'}'"],
   [Token.OpenParen, "'('"],
@@ -243,6 +269,11 @@ export const enum KeywordLimit {
   MaxLength = 10,
 }
 
+export enum ScanMode {
+  Syntax,
+  Doc,
+}
+
 export interface Scanner {
   /** The source code being scanned. */
   readonly file: SourceFile;
@@ -256,8 +287,17 @@ export interface Scanner {
   /** The offset in UTF-16 code units to the start of the current token. */
   readonly tokenPosition: number;
 
+  /** The flags on the current token. */
+  readonly tokenFlags: TokenFlags;
+
   /** Advance one token. */
   scan(): Token;
+
+  /** Advance one token inside DocComment. Use inside {@link scanRange} callback over DocComment range. */
+  scanDoc(): DocToken;
+
+  /** Reset the scanner to the given start and end positions, invoke the callback, and then restore scanner state. */
+  scanRange<T>(range: TextRange, callback: () => T): T;
 
   /** Determine if the scanner has reached the end of the input. */
   eof(): boolean;
@@ -275,12 +315,13 @@ export interface Scanner {
   getTokenValue(): string;
 }
 
-const enum TokenFlags {
+export enum TokenFlags {
   None = 0,
   Escaped = 1 << 0,
   TripleQuoted = 1 << 1,
   Unterminated = 1 << 2,
   NonAscii = 1 << 3,
+  DocComment = 1 << 4,
 }
 
 export function isTrivia(token: Token) {
@@ -313,13 +354,14 @@ export function createScanner(
 ): Scanner {
   const file = typeof source === "string" ? createSourceFile(source, "<anonymous file>") : source;
   const input = file.text;
+  let mode = ScanMode.Syntax;
   let position = 0;
+  let endPosition = input.length;
   let token = Token.None;
   let tokenPosition = -1;
   let tokenFlags = TokenFlags.None;
-
   // Skip BOM
-  if (input.charCodeAt(position) === CharCode.ByteOrderMark) {
+  if (position < endPosition && input.charCodeAt(position) === CharCode.ByteOrderMark) {
     position++;
   }
 
@@ -333,15 +375,20 @@ export function createScanner(
     get tokenPosition() {
       return tokenPosition;
     },
+    get tokenFlags() {
+      return tokenFlags;
+    },
     file,
     scan,
+    scanRange,
+    scanDoc,
     eof,
     getTokenText,
     getTokenValue,
   };
 
   function eof() {
-    return position >= input.length;
+    return position >= endPosition;
   }
 
   function getTokenText() {
@@ -360,7 +407,11 @@ export function createScanner(
   }
 
   function lookAhead(offset: number) {
-    return input.charCodeAt(position + offset);
+    const p = position + offset;
+    if (p >= endPosition) {
+      return Number.NaN;
+    }
+    return input.charCodeAt(p);
   }
 
   function scan(): Token {
@@ -469,56 +520,51 @@ export function createScanner(
           return scanNumber();
 
         case CharCode.LessThan:
+          if (atConflictMarker()) return scanConflictMarker();
           return lookAhead(1) === CharCode.Equals
             ? next(Token.LessThanEquals, 2)
-            : isConflictMarker()
-            ? next(Token.ConflictMarker, mergeConflictMarkerLength)
             : next(Token.LessThan);
 
         case CharCode.GreaterThan:
+          if (atConflictMarker()) return scanConflictMarker();
           return lookAhead(1) === CharCode.Equals
             ? next(Token.GreaterThanEquals, 2)
-            : isConflictMarker()
-            ? next(Token.ConflictMarker, mergeConflictMarkerLength)
             : next(Token.GreaterThan);
 
         case CharCode.Equals:
-          return lookAhead(1) === CharCode.Equals
-            ? next(Token.EqualsEquals, 2)
-            : lookAhead(1) === CharCode.GreaterThan
-            ? next(Token.EqualsGreaterThan, 2)
-            : isConflictMarker()
-            ? next(Token.ConflictMarker, mergeConflictMarkerLength)
-            : next(Token.Equals);
+          if (atConflictMarker()) return scanConflictMarker();
+          switch (lookAhead(1)) {
+            case CharCode.Equals:
+              return next(Token.EqualsEquals, 2);
+            case CharCode.GreaterThan:
+              return next(Token.EqualsGreaterThan, 2);
+          }
+          return next(Token.Equals);
 
         case CharCode.Bar:
-          return lookAhead(1) === CharCode.Bar
-            ? next(Token.BarBar, 2)
-            : isConflictMarker()
-            ? next(Token.ConflictMarker, mergeConflictMarkerLength)
-            : next(Token.Bar);
+          if (atConflictMarker()) return scanConflictMarker();
+          return lookAhead(1) === CharCode.Bar ? next(Token.BarBar, 2) : next(Token.Bar);
 
         case CharCode.DoubleQuote:
           return lookAhead(1) === CharCode.DoubleQuote && lookAhead(2) === CharCode.DoubleQuote
             ? scanTripleQuotedString()
             : scanString();
+
         case CharCode.Exclamation:
           return lookAhead(1) === CharCode.Equals
             ? next(Token.ExclamationEquals, 2)
             : next(Token.Exclamation);
+
         default:
           if (isLowercaseAsciiLetter(ch)) {
             return scanIdentifierOrKeyword();
           }
-
           if (isAsciiIdentifierStart(ch)) {
             return scanIdentifier();
           }
-
           if (ch <= CharCode.MaxAscii) {
             return scanInvalidCharacter();
           }
-
           return scanNonAsciiToken();
       }
     }
@@ -526,15 +572,105 @@ export function createScanner(
     return (token = Token.EndOfFile);
   }
 
-  function next(t: Token, count = 1) {
-    position += count;
-    return (token = t);
+  function scanDoc(): DocToken {
+    tokenPosition = position;
+    tokenFlags = TokenFlags.None;
+
+    if (!eof()) {
+      const ch = input.charCodeAt(position);
+      switch (ch) {
+        case CharCode.CarriageReturn:
+          if (lookAhead(1) === CharCode.LineFeed) {
+            position++;
+          }
+        // fallthrough
+        case CharCode.LineFeed:
+          return next(Token.NewLine);
+
+        case CharCode.Space:
+        case CharCode.Tab:
+        case CharCode.VerticalTab:
+        case CharCode.FormFeed:
+          return scanWhitespace();
+
+        case CharCode.CloseBrace:
+          return next(Token.CloseBrace);
+
+        case CharCode.At:
+          return next(Token.At);
+
+        case CharCode.Asterisk:
+          return next(Token.Star);
+
+        case CharCode.Backtick:
+          return lookAhead(1) === CharCode.Backtick && lookAhead(2) === CharCode.Backtick
+            ? next(Token.DocCodeFenceDelimiter, 3)
+            : scanDocCodeSpan();
+
+        case CharCode.LessThan:
+        case CharCode.GreaterThan:
+        case CharCode.Equals:
+        case CharCode.Bar:
+          if (atConflictMarker()) return scanConflictMarker();
+          return next(Token.DocText);
+      }
+
+      if (isAsciiIdentifierStart(ch)) {
+        return scanIdentifier();
+      }
+
+      if (ch <= CharCode.MaxAscii) {
+        return next(Token.DocText);
+      }
+
+      const cp = input.codePointAt(position)!;
+      if (isIdentifierStart(cp)) {
+        return scanNonAsciiIdentifier(cp);
+      }
+
+      return scanUnknown(Token.DocText);
+    }
+
+    return (token = Token.EndOfFile);
   }
 
-  function unterminated(t: Token) {
+  function scanRange<T>(range: TextRange, callback: () => T): T {
+    const savedPosition = position;
+    const savedEndPosition = endPosition;
+    const savedToken = token;
+    const savedTokenPosition = tokenPosition;
+    const savedTokenFlags = tokenFlags;
+    const savedMode = mode;
+
+    let result: T;
+    try {
+      position = range.pos;
+      endPosition = range.end;
+      token = Token.None;
+      tokenPosition = -1;
+      tokenFlags = TokenFlags.None;
+      result = callback();
+    } finally {
+      mode = savedMode;
+      position = savedPosition;
+      endPosition = savedEndPosition;
+      token = savedToken;
+      tokenPosition = savedTokenPosition;
+      tokenFlags = savedTokenFlags;
+    }
+
+    return result;
+  }
+
+  function next<T extends Token>(t: T, count = 1): T {
+    position += count;
+    return (token = t) as T;
+  }
+
+  function unterminated<T extends Token>(t: T): T {
     tokenFlags |= TokenFlags.Unterminated;
     error({ code: "unterminated", format: { token: TokenDisplay[t] } });
-    return (token = t);
+    return (token = t) as T;
   }
 
   function scanNonAsciiToken() {
@@ -553,28 +689,15 @@ export function createScanner(
     return scanInvalidCharacter();
   }
 
-  function scanInvalidCharacter() {
-    const codePoint = input.codePointAt(position)!;
-    token = next(Token.Invalid, utf16CodeUnits(codePoint));
+  function scanInvalidCharacter(): Token.Invalid {
+    token = scanUnknown(Token.Invalid);
     error({ code: "invalid-character" });
     return token;
   }
 
-  function isConflictMarker() {
-    // Conflict markers must be at the start of a line.
-    const ch = input.charCodeAt(position);
-    if (position === 0 || isLineBreak(input.charCodeAt(position - 1))) {
-      if (position + mergeConflictMarkerLength < input.length) {
-        for (let i = 0; i < mergeConflictMarkerLength; i++) {
-          if (lookAhead(i) !== ch) {
-            return false;
-          }
-        }
-        return ch === CharCode.Equals || lookAhead(mergeConflictMarkerLength) === CharCode.Space;
-      }
-    }
-
-    return false;
+  function scanUnknown<T extends Token>(t: T): T {
+    const codePoint = input.codePointAt(position)!;
+    return (token = next(t, utf16CodeUnits(codePoint)));
   }
 
   function error<
@@ -588,7 +711,7 @@ export function createScanner(
     diagnosticHandler(diagnostic);
   }
 
-  function scanWhitespace(): Token {
+  function scanWhitespace(): Token.Whitespace {
     do {
       position++;
     } while (!eof() && isWhiteSpaceSingleLine(input.charCodeAt(position)));
@@ -596,12 +719,12 @@ export function createScanner(
     return (token = Token.Whitespace);
   }
 
-  function scanSignedNumber() {
+  function scanSignedNumber(): Token.NumericLiteral {
     position++; // consume '+/-'
     return scanNumber();
   }
 
-  function scanNumber() {
+  function scanNumber(): Token.NumericLiteral {
     scanKnownDigits();
     if (!eof() && input.charCodeAt(position) === CharCode.Dot) {
       position++;
@@ -618,13 +741,13 @@ export function createScanner(
     return (token = Token.NumericLiteral);
   }
 
-  function scanKnownDigits() {
+  function scanKnownDigits(): void {
     do {
       position++;
     } while (!eof() && isDigit(input.charCodeAt(position)));
   }
 
-  function scanRequiredDigits() {
+  function scanRequiredDigits(): void {
     if (eof() || !isDigit(input.charCodeAt(position))) {
       error({ code: "digit-expected" });
       return;
@@ -632,7 +755,7 @@ export function createScanner(
     scanKnownDigits();
   }
 
-  function scanHexNumber() {
+  function scanHexNumber(): Token.NumericLiteral {
     position += 2; // consume '0x'
 
     if (eof() || !isHexDigit(input.charCodeAt(position))) {
@@ -646,7 +769,7 @@ export function createScanner(
     return (token = Token.NumericLiteral);
   }
 
-  function scanBinaryNumber() {
+  function scanBinaryNumber(): Token.NumericLiteral {
     position += 2; // consume '0b'
 
     if (eof() || !isBinaryDigit(input.charCodeAt(position))) {
@@ -660,19 +783,40 @@ export function createScanner(
     return (token = Token.NumericLiteral);
   }
 
-  function scanSingleLineComment() {
-    position = skipSingleLineComment(input, position);
+  function scanSingleLineComment(): Token.SingleLineComment {
+    position = skipSingleLineComment(input, position, endPosition);
     return (token = Token.SingleLineComment);
   }
 
-  function scanMultiLineComment() {
+  function scanMultiLineComment(): Token.MultiLineComment {
+    token = Token.MultiLineComment;
+    if (lookAhead(2) === CharCode.Asterisk) {
+      tokenFlags |= TokenFlags.DocComment;
+    }
     const [newPosition, terminated] = skipMultiLineComment(input, position);
     position = newPosition;
-    token = Token.MultiLineComment;
     return terminated ? token : unterminated(token);
   }
 
-  function scanString() {
+  function scanDocCodeSpan(): Token.DocCodeSpan {
+    position++; // consume '`'
+
+    loop: for (; !eof(); position++) {
+      const ch = input.charCodeAt(position);
+      switch (ch) {
+        case CharCode.Backtick:
+          position++;
+          return (token = Token.DocCodeSpan);
+        case CharCode.CarriageReturn:
+        case CharCode.LineFeed:
+          break loop;
+      }
+    }
+
+    return unterminated(Token.DocCodeSpan);
+  }
+
+  function scanString(): Token.StringLiteral {
     position++; // consume '"'
 
     loop: for (; !eof(); position++) {
@@ -697,7 +841,7 @@ export function createScanner(
     return unterminated(Token.StringLiteral);
   }
 
-  function scanTripleQuotedString() {
+  function scanTripleQuotedString(): Token.StringLiteral {
     tokenFlags |= TokenFlags.TripleQuoted;
     position += 3; // consume '"""'
 
@@ -715,7 +859,7 @@ export function createScanner(
     return unterminated(Token.StringLiteral);
   }
 
-  function getStringTokenValue() {
+  function getStringTokenValue(): string {
     const quoteLength = tokenFlags & TokenFlags.TripleQuoted ? 3 : 1;
     const start = tokenPosition + quoteLength;
     const end = tokenFlags & TokenFlags.Unterminated ? position : position - quoteLength;
@@ -731,12 +875,12 @@ export function createScanner(
     return input.substring(start, end);
   }
 
-  function getIdentifierTokenValue() {
+  function getIdentifierTokenValue(): string {
     const text = getTokenText();
     return tokenFlags & TokenFlags.NonAscii ? text.normalize("NFC") : text;
   }
 
-  function unindentAndUnescapeTripleQuotedString(start: number, end: number) {
+  function unindentAndUnescapeTripleQuotedString(start: number, end: number): string {
     // ignore leading whitespace before required initial line break
     while (start < end && isWhiteSpaceSingleLine(input.charCodeAt(start))) {
       start++;
@@ -828,7 +972,7 @@ export function createScanner(
     end: number,
     indentationStart: number,
     indentationEnd: number
-  ) {
+  ): number {
     let indentationPos = indentationStart;
     end = Math.min(end, pos + (indentationEnd - indentationStart));
 
@@ -849,7 +993,7 @@ export function createScanner(
     return pos;
   }
 
-  function unescapeString(start: number, end: number) {
+  function unescapeString(start: number, end: number): string {
     let result = "";
     let pos = start;
 
@@ -875,7 +1019,7 @@ export function createScanner(
     return result;
   }
 
-  function unescapeOne(pos: number) {
+  function unescapeOne(pos: number): string {
     const ch = input.charCodeAt(pos + 1);
     switch (ch) {
       case CharCode.r:
@@ -894,7 +1038,7 @@ export function createScanner(
     }
   }
 
-  function scanIdentifierOrKeyword() {
+  function scanIdentifierOrKeyword(): Token {
     let count = 0;
     let ch = input.charCodeAt(position);
 
@@ -935,7 +1079,7 @@ export function createScanner(
     return (token = Token.Identifier);
   }
 
-  function scanIdentifier() {
+  function scanIdentifier(): Token.Identifier {
     let ch: number;
 
     do {
@@ -955,7 +1099,7 @@ export function createScanner(
     return (token = Token.Identifier);
   }
 
-  function scanNonAsciiIdentifier(startCodePoint: number) {
+  function scanNonAsciiIdentifier(startCodePoint: number): Token.Identifier {
     tokenFlags |= TokenFlags.NonAscii;
     let cp = startCodePoint;
     do {
@@ -964,10 +1108,43 @@ export function createScanner(
 
     return (token = Token.Identifier);
   }
+
+  function atConflictMarker(): boolean {
+    return isConflictMarker(input, position, endPosition);
+  }
+
+  function scanConflictMarker(): Token.ConflictMarker {
+    const marker = input.charCodeAt(position);
+    position += mergeConflictMarkerLength;
+    error({ code: "conflict-marker" });
+
+    if (marker === CharCode.LessThan || marker === CharCode.GreaterThan) {
+      // Consume everything from >>>>>>> or <<<<<<< to the end of the line.
+      while (position < endPosition && !isLineBreak(input.charCodeAt(position))) {
+        position++;
+      }
+    } else {
+      // Consume everything from the start of a ||||||| or =======
+      // marker to the start of the next ======= or >>>>>>> marker.
+      while (position < endPosition) {
+        const ch = input.charCodeAt(position);
+        if (
+          (ch === CharCode.Equals || ch === CharCode.GreaterThan) &&
+          ch !== marker &&
+          isConflictMarker(input, position, endPosition)
+        ) {
+          break;
+        }
+        position++;
+      }
+    }
+
+    return (token = Token.ConflictMarker);
+  }
 }
 
-export function skipTrivia(input: string, position: number): number {
-  while (position < input.length) {
+export function skipTrivia(input: string, position: number, endPosition = input.length): number {
+  while (position < endPosition) {
     const ch = input.charCodeAt(position);
 
     if (isWhiteSpace(ch)) {
@@ -978,10 +1155,10 @@ export function skipTrivia(input: string, position: number): number {
     if (ch === CharCode.Slash) {
       switch (input.charCodeAt(position + 1)) {
         case CharCode.Slash:
-          position = skipSingleLineComment(input, position);
+          position = skipSingleLineComment(input, position, endPosition);
           continue;
         case CharCode.Asterisk:
-          position = skipMultiLineComment(input, position)[0];
+          position = skipMultiLineComment(input, position, endPosition)[0];
           continue;
       }
     }
@@ -992,8 +1169,12 @@ export function skipTrivia(input: string, position: number): number {
   return position;
 }
 
-export function skipWhiteSpace(input: string, position: number): number {
-  while (position < input.length) {
+export function skipWhiteSpace(
+  input: string,
+  position: number,
+  endPosition = input.length
+): number {
+  while (position < endPosition) {
     const ch = input.charCodeAt(position);
 
     if (!isWhiteSpace(ch)) {
@@ -1005,10 +1186,14 @@ export function skipWhiteSpace(input: string, position: number): number {
   return position;
 }
 
-function skipSingleLineComment(input: string, position: number): number {
+function skipSingleLineComment(
+  input: string,
+  position: number,
+  endPosition = input.length
+): number {
   position += 2; // consume '//'
 
-  for (; position < input.length; position++) {
+  for (; position < endPosition; position++) {
     if (isLineBreak(input.charCodeAt(position))) {
       break;
     }
@@ -1019,11 +1204,12 @@ function skipSingleLineComment(input: string, position: number): number {
 
 function skipMultiLineComment(
   input: string,
-  position: number
+  position: number,
+  endPosition = input.length
 ): [position: number, terminated: boolean] {
   position += 2; // consume '/*'
 
-  for (; position < input.length; position++) {
+  for (; position < endPosition; position++) {
     if (
       input.charCodeAt(position) === CharCode.Asterisk &&
       input.charCodeAt(position + 1) === CharCode.Slash
@@ -1033,6 +1219,26 @@ function skipMultiLineComment(
   }
 
   return [position, false];
+}
+
+function isConflictMarker(input: string, position: number, endPosition = input.length): boolean {
+  // Conflict markers must be at the start of a line.
+  const ch = input.charCodeAt(position);
+  if (position === 0 || isLineBreak(input.charCodeAt(position - 1))) {
+    if (position + mergeConflictMarkerLength < endPosition) {
+      for (let i = 0; i < mergeConflictMarkerLength; i++) {
+        if (input.charCodeAt(position + i) !== ch) {
+          return false;
+        }
+      }
+      return (
+        ch === CharCode.Equals ||
+        input.charCodeAt(position + mergeConflictMarkerLength) === CharCode.Space
+      );
+    }
+  }
+
+  return false;
 }
 
 function getTokenDisplayTable(entries: [Token, string][]): readonly string[] {

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -1316,12 +1316,12 @@ export interface DocReturnsTagNode extends DocTagBaseNode {
 
 export interface DocParamTagNode extends DocTagBaseNode {
   readonly kind: SyntaxKind.DocParamTag;
-  readonly name: IdentifierNode;
+  readonly paramName: IdentifierNode;
 }
 
 export interface DocTemplateTagNode extends DocTagBaseNode {
   readonly kind: SyntaxKind.DocTemplateTag;
-  readonly name: IdentifierNode;
+  readonly paramName: IdentifierNode;
 }
 
 export interface DocUnknownTagNode extends DocTagBaseNode {

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -583,6 +583,12 @@ export enum SyntaxKind {
   InvalidStatement,
   LineComment,
   BlockComment,
+  Doc,
+  DocText,
+  DocParamTag,
+  DocReturnsTag,
+  DocTemplateTag,
+  DocUnknownTag,
   Projection,
   ProjectionParameterDeclaration,
   ProjectionModelSelector,
@@ -648,6 +654,7 @@ export interface BaseNode extends TextRange {
   readonly kind: SyntaxKind;
   readonly parent?: Node;
   readonly directives?: readonly DirectiveExpressionNode[];
+  readonly docs?: readonly DocNode[];
   readonly flags: NodeFlags;
   /**
    * Could be undefined but making this optional creates a lot of noise. In practice,
@@ -681,6 +688,9 @@ export type Node =
   | Expression
   | FunctionParameterNode
   | Modifier
+  | DocNode
+  | DocContent
+  | DocTag
   | ProjectionStatementItem
   | ProjectionExpression
   | ProjectionModelSelectorNode
@@ -713,7 +723,10 @@ export interface BlockComment extends TextRange {
 }
 
 export interface ParseOptions {
+  /** When true, collect comment ranges in {@link CadlScriptNode.comments}. */
   readonly comments?: boolean;
+  /** When true, parse doc comments into {@link Node.docs}. */
+  readonly docs?: boolean;
 }
 
 export interface CadlScriptNode extends DeclarationNode, BaseNode {
@@ -1275,6 +1288,46 @@ export enum IdentifierKind {
   Declaration,
   Other,
 }
+
+// Doc-comment related syntax
+
+export interface DocNode extends BaseNode {
+  readonly kind: SyntaxKind.Doc;
+  readonly content: readonly DocContent[];
+  readonly tags: readonly DocTag[];
+}
+
+export interface DocTagBaseNode extends BaseNode {
+  readonly tagName: IdentifierNode;
+  readonly content: readonly DocContent[];
+}
+
+export type DocTag = DocReturnsTagNode | DocParamTagNode | DocTemplateTagNode | DocUnknownTagNode;
+export type DocContent = DocTextNode;
+
+export interface DocTextNode extends BaseNode {
+  readonly kind: SyntaxKind.DocText;
+  readonly text: string;
+}
+
+export interface DocReturnsTagNode extends DocTagBaseNode {
+  readonly kind: SyntaxKind.DocReturnsTag;
+}
+
+export interface DocParamTagNode extends DocTagBaseNode {
+  readonly kind: SyntaxKind.DocParamTag;
+  readonly name: IdentifierNode;
+}
+
+export interface DocTemplateTagNode extends DocTagBaseNode {
+  readonly kind: SyntaxKind.DocTemplateTag;
+  readonly name: IdentifierNode;
+}
+
+export interface DocUnknownTagNode extends DocTagBaseNode {
+  readonly kind: SyntaxKind.DocUnknownTag;
+}
+////
 
 /**
  * Identifies the position within a source file by line number and offset from

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -317,9 +317,10 @@ export function printNode(
     case SyntaxKind.DocTemplateTag:
     case SyntaxKind.DocReturnsTag:
     case SyntaxKind.DocUnknownTag:
+      // https://github.com/microsoft/cadl/issues/1319 Tracks pretty-printing doc comments.
       compilerAssert(
         false,
-        "Doc comments are handled as regular comments by formatter and parsing of them should be disabled when formatting."
+        "Currently, doc comments are only handled as regular comments and we do not opt in to parsing them so we shouldn't reach here."
       );
       return "";
     case SyntaxKind.JsSourceFile:

--- a/packages/compiler/formatter/print/printer.ts
+++ b/packages/compiler/formatter/print/printer.ts
@@ -1,4 +1,5 @@
 import prettier, { AstPath, Doc, Printer } from "prettier";
+import { compilerAssert } from "../../core/diagnostics.js";
 import { createScanner, Token } from "../../core/scanner.js";
 import {
   AliasStatementNode,
@@ -310,12 +311,21 @@ export function printNode(
       return path.call(print, "target");
     case SyntaxKind.Return:
       return printReturnExpression(path as AstPath<ReturnExpressionNode>, options, print);
+    case SyntaxKind.Doc:
+    case SyntaxKind.DocText:
+    case SyntaxKind.DocParamTag:
+    case SyntaxKind.DocTemplateTag:
+    case SyntaxKind.DocReturnsTag:
+    case SyntaxKind.DocUnknownTag:
+      compilerAssert(
+        false,
+        "Doc comments are handled as regular comments by formatter and parsing of them should be disabled when formatting."
+      );
+      return "";
     case SyntaxKind.JsSourceFile:
     case SyntaxKind.EmptyStatement:
     case SyntaxKind.InvalidStatement:
       return getRawText(node, options);
-    // default:
-    //   return getRawText(node, options);
     default:
       // Dummy const to ensure we handle all node types.
       // If you get an error here, add a case for the new node type

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -803,7 +803,7 @@ describe("compiler: parser", () => {
   });
 
   describe("conflict marker", () => {
-    // NOTE: Use of ${} to obfuscate conflict markers so that their not
+    // NOTE: Use of ${} to obfuscate conflict markers so that they're not
     // flagged while working on these tests.
     parseErrorEach(
       [

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -769,7 +769,7 @@ describe("compiler: parser", () => {
            * @param x the param
            * @template T some template
            * @returns something
-           * @madeup this an unknown tag
+           * @pretend this an unknown tag
            */
           op test<T>(x: string): string;
           `,
@@ -793,7 +793,7 @@ describe("compiler: parser", () => {
             strictEqual(docs[0].tags[2].tagName.sv, "returns");
             strictEqual(docs[0].tags[2].content[0].text, "something");
             strictEqual(docs[0].tags[3].kind, SyntaxKind.DocUnknownTag as const);
-            strictEqual(docs[0].tags[3].tagName.sv, "madeup");
+            strictEqual(docs[0].tags[3].tagName.sv, "pretend");
             strictEqual(docs[0].tags[3].content[0].text, "this an unknown tag");
           },
         ],

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -784,11 +784,11 @@ describe("compiler: parser", () => {
             strictEqual(docs[0].tags.length, 4);
             strictEqual(docs[0].tags[0].kind, SyntaxKind.DocParamTag as const);
             strictEqual(docs[0].tags[0].tagName.sv, "param");
-            strictEqual(docs[0].tags[0].name.sv, "x");
+            strictEqual(docs[0].tags[0].paramName.sv, "x");
             strictEqual(docs[0].tags[0].content[0].text, "the param");
             strictEqual(docs[0].tags[1].kind, SyntaxKind.DocTemplateTag as const);
             strictEqual(docs[0].tags[1].tagName.sv, "template");
-            strictEqual(docs[0].tags[1].name.sv, "T");
+            strictEqual(docs[0].tags[1].paramName.sv, "T");
             strictEqual(docs[0].tags[2].kind, SyntaxKind.DocReturnsTag as const);
             strictEqual(docs[0].tags[2].tagName.sv, "returns");
             strictEqual(docs[0].tags[2].content[0].text, "something");

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -2,7 +2,14 @@ import assert, { deepStrictEqual } from "assert";
 import { CharCode } from "../core/charcode.js";
 import { formatDiagnostic, logVerboseTestOutput } from "../core/diagnostics.js";
 import { hasParseError, parse, visitChildren } from "../core/parser.js";
-import { CadlScriptNode, Node, NodeFlags, SourceFile, SyntaxKind } from "../core/types.js";
+import {
+  CadlScriptNode,
+  Node,
+  NodeFlags,
+  ParseOptions,
+  SourceFile,
+  SyntaxKind,
+} from "../core/types.js";
 import { DiagnosticMatch, expectDiagnostics } from "../testing/expect.js";
 
 describe("compiler: parser", () => {
@@ -730,11 +737,80 @@ describe("compiler: parser", () => {
   describe("invalid statement", () => {
     parseErrorEach([["@myDecN.)", [/Identifier expected/]]]);
   });
+
+  describe("doc comments", () => {
+    parseEach(
+      [
+        `
+      /** One-liner */ 
+      model M {}
+      `,
+        `
+      /** 
+      * This one has a \`code span\` and a code fence and it spreads over
+      * more than one line.
+      *
+      * \`\`\`
+      * This is not a @tag because we're in a code fence.
+      * \`\`\`
+      *
+      * \`This is not a @tag either because we're in a code span\`.
+      * 
+      * @param x the param
+      * @template T some template
+      * @returns something
+      * @madeup this an unknown tag
+      */
+      op test<T>(x: string): string;
+      `,
+      ],
+      { docs: true }
+    );
+  });
+
+  describe("conflict marker", () => {
+    // NOTE: Use of ${} to obfuscate conflict markers so that their not
+    // flagged while working on these tests.
+    parseErrorEach(
+      [
+        [
+          `
+${"<<<<<<<"} ours
+model XY {}
+${"|||||||"} base
+model X {}
+${"======="}
+model XYZ {}
+${">>>>>>>"} theirs`,
+          [
+            { code: "conflict-marker", pos: 1, end: 8 },
+            { code: "conflict-marker", pos: 26, end: 33 },
+            { code: "conflict-marker", pos: 50, end: 57 },
+            { code: "conflict-marker", pos: 71, end: 78 },
+          ],
+        ],
+        [
+          `
+${"<<<<<<<"} ours
+model XY {}
+${"======="}
+model XYZ {}
+${">>>>>>>"} theirs`,
+          [
+            { code: "conflict-marker", pos: 1, end: 8 },
+            { code: "conflict-marker", pos: 26, end: 33 },
+            { code: "conflict-marker", pos: 47, end: 54 },
+          ],
+        ],
+      ],
+      { strict: true }
+    );
+  });
 });
 
 type Callback = (node: CadlScriptNode) => void;
 
-function parseEach(cases: (string | [string, Callback])[]) {
+function parseEach(cases: (string | [string, Callback])[], options?: ParseOptions) {
   for (const each of cases) {
     const code = typeof each === "string" ? each : each[0];
     const callback = typeof each === "string" ? undefined : each[1];
@@ -743,7 +819,7 @@ function parseEach(cases: (string | [string, Callback])[]) {
       logVerboseTestOutput(code);
 
       logVerboseTestOutput("\n=== Parse Result ===");
-      const astNode = parse(code);
+      const astNode = parse(code, options);
       if (callback) {
         callback(astNode);
       }
@@ -830,14 +906,14 @@ function checkPositioning(node: Node, file: SourceFile) {
  */
 function parseErrorEach(
   cases: [string, (RegExp | DiagnosticMatch)[], Callback?][],
-  options = { strict: false }
+  options: ParseOptions & { strict: boolean } = { strict: false }
 ) {
   for (const [code, matches, callback] of cases) {
     it(`doesn't parse '${shorten(code)}'`, () => {
       logVerboseTestOutput("=== Source ===");
       logVerboseTestOutput(code);
 
-      const astNode = parse(code);
+      const astNode = parse(code, options);
       if (callback) {
         callback(astNode);
       }


### PR DESCRIPTION
This is currently opt-in via ParseOptions.docs = true. It will need to become always-on or opt-out when we implement the doc unification proposal linked to #927, but pending more tests and perf measurement, it seemed prudent to keep it behind a flag for now. This should unblock website doc generation consumption while allowing further work in this area to be done in parallel.

Currently only `@param`, `@template`, and `@returns` (+ alternate spelling `@return`) are supported. Other tags are parsed as an "unknown" tag nodes. There is no diagnostic for unknown tags at this time.

`/**...*/` is still allowed in any position as trivia, but can be parsed to structured data when applied to one of the following nodes:

- any statement
- model property
- operation parameter
- interface operation
- union variant
- enum member

There is also a breaking change here for `#directives` for consistency. Directives are now also limited to the same set of nodes above. It seemed rather arbitrary that you could apply them to any list element and I have never seen them used in other positions like on a decorator/template/tuple argument. Release note: https://github.com/microsoft/cadl/issues/1263#issuecomment-1329690090

Single-line `code spans` are recognized as are multi-line code blocks fenced by triple backticks. Inside these code regions, `@` can be used as content and will not be parsed as a tag.

Finally, this includes a fix for merge conflict marker scanning. Although we returned conflict marker tokens, we did not skip the right parts of the input and therefore did not achieve the desired good error recovery in the presence of conflict markers.

Fix #719 