### PR TITLE
Omit `never` metadata properties in openapi3 and document for other emitter/users

### DIFF
--- a/common/changes/@cadl-lang/openapi3/docs-never-props_2022-11-30-21-19.json
+++ b/common/changes/@cadl-lang/openapi3/docs-never-props_2022-11-30-21-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Omit metadata properties of type `never`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/docs/language-basics/models.md
+++ b/docs/language-basics/models.md
@@ -52,7 +52,7 @@ model Dog {
 
 #### `never`
 
-A record property can be declared as having the type never. This should mean that the record shouldn't be having that property.
+A model property can be declared as having the type never. This can be interpreted as the model not having that property.
 
 This can be useful in model template to omit a property.
 

--- a/docs/language-basics/models.md
+++ b/docs/language-basics/models.md
@@ -48,6 +48,28 @@ model Dog {
 }
 ```
 
+### Special property types
+
+#### `never`
+
+A record property can be declared as having the type never. This should mean that the record shouldn't be having that property.
+
+This can be useful in model template to omit a property.
+
+```cadl
+model Address<TState> {
+  state: TState;
+  city: string;
+  street: string;
+}
+
+model UKAddress is Address<never>;
+```
+
+:::note
+That is still up to the emitter to be removing `never` properties. Cadl compiler will not automatically omit those.
+:::
+
 ### Array
 
 Array are models created using the `[]` syntax which is just a syntactic sugar for using the `Array<T>` model type.

--- a/docs/language-basics/models.md
+++ b/docs/language-basics/models.md
@@ -54,7 +54,7 @@ model Dog {
 
 A model property can be declared as having the type never. This can be interpreted as the model not having that property.
 
-This can be useful in model template to omit a property.
+This can be useful in a model template to omit a property.
 
 ```cadl
 model Address<TState> {

--- a/docs/language-basics/models.md
+++ b/docs/language-basics/models.md
@@ -67,7 +67,7 @@ model UKAddress is Address<never>;
 ```
 
 :::note
-That is still up to the emitter to be removing `never` properties. Cadl compiler will not automatically omit those.
+It is up to the emitter to remove `never` properties. The Cadl compiler will not automatically omit them.
 :::
 
 ### Array

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -717,6 +717,9 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
   }
 
   function emitParameter(parameter: HttpOperationParameter, visibility: Visibility) {
+    if (isNeverType(parameter.param.type)) {
+      return;
+    }
     const ph = getParamPlaceholder(parameter.param);
     currentEndpoint.parameters.push(ph);
 

--- a/packages/openapi3/test/parameters.test.ts
+++ b/packages/openapi3/test/parameters.test.ts
@@ -130,6 +130,17 @@ describe("openapi3: parameters", () => {
     ]);
   });
 
+  it("omit parameters with type never", async () => {
+    const res = await openApiFor(
+      `
+      op test(@query select: never, @query top: int32): void;
+      `
+    );
+    strictEqual(res.paths["/"].get.parameters.length, 1);
+    strictEqual(res.paths["/"].get.parameters[0].in, "query");
+    strictEqual(res.paths["/"].get.parameters[0].name, "top");
+  });
+
   describe("content type parameter", () => {
     it("header named with 'Content-Type' gets resolved as content type for operation.", async () => {
       const res = await openApiFor(


### PR DESCRIPTION
fix [#1200](https://github.com/microsoft/cadl/issues/1200)
<img width="997" alt="image" src="https://user-images.githubusercontent.com/1031227/204908343-05a01fdd-f1b1-4e26-843d-8933878d62db.png">
