### PR TITLE
New `emit` and `options` config and compiler options replacing `emitters`

### DIFF
--- a/common/changes/@cadl-lang/compiler/emit-options-consistency_2022-12-02-01-32.json
+++ b/common/changes/@cadl-lang/compiler/emit-options-consistency_2022-12-02-01-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "**Deprecation** Split `emitters` in cadl-project.yaml and compiler in 2 option `emit` and `options` that makes it consistent with the CLI",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/openapi3/emit-options-consistency_2022-12-02-01-32.json
+++ b/common/changes/@cadl-lang/openapi3/emit-options-consistency_2022-12-02-01-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Internal: Update tests to change from `emitters` compiler options to `emit` and `options`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/compiler/config/config-interpolation.ts
+++ b/packages/compiler/config/config-interpolation.ts
@@ -1,7 +1,7 @@
 import { createDiagnosticCollector, ignoreDiagnostics } from "../core/diagnostics.js";
 import { createDiagnostic } from "../core/messages.js";
 import { Diagnostic, NoTarget } from "../core/types.js";
-import { CadlConfig, ConfigEnvironmentVariable, ConfigParameter } from "./types.js";
+import { CadlConfig, ConfigEnvironmentVariable, ConfigParameter, EmitterOptions } from "./types.js";
 
 export interface ExpandConfigOptions {
   readonly cwd: string;
@@ -12,31 +12,34 @@ export interface ExpandConfigOptions {
 
 export function expandConfigVariables(
   config: CadlConfig,
-  options: ExpandConfigOptions
+  expandOptions: ExpandConfigOptions
 ): [CadlConfig, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
   const builtInVars = {
     "project-root": config.projectRoot,
-    cwd: options.cwd,
+    cwd: expandOptions.cwd,
   };
 
   const commonVars = {
     ...builtInVars,
-    ...diagnostics.pipe(resolveArgs(config.parameters, options.args, builtInVars)),
-    env: diagnostics.pipe(resolveArgs(config.environmentVariables, options.env, builtInVars)),
+    ...diagnostics.pipe(resolveArgs(config.parameters, expandOptions.args, builtInVars)),
+    env: diagnostics.pipe(resolveArgs(config.environmentVariables, expandOptions.env, builtInVars)),
   };
   const outputDir = diagnostics.pipe(
-    resolveValue(options.outputDir ?? config.outputDir, commonVars)
+    resolveValue(expandOptions.outputDir ?? config.outputDir, commonVars)
   );
 
-  const emitters: Record<string, Record<string, unknown>> = {};
-
-  for (const [name, emitterOptions] of Object.entries(config.emitters)) {
-    const emitterVars = { ...commonVars, "output-dir": outputDir, "emitter-name": name };
-    emitters[name] = diagnostics.pipe(resolveValues(emitterOptions, emitterVars));
+  const result = { ...config, outputDir };
+  if (config.options) {
+    const options: Record<string, EmitterOptions> = {};
+    for (const [name, emitterOptions] of Object.entries(config.options)) {
+      const emitterVars = { ...commonVars, "output-dir": outputDir, "emitter-name": name };
+      options[name] = diagnostics.pipe(resolveValues(emitterOptions, emitterVars));
+    }
+    result.options = options;
   }
 
-  return diagnostics.wrap({ ...config, outputDir, emitters });
+  return diagnostics.wrap(result);
 }
 
 function resolveArgs(

--- a/packages/compiler/config/config-loader.ts
+++ b/packages/compiler/config/config-loader.ts
@@ -116,6 +116,16 @@ async function loadConfigFile(
 
   // @deprecated Legacy backward compatibility of emitters option. To remove March Sprint.
   if (data.emitters) {
+    diagnostics.push(
+      createDiagnostic({
+        code: "deprecated",
+        format: {
+          message:
+            "`emitters` options in cadl-project.yaml is deprecated use `emit` and `options` instead.",
+        },
+        target: NoTarget,
+      })
+    );
     emit = [];
     options = {};
     for (const [name, emitterOptions] of Object.entries(data.emitters)) {

--- a/packages/compiler/config/config-schema.ts
+++ b/packages/compiler/config/config-schema.ts
@@ -65,6 +65,17 @@ export const CadlConfigJsonSchema: JSONSchemaType<CadlRawConfig> = {
       nullable: true,
       items: { type: "string" },
     },
+    emit: {
+      type: "array",
+      nullable: true,
+      items: { type: "string" },
+    },
+    options: {
+      type: "object",
+      nullable: true,
+      required: [],
+      additionalProperties: emitterOptionsSchema,
+    },
     emitters: {
       type: "object",
       nullable: true,

--- a/packages/compiler/config/types.ts
+++ b/packages/compiler/config/types.ts
@@ -55,9 +55,14 @@ export interface CadlConfig {
   imports?: string[];
 
   /**
-   * Emitter configuration
+   * Name of emitters or path to emitters that should be used.
    */
-  emitters: Record<string, EmitterOptions>;
+  emit?: string[];
+
+  /**
+   * Name of emitters or path to emitters that should be used.
+   */
+  options?: Record<string, EmitterOptions>;
 }
 
 /**
@@ -72,6 +77,9 @@ export interface CadlRawConfig {
   "output-dir"?: string;
   trace?: string | string[];
   imports?: string[];
+
+  emit?: string[];
+  options?: Record<string, EmitterOptions>;
   emitters?: Record<string, boolean | EmitterOptions>;
 }
 

--- a/packages/compiler/core/cli/args.ts
+++ b/packages/compiler/core/cli/args.ts
@@ -5,7 +5,7 @@ import { createDiagnosticCollector } from "../index.js";
 import { CompilerOptions } from "../options.js";
 import { resolvePath } from "../path-utils.js";
 import { CompilerHost, Diagnostic } from "../types.js";
-import { omitUndefined } from "../util.js";
+import { deepClone, omitUndefined } from "../util.js";
 
 export interface CompileCliArgs {
   "output-dir"?: string;
@@ -128,14 +128,14 @@ function resolveEmitteroptions(
   config: CadlConfig,
   cliOptions: Record<string | "miscOptions", Record<string, unknown>>
 ): Record<string, EmitterOptions> {
-  const configuredEmitters: Record<string, Record<string, unknown>> = {};
+  const configuredEmitters: Record<string, Record<string, unknown>> = deepClone(
+    config.options ?? {}
+  );
 
-  for (const [emitterName, emitterConfig] of Object.entries(config.options ?? {})) {
-    const cliOptionOverride = cliOptions[emitterName];
-
+  for (const [emitterName, cliOptionOverride] of Object.entries(cliOptions)) {
     configuredEmitters[emitterName] = {
-      ...emitterConfig,
-      ...(cliOptionOverride ?? {}),
+      ...(configuredEmitters[emitterName] ?? {}),
+      ...cliOptionOverride,
     };
   }
 

--- a/packages/compiler/core/cli/cli.ts
+++ b/packages/compiler/core/cli/cli.ts
@@ -342,8 +342,10 @@ async function getCompilerOptionsOrExit(
   args: CompileCliArgs
 ): Promise<CompilerOptions> {
   const [options, diagnostics] = await getCompilerOptions(host, process.cwd(), args, process.env);
-  if (options === undefined) {
+  if (diagnostics.length > 0) {
     logDiagnostics(diagnostics, host.logSink);
+  }
+  if (options === undefined) {
     logDiagnosticCount(diagnostics);
     process.exit(1);
   }

--- a/packages/compiler/core/messages.ts
+++ b/packages/compiler/core/messages.ts
@@ -559,10 +559,16 @@ const diagnostics = {
       default: paramMessage`onValidate failed with errors. ${"error"}`,
     },
   },
-  "emitter-not-found": {
+  "invalid-emitter": {
     severity: "error",
     messages: {
       default: paramMessage`Requested emitter package ${"emitterPackage"} does not provide an "onEmit" function.`,
+    },
+  },
+  "emitter-not-found": {
+    severity: "error",
+    messages: {
+      default: paramMessage`Emitter with name ${"emitterName"} is not found.`,
     },
   },
   "missing-import": {

--- a/packages/compiler/core/options.ts
+++ b/packages/compiler/core/options.ts
@@ -1,3 +1,4 @@
+import { EmitterOptions } from "../config/types.js";
 import { ParseOptions } from "./types.js";
 
 export interface CompilerOptions {
@@ -14,7 +15,24 @@ export interface CompilerOptions {
    */
   outputPath?: string;
 
-  emitters?: Record<string, Record<string, unknown>>;
+  /**
+   * List or path to emitters to use.
+   */
+  emit?: string[];
+
+  /**
+   * Emitter options.
+   * Key value pair where the key must be the emitter name.
+   */
+  options?: Record<string, EmitterOptions>;
+
+  /**
+   * @deprecated use {@link emit} and {@link options} instead.
+   *
+   * Will be removed in March 2022 sprint.
+   */
+  emitters?: Record<string, EmitterOptions>;
+
   nostdlib?: boolean;
   noEmit?: boolean;
   additionalImports?: string[];

--- a/packages/compiler/server/serverlib.ts
+++ b/packages/compiler/server/serverlib.ts
@@ -416,7 +416,8 @@ export function createServer(host: ServerHost): Server {
 
     const options = {
       ...serverOptions,
-      emitters: config.emitters,
+      emit: config.emit,
+      options: config.options,
     };
 
     if (!upToDate(document)) {

--- a/packages/compiler/test/cli.test.ts
+++ b/packages/compiler/test/cli.test.ts
@@ -29,8 +29,8 @@ describe("compiler: cli", () => {
     it("no args and config: return empty options with output-dir at {cwd}/cadl-output", async () => {
       const options = await resolveCompilerOptions({});
       deepStrictEqual(options, {
-        emitters: {},
         outputDir: `${cwd}/cadl-output`,
+        options: {},
       });
     });
 
@@ -44,7 +44,8 @@ describe("compiler: cli", () => {
                 default: "/default-arg-value",
               },
             },
-            emitters: {
+            emit: ["@cadl-lang/openapi3", "@cadl-lang/with-args"],
+            options: {
               "@cadl-lang/openapi3": {
                 "emitter-output-dir": "{output-dir}/custom",
               },
@@ -60,7 +61,7 @@ describe("compiler: cli", () => {
         const options = await resolveCompilerOptions({});
 
         strictEqual(
-          options?.emitters?.["@cadl-lang/openapi3"]?.["emitter-output-dir"],
+          options?.options?.["@cadl-lang/openapi3"]?.["emitter-output-dir"],
           `${cwd}/cadl-output/custom`
         );
       });
@@ -69,7 +70,7 @@ describe("compiler: cli", () => {
         const options = await resolveCompilerOptions({ "output-dir": `${cwd}/my-output-dir` });
 
         strictEqual(
-          options?.emitters?.["@cadl-lang/openapi3"]?.["emitter-output-dir"],
+          options?.options?.["@cadl-lang/openapi3"]?.["emitter-output-dir"],
           `${cwd}/my-output-dir/custom`
         );
       });
@@ -80,7 +81,7 @@ describe("compiler: cli", () => {
         });
 
         strictEqual(
-          options?.emitters?.["@cadl-lang/openapi3"]?.["emitter-output-dir"],
+          options?.options?.["@cadl-lang/openapi3"]?.["emitter-output-dir"],
           `${cwd}/relative-to-cwd`
         );
       });
@@ -90,7 +91,7 @@ describe("compiler: cli", () => {
           const options = await resolveCompilerOptions({});
 
           strictEqual(
-            options?.emitters?.["@cadl-lang/with-args"]?.["emitter-output-dir"],
+            options?.options?.["@cadl-lang/with-args"]?.["emitter-output-dir"],
             `/default-arg-value/custom`
           );
         });
@@ -101,7 +102,7 @@ describe("compiler: cli", () => {
           });
 
           strictEqual(
-            options?.emitters?.["@cadl-lang/with-args"]?.["emitter-output-dir"],
+            options?.options?.["@cadl-lang/with-args"]?.["emitter-output-dir"],
             `/my-updated-arg-value/custom`
           );
         });

--- a/packages/compiler/test/config/config-interpolation.test.ts
+++ b/packages/compiler/test/config/config-interpolation.test.ts
@@ -211,7 +211,7 @@ describe("compiler: config interpolation", () => {
         ...defaultConfig,
         projectRoot: "/dev/ws",
         outputDir: "/my-custom-output-dir",
-        emitters: {
+        options: {
           emitter1: {
             "emitter-output-dir": "{output-dir}/emitter1",
           },
@@ -220,7 +220,7 @@ describe("compiler: config interpolation", () => {
       const resolved = expectExpandConfigVariables(config, { cwd: "/dev/wd" });
       deepStrictEqual(resolved, {
         ...config,
-        emitters: {
+        options: {
           emitter1: {
             "emitter-output-dir": "/my-custom-output-dir/emitter1",
           },
@@ -233,7 +233,7 @@ describe("compiler: config interpolation", () => {
         ...defaultConfig,
         projectRoot: "/dev/ws",
         outputDir: "/my-custom-output-dir",
-        emitters: {
+        options: {
           emitter1: {
             "emitter-output-dir": "{output-dir}/{emitter-folder}",
             "emitter-folder": "custom-1",
@@ -243,7 +243,7 @@ describe("compiler: config interpolation", () => {
       const resolved = expectExpandConfigVariables(config, { cwd: "/dev/wd" });
       deepStrictEqual(resolved, {
         ...config,
-        emitters: {
+        options: {
           emitter1: {
             "emitter-output-dir": "/my-custom-output-dir/custom-1",
             "emitter-folder": "custom-1",

--- a/packages/compiler/test/config/config.test.ts
+++ b/packages/compiler/test/config/config.test.ts
@@ -26,7 +26,7 @@ describe("compiler: config file loading", () => {
       deepStrictEqual(config, {
         diagnostics: [],
         outputDir: "{cwd}/cadl-output",
-        emitters: { openapi: {} },
+        emit: ["openapi"],
       });
     });
 
@@ -36,7 +36,7 @@ describe("compiler: config file loading", () => {
         diagnostics: [],
         extends: "./cadl-base.yaml",
         outputDir: "{cwd}/cadl-output",
-        emitters: { openapi: {} },
+        emit: ["openapi"],
       });
     });
 
@@ -45,33 +45,26 @@ describe("compiler: config file loading", () => {
       deepStrictEqual(config, {
         diagnostics: [],
         outputDir: "{cwd}/cadl-output",
-        emitters: {},
       });
     });
 
     it("deep clones defaults when not found", async () => {
       let config = await loadTestConfig("empty");
-      config.emitters["x"] = {};
-
       config = await loadTestConfig("empty");
       deepStrictEqual(config, {
         diagnostics: [],
         outputDir: "{cwd}/cadl-output",
-        emitters: {},
       });
     });
 
     it("deep clones defaults when found", async () => {
       let config = await loadTestConfig("simple");
-      config.emitters["x"] = {};
 
       config = await loadTestConfig("simple");
       deepStrictEqual(config, {
         diagnostics: [],
         outputDir: "{cwd}/cadl-output",
-        emitters: {
-          openapi: {},
-        },
+        emit: ["openapi"],
       });
     });
   });

--- a/packages/compiler/test/config/scenarios/extends/cadl-base.yaml
+++ b/packages/compiler/test/config/scenarios/extends/cadl-base.yaml
@@ -1,2 +1,2 @@
-emitters:
-  openapi: true
+emit:
+  - openapi

--- a/packages/compiler/test/config/scenarios/simple/cadl-project.yaml
+++ b/packages/compiler/test/config/scenarios/simple/cadl-project.yaml
@@ -1,3 +1,3 @@
 # This has comments
-emitters:
-  openapi: true
+emit:
+  - openapi

--- a/packages/compiler/test/e2e/scenarios/scenarios.e2e.ts
+++ b/packages/compiler/test/e2e/scenarios/scenarios.e2e.ts
@@ -34,7 +34,7 @@ describe("compiler: entrypoints", () => {
 
     it("compile library with Cadl entrypoint and emitter", async () => {
       const program = await compileScenario("emitter-with-cadl", {
-        emitters: { "@cadl-lang/test-emitter-with-cadl": {} },
+        emit: ["@cadl-lang/test-emitter-with-cadl"],
       });
       expectDiagnosticEmpty(program.diagnostics);
     });
@@ -53,7 +53,7 @@ describe("compiler: entrypoints", () => {
 
     it("emit diagnostics if emitter has invalid main", async () => {
       const program = await compileScenario("import-library-invalid", {
-        emitters: { "my-lib": {} },
+        emit: ["my-lib"],
       });
       expectDiagnostics(program.diagnostics, {
         code: "library-invalid",
@@ -63,7 +63,7 @@ describe("compiler: entrypoints", () => {
 
     it("emit diagnostics if emitter require import that is not imported", async () => {
       const program = await compileScenario("emitter-require-import", {
-        emitters: { "@cadl-lang/my-emitter": {} },
+        emit: ["@cadl-lang/my-emitter"],
       });
       expectDiagnostics(program.diagnostics, {
         code: "missing-import",
@@ -75,7 +75,7 @@ describe("compiler: entrypoints", () => {
       await rejects(
         () =>
           compileScenario("emitter-throw-error", {
-            emitters: { "@cadl-lang/my-emitter": {} },
+            emit: ["@cadl-lang/my-emitter"],
           }),
         new RegExp(
           [
@@ -90,7 +90,7 @@ describe("compiler: entrypoints", () => {
 
     it("succeed if required import from an emitter is imported", async () => {
       const program = await compileScenario("emitter-require-import", {
-        emitters: { "@cadl-lang/my-emitter": {} },
+        emit: ["@cadl-lang/my-emitter"],
         additionalImports: ["@cadl-lang/my-lib"],
       });
       expectDiagnosticEmpty(program.diagnostics);
@@ -98,14 +98,14 @@ describe("compiler: entrypoints", () => {
 
     it("succeed if loading different install of the same library at the same version", async () => {
       const program = await compileScenario("same-library-same-version", {
-        emitters: { "@cadl-lang/lib2": {} },
+        emit: ["@cadl-lang/lib2"],
       });
       expectDiagnosticEmpty(program.diagnostics);
     });
 
     it("emit error if loading different install of the same library at different version", async () => {
       const program = await compileScenario("same-library-diff-version", {
-        emitters: { "@cadl-lang/lib2": {} },
+        emit: ["@cadl-lang/lib2"],
       });
       expectDiagnostics(program.diagnostics, {
         code: "incompatible-library",

--- a/packages/openapi3/test/openapi-output.test.ts
+++ b/packages/openapi3/test/openapi-output.test.ts
@@ -13,7 +13,8 @@ describe("openapi3: output file", () => {
 
     const diagnostics = await runner.diagnose(code, {
       noEmit: false,
-      emitters: { "@cadl-lang/openapi3": { ...options, "output-file": outPath } },
+      emit: ["@cadl-lang/openapi3"],
+      options: { "@cadl-lang/openapi3": { ...options, "output-file": outPath } },
     });
 
     expectDiagnosticEmpty(diagnostics.filter((x) => x.code !== "@cadl-lang/rest/no-routes"));
@@ -58,7 +59,8 @@ describe("openapi3: types included", () => {
 
     const diagnostics = await runner.diagnose(code, {
       noEmit: false,
-      emitters: { "@cadl-lang/openapi3": { ...options, "output-file": outPath } },
+      emit: ["@cadl-lang/openapi3"],
+      options: { "@cadl-lang/openapi3": { ...options, "output-file": outPath } },
     });
 
     expectDiagnosticEmpty(diagnostics.filter((x) => x.code !== "@cadl-lang/rest/no-routes"));

--- a/packages/openapi3/test/test-host.ts
+++ b/packages/openapi3/test/test-host.ts
@@ -32,7 +32,7 @@ export async function createOpenAPITestRunner({
   return createTestWrapper(host, {
     wrapper: (code) => `${importAndUsings} ${code}`,
     compilerOptions: {
-      emitters: { "@cadl-lang/openapi3": {} },
+      emit: ["@cadl-lang/openapi3"],
     },
   });
 }
@@ -44,7 +44,8 @@ function versionedOutput(path: string, version: string) {
 export async function diagnoseOpenApiFor(code: string, options: OpenAPI3EmitterOptions = {}) {
   const runner = await createOpenAPITestRunner();
   const diagnostics = await runner.diagnose(code, {
-    emitters: { "@cadl-lang/openapi3": options as any },
+    emit: ["@cadl-lang/openapi3"],
+    options: { "@cadl-lang/openapi3": options as any },
   });
   return diagnostics.filter((x) => x.code !== "@cadl-lang/rest/no-routes");
 }
@@ -64,7 +65,8 @@ export async function openApiFor(
   );
   const diagnostics = await host.diagnose("./main.cadl", {
     noEmit: false,
-    emitters: { "@cadl-lang/openapi3": { ...options, "output-file": outPath } },
+    emit: ["@cadl-lang/openapi3"],
+    options: { "@cadl-lang/openapi3": { ...options, "output-file": outPath } },
   });
   expectDiagnosticEmpty(diagnostics.filter((x) => x.code !== "@cadl-lang/rest/no-routes"));
 

--- a/packages/openapi3/test/versioning.test.ts
+++ b/packages/openapi3/test/versioning.test.ts
@@ -114,7 +114,7 @@ describe("openapi3: versioning", () => {
     const runner = createTestWrapper(host, {
       autoImports: [...host.libraries.map((x) => x.name), "./test.js"],
       autoUsings: ["Cadl.Rest", "Cadl.Http", "OpenAPI", "Cadl.Versioning"],
-      compilerOptions: { emitters: { "@cadl-lang/openapi3": {} } },
+      compilerOptions: { emit: ["@cadl-lang/openapi3"] },
     });
 
     await runner.compile(`

--- a/packages/playground/src/components/playground.tsx
+++ b/packages/playground/src/components/playground.tsx
@@ -83,6 +83,11 @@ export const Playground: FunctionComponent<PlaygroundProps> = ({ host }) => {
       const program = await cadlCompiler.compile(host, "main.cadl", {
         outputDir: "cadl-output",
         emit: [PlaygroundManifest.defaultEmitter],
+        options: {
+          [PlaygroundManifest.defaultEmitter]: {
+            "emitter-output-dir": "cadl-output"
+          },
+        }
       });
       setInternalCompilerError(undefined);
       setProgram(program);

--- a/packages/playground/src/components/playground.tsx
+++ b/packages/playground/src/components/playground.tsx
@@ -85,9 +85,9 @@ export const Playground: FunctionComponent<PlaygroundProps> = ({ host }) => {
         emit: [PlaygroundManifest.defaultEmitter],
         options: {
           [PlaygroundManifest.defaultEmitter]: {
-            "emitter-output-dir": "cadl-output"
+            "emitter-output-dir": "cadl-output",
           },
-        }
+        },
       });
       setInternalCompilerError(undefined);
       setProgram(program);

--- a/packages/playground/src/components/playground.tsx
+++ b/packages/playground/src/components/playground.tsx
@@ -82,7 +82,7 @@ export const Playground: FunctionComponent<PlaygroundProps> = ({ host }) => {
     try {
       const program = await cadlCompiler.compile(host, "main.cadl", {
         outputDir: "cadl-output",
-        emitters: { [PlaygroundManifest.defaultEmitter]: {} },
+        emit: [PlaygroundManifest.defaultEmitter],
       });
       setInternalCompilerError(undefined);
       setProgram(program);

--- a/packages/samples/cadl-project.yaml
+++ b/packages/samples/cadl-project.yaml
@@ -1,2 +1,2 @@
-emitters:
-  "@cadl-lang/openapi3": true
+emit:
+  - "@cadl-lang/openapi3"


### PR DESCRIPTION
fix #1274
also fix #1211 (Emit error when using `--option` or `options` in config with an unknown emitter as key)