### PR TITLE
Fix: `miscOptions` being treated as an emitter option

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-misc-options_2022-12-02-21-34.json
+++ b/common/changes/@cadl-lang/compiler/fix-misc-options_2022-12-02-21-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix: miscOptions handling",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/docs/introduction/configuration/tracing.md
+++ b/docs/introduction/configuration/tracing.md
@@ -60,6 +60,7 @@ This is a list of the trace area used in the compiler
 
 | Area                        | Description                                                          |
 | --------------------------- | -------------------------------------------------------------------- |
+| `compiler.options`          | Log the resolved compiler options                                    |
 | `import-resolution.library` | Information related to the resolution of import libraries            |
 | `projection.log`            | Debug information logged by the `log()` function used in projections |
 | `bind.js`                   | Information when binding JS files                                    |

--- a/packages/compiler/core/cli/args.ts
+++ b/packages/compiler/core/cli/args.ts
@@ -48,7 +48,7 @@ export async function getCompilerOptions(
     warnAsError: args["warn-as-error"] ?? config.warnAsError,
     trace: args.trace ?? config.trace,
     emit: args.emit ?? config.emit,
-    options: resolveEmitteroptions(config, cliOptions),
+    options: resolveEmitterOptions(config, cliOptions),
   };
   const cliOutputDir = pathArg ? resolvePath(cwd, pathArg) : undefined;
 
@@ -124,7 +124,7 @@ function resolveCliOptions(
   return options;
 }
 
-function resolveEmitteroptions(
+function resolveEmitterOptions(
   config: CadlConfig,
   cliOptions: Record<string | "miscOptions", Record<string, unknown>>
 ): Record<string, EmitterOptions> {
@@ -133,6 +133,9 @@ function resolveEmitteroptions(
   );
 
   for (const [emitterName, cliOptionOverride] of Object.entries(cliOptions)) {
+    if (emitterName === "miscOptions") {
+      continue;
+    }
     configuredEmitters[emitterName] = {
       ...(configuredEmitters[emitterName] ?? {}),
       ...cliOptionOverride,

--- a/packages/compiler/core/cli/args.ts
+++ b/packages/compiler/core/cli/args.ts
@@ -109,6 +109,7 @@ function resolveCliOptions(
         options.miscOptions = {};
       }
       options.miscOptions[key] = optionParts[1];
+      continue;
     } else if (optionKeyParts.length > 2) {
       throw new Error(
         `The --option parameter value "${option}" must be in the format: <emitterName>.some-options=value`

--- a/packages/compiler/core/program.ts
+++ b/packages/compiler/core/program.ts
@@ -304,6 +304,8 @@ export async function compile(
     resolveTypeReference,
   };
 
+  trace("compiler.options", JSON.stringify(options, null, 2));
+
   function trace(area: string, message: string) {
     tracer.trace(area, message);
   }
@@ -335,7 +337,6 @@ export async function compile(
       emit ??= Object.keys(options.emitters);
       emitterOptions ??= options.emitters;
     }
-
     await loadEmitters(resolvedMain, emit ?? [], emitterOptions ?? {});
   }
 
@@ -622,7 +623,7 @@ export async function compile(
     // This is the emitter names under options that haven't been used. We need to check if it points to an emitter that wasn't loaded
     for (const emitterName of emitterThatShouldExists) {
       // attempt to resolve a node module with this name
-      const module = await resolveEmitterModuleAndEntrypoint(emitterName, mainFile);
+      const module = await resolveEmitterModuleAndEntrypoint(mainFile, emitterName);
       if (module?.entrypoint === undefined) {
         program.reportDiagnostic(
           createDiagnostic({
@@ -642,6 +643,7 @@ export async function compile(
     { module: ModuleResolutionResult; entrypoint: JsSourceFileNode | undefined } | undefined
   > {
     const basedir = getDirectoryPath(mainFile);
+
     // attempt to resolve a node module with this name
     const module = await resolveJSLibrary(emitterNameOrPath, basedir);
     if (!module) {

--- a/packages/compiler/test/cli.test.ts
+++ b/packages/compiler/test/cli.test.ts
@@ -34,6 +34,15 @@ describe("compiler: cli", () => {
       });
     });
 
+    it("--option without an emitter are moved to miscOptions", async () => {
+      const options = await resolveCompilerOptions({
+        options: [`test-debug=true`],
+      });
+
+      deepStrictEqual(options?.miscOptions, { "test-debug": "true" });
+      deepStrictEqual(options?.options, {});
+    });
+
     context("config file with emitters", () => {
       beforeEach(() => {
         host.addCadlFile(


### PR DESCRIPTION
PR #1357 contained some issue that make the sample regen fail in cadl-azure repo