### PR TITLE
Lock versions

### DIFF
--- a/common/changes/@cadl-lang/migrate/lock-versions_2022-12-05-17-34.json
+++ b/common/changes/@cadl-lang/migrate/lock-versions_2022-12-05-17-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/migrate",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/migrate"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -10,8 +10,10 @@
  */
 [
   {
-    "definitionName": "individualVersion",
-    "policyName": "cadl"
+    "definitionName": "lockStepVersion",
+    "policyName": "cadl",
+    "version": "0.37.0",
+    "nextBump": "minor"
   }
   // {
   //   /**

--- a/packages/migrate/src/migrate.ts
+++ b/packages/migrate/src/migrate.ts
@@ -26,7 +26,7 @@ async function loadCompiler<V extends CadlCompilerVersion>(version: V): Promise<
   try {
     return await import(`@cadl-lang/compiler-v${version}`);
   } catch {
-    return await import("@cadl-lang/compiler");
+    return (await import("@cadl-lang/compiler")) as any;
   }
 }
 

--- a/rush.json
+++ b/rush.json
@@ -52,7 +52,7 @@
       "packageName": "@cadl-lang/compiler",
       "projectFolder": "packages/compiler",
       "reviewCategory": "production",
-      "shouldPublish": true
+      "versionPolicyName": "cadl"
     },
     {
       "packageName": "@cadl-lang/samples",
@@ -74,7 +74,7 @@
       "packageName": "cadl-vscode",
       "projectFolder": "packages/cadl-vscode",
       "reviewCategory": "production",
-      "shouldPublish": true
+      "versionPolicyName": "cadl"
     },
     {
       // VS package not in @scope purely for symmetry with VSCode package
@@ -82,13 +82,67 @@
       "packageName": "cadl-vs",
       "projectFolder": "packages/cadl-vs",
       "reviewCategory": "production",
-      "shouldPublish": true
+      "versionPolicyName": "cadl"
     },
     {
       "packageName": "@cadl-lang/prettier-plugin-cadl",
       "projectFolder": "packages/prettier-plugin-cadl",
       "reviewCategory": "production",
-      "shouldPublish": true
+      "versionPolicyName": "cadl"
+    },
+    {
+      "packageName": "@cadl-lang/rest",
+      "projectFolder": "packages/rest",
+      "reviewCategory": "production",
+      "versionPolicyName": "cadl"
+    },
+    {
+      "packageName": "@cadl-lang/openapi",
+      "projectFolder": "packages/openapi",
+      "reviewCategory": "production",
+      "versionPolicyName": "cadl"
+    },
+    {
+      "packageName": "@cadl-lang/lint",
+      "projectFolder": "packages/lint",
+      "reviewCategory": "production",
+      "versionPolicyName": "cadl"
+    },
+    {
+      "packageName": "@cadl-lang/migrate",
+      "projectFolder": "packages/migrate",
+      "reviewCategory": "production",
+      "versionPolicyName": "cadl"
+    },
+    {
+      "packageName": "@cadl-lang/library-linter",
+      "projectFolder": "packages/library-linter",
+      "reviewCategory": "production",
+      "versionPolicyName": "cadl"
+    },
+    {
+      "packageName": "@cadl-lang/eslint-plugin",
+      "projectFolder": "packages/eslint-plugin-cadl",
+      "reviewCategory": "production",
+      "versionPolicyName": "cadl"
+    },
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "projectFolder": "packages/openapi3",
+      "reviewCategory": "production",
+      "versionPolicyName": "cadl"
+    },
+    {
+      "packageName": "@cadl-lang/html-program-viewer",
+      "projectFolder": "packages/html-program-viewer",
+      "reviewCategory": "production",
+      "versionPolicyName": "cadl"
+    },
+    {
+      "packageName": "@cadl-lang/versioning",
+      "projectFolder": "packages/versioning",
+      "reviewCategory": "production",
+      "versionPolicyName": "cadl"
     },
     {
       "packageName": "@cadl-lang/eslint-config-cadl",
@@ -108,60 +162,7 @@
       "reviewCategory": "production",
       "shouldPublish": false
     },
-    {
-      "packageName": "@cadl-lang/rest",
-      "projectFolder": "packages/rest",
-      "reviewCategory": "production",
-      "shouldPublish": true
-    },
-    {
-      "packageName": "@cadl-lang/openapi",
-      "projectFolder": "packages/openapi",
-      "reviewCategory": "production",
-      "shouldPublish": true
-    },
-    {
-      "packageName": "@cadl-lang/lint",
-      "projectFolder": "packages/lint",
-      "reviewCategory": "production",
-      "shouldPublish": true
-    },
-    {
-      "packageName": "@cadl-lang/migrate",
-      "projectFolder": "packages/migrate",
-      "reviewCategory": "production",
-      "shouldPublish": true
-    },
-    {
-      "packageName": "@cadl-lang/library-linter",
-      "projectFolder": "packages/library-linter",
-      "reviewCategory": "production",
-      "shouldPublish": true
-    },
-    {
-      "packageName": "@cadl-lang/eslint-plugin",
-      "projectFolder": "packages/eslint-plugin-cadl",
-      "reviewCategory": "production",
-      "shouldPublish": true
-    },
-    {
-      "packageName": "@cadl-lang/openapi3",
-      "projectFolder": "packages/openapi3",
-      "reviewCategory": "production",
-      "shouldPublish": true
-    },
-    {
-      "packageName": "@cadl-lang/html-program-viewer",
-      "projectFolder": "packages/html-program-viewer",
-      "reviewCategory": "production",
-      "shouldPublish": true
-    },
-    {
-      "packageName": "@cadl-lang/versioning",
-      "projectFolder": "packages/versioning",
-      "reviewCategory": "production",
-      "shouldPublish": true
-    },
+
     {
       "packageName": "@cadl-lang/playground",
       "projectFolder": "packages/playground",


### PR DESCRIPTION
fix #1366  Pinned compiler packages to `0.37.0` which was the compiler package version (next version will be `0.38.0`) 
