### PR TITLE
Fix issues with @added and @removed versioning decorators

### DIFF
--- a/common/changes/@cadl-lang/versioning/versioning-FixAddedRemoved_2022-12-06-22-36.json
+++ b/common/changes/@cadl-lang/versioning/versioning-FixAddedRemoved_2022-12-06-22-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "Fix issues with @added and @removed. Deprecate addedAfter and removedOnOrBefore. Added existsOnVersion.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/common/changes/@cadl-lang/versioning/versioning-FixAddedRemoved_2022-12-06-22-36.json
+++ b/common/changes/@cadl-lang/versioning/versioning-FixAddedRemoved_2022-12-06-22-36.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@cadl-lang/versioning",
-      "comment": "Fix issues with @added and @removed. Deprecate addedAfter and removedOnOrBefore. Added existsOnVersion.",
+      "comment": "Fix issues with @added and @removed. Deprecate addedAfter and removedOnOrBefore. Added existsAtVersion.",
       "type": "none"
     }
   ],

--- a/packages/versioning/lib/decorators.cadl
+++ b/packages/versioning/lib/decorators.cadl
@@ -12,7 +12,7 @@ extern dec removed(target: unknown, version: EnumMember);
 extern dec renamedFrom(target: unknown, version: EnumMember, oldName?: string);
 extern dec madeOptional(target: unknown, version: EnumMember);
 
-extern fn existsOnVersion(target: unknown, version: EnumMember): boolean;
+extern fn existsAtVersion(target: unknown, version: EnumMember): boolean;
 extern fn hasDifferentNameAtVersion(target: unknown, version: EnumMember): boolean;
 extern fn madeOptionalAfter(target: unknown, version: EnumMember): boolean;
 extern fn getVersionForEnumMember(target: unknown, version: EnumMember): boolean;

--- a/packages/versioning/lib/decorators.cadl
+++ b/packages/versioning/lib/decorators.cadl
@@ -12,9 +12,7 @@ extern dec removed(target: unknown, version: EnumMember);
 extern dec renamedFrom(target: unknown, version: EnumMember, oldName?: string);
 extern dec madeOptional(target: unknown, version: EnumMember);
 
-extern fn addedAfter(target: unknown, version: EnumMember): boolean;
-extern fn removedOnOrBefore(target: unknown, version: EnumMember): boolean;
+extern fn existsOnVersion(target: unknown, version: EnumMember): boolean;
 extern fn hasDifferentNameAtVersion(target: unknown, version: EnumMember): boolean;
-extern fn renamedAfter(target: unknown, version: EnumMember): boolean;
 extern fn madeOptionalAfter(target: unknown, version: EnumMember): boolean;
 extern fn getVersionForEnumMember(target: unknown, version: EnumMember): boolean;

--- a/packages/versioning/lib/versioning.cadl
+++ b/packages/versioning/lib/versioning.cadl
@@ -6,7 +6,7 @@ using Cadl.Versioning;
 #suppress "projections-are-experimental"
 projection op#v {
   to(version) {
-    if !existsOnVersion(self, version) {
+    if !existsAtVersion(self, version) {
       return never;
     };
     if hasDifferentNameAtVersion(self, version) {
@@ -14,7 +14,7 @@ projection op#v {
     };
   }
   from(version) {
-    if !existsOnVersion(self, version) {
+    if !existsAtVersion(self, version) {
       return never;
     };
     if hasDifferentNameAtVersion(self, version) {
@@ -26,20 +26,20 @@ projection op#v {
 #suppress "projections-are-experimental"
 projection interface#v {
   to(version) {
-    if !existsOnVersion(self, version) {
+    if !existsAtVersion(self, version) {
       return never;
     };
     if hasDifferentNameAtVersion(self, version) {
       self::rename(getNameAtVersion(self, version));
     };
     self::operations::forEach((operation) => {
-      if !existsOnVersion(operation, version) {
+      if !existsAtVersion(operation, version) {
         self::deleteOperation(operation::name);
       };
     });
   }
   from(version) {
-    if !existsOnVersion(self, version) {
+    if !existsAtVersion(self, version) {
       return never;
     } else {
       if hasDifferentNameAtVersion(self, version) {
@@ -47,7 +47,7 @@ projection interface#v {
       };
 
       self::projectionBase::operations::forEach((operation) => {
-        if !existsOnVersion(operation, version) {
+        if !existsAtVersion(operation, version) {
           self::addOperation(operation::name, operation::parameters, operation::returnType);
         };
       });
@@ -58,7 +58,7 @@ projection interface#v {
 #suppress "projections-are-experimental"
 projection union#v {
   to(version) {
-    if !existsOnVersion(self, version) {
+    if !existsAtVersion(self, version) {
       return never;
     } else {
       if hasDifferentNameAtVersion(self, version) {
@@ -66,7 +66,7 @@ projection union#v {
       };
 
       self::variants::forEach((variant) => {
-        if !existsOnVersion(variant, version) {
+        if !existsAtVersion(variant, version) {
           self::deleteVariant(variant::name);
         } else if hasDifferentNameAtVersion(variant, version) {
           self::renameVariant(variant::name, getNameAtVersion(variant, version));
@@ -75,7 +75,7 @@ projection union#v {
     };
   }
   from(version) {
-    if !existsOnVersion(self, version) {
+    if !existsAtVersion(self, version) {
       return never;
     } else {
       if hasDifferentNameAtVersion(self, version) {
@@ -83,7 +83,7 @@ projection union#v {
       };
 
       self::projectionBase::variants::forEach((variant) => {
-        if !existsOnVersion(variant, version) {
+        if !existsAtVersion(variant, version) {
           self::addVariant(variant::name, variant::type);
         } else if hasDifferentNameAtVersion(variant, version) {
           self::renameVariant(getNameAtVersion(variant, version), variant::name);
@@ -96,7 +96,7 @@ projection union#v {
 #suppress "projections-are-experimental"
 projection model#v {
   to(version) {
-    if !existsOnVersion(self, version) {
+    if !existsAtVersion(self, version) {
       return never;
     } else {
       if hasDifferentNameAtVersion(self, version) {
@@ -104,7 +104,7 @@ projection model#v {
       };
 
       self::properties::forEach((p) => {
-        if !existsOnVersion(p, version) {
+        if !existsAtVersion(p, version) {
           self::deleteProperty(p::name);
         };
 
@@ -119,7 +119,7 @@ projection model#v {
     };
   }
   from(version) {
-    if !existsOnVersion(self, version) {
+    if !existsAtVersion(self, version) {
       return never;
     } else {
       if hasDifferentNameAtVersion(self, version) {
@@ -127,7 +127,7 @@ projection model#v {
       };
 
       self::projectionBase::properties::forEach((p) => {
-        if !existsOnVersion(p, version) {
+        if !existsAtVersion(p, version) {
           self::addProperty(p::name, p::type);
         };
 
@@ -146,7 +146,7 @@ projection model#v {
 #suppress "projections-are-experimental"
 projection enum#v {
   to(version) {
-    if !existsOnVersion(self, version) {
+    if !existsAtVersion(self, version) {
       return never;
     } else {
       if hasDifferentNameAtVersion(self, version) {
@@ -154,7 +154,7 @@ projection enum#v {
       };
 
       self::members::forEach((m) => {
-        if !existsOnVersion(m, version) {
+        if !existsAtVersion(m, version) {
           self::deleteMember(m::name);
         };
 
@@ -165,7 +165,7 @@ projection enum#v {
     };
   }
   from(version) {
-    if !existsOnVersion(self, version) {
+    if !existsAtVersion(self, version) {
       return never;
     } else {
       if hasDifferentNameAtVersion(self, version) {
@@ -173,7 +173,7 @@ projection enum#v {
       };
 
       self::projectionBase::members::forEach((m) => {
-        if !existsOnVersion(m, version, self::projectionBase) {
+        if !existsAtVersion(m, version, self::projectionBase) {
           self::addMember(m::name, m::type);
         };
 

--- a/packages/versioning/lib/versioning.cadl
+++ b/packages/versioning/lib/versioning.cadl
@@ -6,20 +6,18 @@ using Cadl.Versioning;
 #suppress "projections-are-experimental"
 projection op#v {
   to(version) {
-    if addedAfter(self, version) {
+    if !existsOnVersion(self, version) {
       return never;
-    } else if removedOnOrBefore(self, version) {
-      return never;
-    } else if hasDifferentNameAtVersion(self, version) {
+    };
+    if hasDifferentNameAtVersion(self, version) {
       self::rename(getNameAtVersion(self, version));
     };
   }
   from(version) {
-    if addedAfter(self, version) {
+    if !existsOnVersion(self, version) {
       return never;
-    } else if removedOnOrBefore(self, version) {
-      return never;
-    } else if hasDifferentNameAtVersion(self, version) {
+    };
+    if hasDifferentNameAtVersion(self, version) {
       self::rename(self::projectionBase::name);
     };
   }
@@ -28,28 +26,20 @@ projection op#v {
 #suppress "projections-are-experimental"
 projection interface#v {
   to(version) {
-    if addedAfter(self, version) {
+    if !existsOnVersion(self, version) {
       return never;
-    } else if removedOnOrBefore(self, version) {
-      return never;
-    } else {
-      if hasDifferentNameAtVersion(self, version) {
-        self::rename(getNameAtVersion(self, version));
-      };
-
-      self::operations::forEach((operation) => {
-        if addedAfter(operation, version) {
-          self::deleteOperation(operation::name);
-        } else if removedOnOrBefore(operation, version) {
-          self::deleteOperation(operation::name);
-        };
-      });
     };
+    if hasDifferentNameAtVersion(self, version) {
+      self::rename(getNameAtVersion(self, version));
+    };
+    self::operations::forEach((operation) => {
+      if !existsOnVersion(operation, version) {
+        self::deleteOperation(operation::name);
+      };
+    });
   }
   from(version) {
-    if addedAfter(self, version) {
-      return never;
-    } else if removedOnOrBefore(self, version) {
+    if !existsOnVersion(self, version) {
       return never;
     } else {
       if hasDifferentNameAtVersion(self, version) {
@@ -57,9 +47,7 @@ projection interface#v {
       };
 
       self::projectionBase::operations::forEach((operation) => {
-        if addedAfter(operation, version) {
-          self::addOperation(operation::name, operation::parameters, operation::returnType);
-        } else if removedOnOrBefore(operation, version) {
+        if !existsOnVersion(operation, version) {
           self::addOperation(operation::name, operation::parameters, operation::returnType);
         };
       });
@@ -70,9 +58,7 @@ projection interface#v {
 #suppress "projections-are-experimental"
 projection union#v {
   to(version) {
-    if addedAfter(self, version) {
-      return never;
-    } else if removedOnOrBefore(self, version) {
+    if !existsOnVersion(self, version) {
       return never;
     } else {
       if hasDifferentNameAtVersion(self, version) {
@@ -80,9 +66,7 @@ projection union#v {
       };
 
       self::variants::forEach((variant) => {
-        if addedAfter(variant, version) {
-          self::deleteVariant(variant::name);
-        } else if removedOnOrBefore(variant, version) {
+        if !existsOnVersion(variant, version) {
           self::deleteVariant(variant::name);
         } else if hasDifferentNameAtVersion(variant, version) {
           self::renameVariant(variant::name, getNameAtVersion(variant, version));
@@ -91,9 +75,7 @@ projection union#v {
     };
   }
   from(version) {
-    if addedAfter(self, version) {
-      return never;
-    } else if removedOnOrBefore(self, version) {
+    if !existsOnVersion(self, version) {
       return never;
     } else {
       if hasDifferentNameAtVersion(self, version) {
@@ -101,9 +83,7 @@ projection union#v {
       };
 
       self::projectionBase::variants::forEach((variant) => {
-        if addedAfter(variant, version) {
-          self::addVariant(variant::name, variant::type);
-        } else if removedOnOrBefore(variant, version) {
+        if !existsOnVersion(variant, version) {
           self::addVariant(variant::name, variant::type);
         } else if hasDifferentNameAtVersion(variant, version) {
           self::renameVariant(getNameAtVersion(variant, version), variant::name);
@@ -116,9 +96,7 @@ projection union#v {
 #suppress "projections-are-experimental"
 projection model#v {
   to(version) {
-    if addedAfter(self, version) {
-      return never;
-    } else if removedOnOrBefore(self, version) {
+    if !existsOnVersion(self, version) {
       return never;
     } else {
       if hasDifferentNameAtVersion(self, version) {
@@ -126,11 +104,7 @@ projection model#v {
       };
 
       self::properties::forEach((p) => {
-        if addedAfter(p, version) {
-          self::deleteProperty(p::name);
-        };
-
-        if removedOnOrBefore(p, version) {
+        if !existsOnVersion(p, version) {
           self::deleteProperty(p::name);
         };
 
@@ -145,9 +119,7 @@ projection model#v {
     };
   }
   from(version) {
-    if addedAfter(self, version) {
-      return never;
-    } else if removedOnOrBefore(self, version) {
+    if !existsOnVersion(self, version) {
       return never;
     } else {
       if hasDifferentNameAtVersion(self, version) {
@@ -155,11 +127,7 @@ projection model#v {
       };
 
       self::projectionBase::properties::forEach((p) => {
-        if addedAfter(p, version) {
-          self::addProperty(p::name, p::type);
-        };
-
-        if removedOnOrBefore(p, version) {
+        if !existsOnVersion(p, version) {
           self::addProperty(p::name, p::type);
         };
 
@@ -178,9 +146,7 @@ projection model#v {
 #suppress "projections-are-experimental"
 projection enum#v {
   to(version) {
-    if addedAfter(self, version) {
-      return never;
-    } else if removedOnOrBefore(self, version) {
+    if !existsOnVersion(self, version) {
       return never;
     } else {
       if hasDifferentNameAtVersion(self, version) {
@@ -188,11 +154,7 @@ projection enum#v {
       };
 
       self::members::forEach((m) => {
-        if addedAfter(m, version) {
-          self::deleteMember(m::name);
-        };
-
-        if removedOnOrBefore(m, version) {
+        if !existsOnVersion(m, version) {
           self::deleteMember(m::name);
         };
 
@@ -203,9 +165,7 @@ projection enum#v {
     };
   }
   from(version) {
-    if addedAfter(self, version) {
-      return never;
-    } else if removedOnOrBefore(self, version) {
+    if !existsOnVersion(self, version) {
       return never;
     } else {
       if hasDifferentNameAtVersion(self, version) {
@@ -213,11 +173,7 @@ projection enum#v {
       };
 
       self::projectionBase::members::forEach((m) => {
-        if addedAfter(m, version, self::projectionBase) {
-          self::addMember(m::name, m::type);
-        };
-
-        if removedOnOrBefore(m, version, self::projectionBase) {
+        if !existsOnVersion(m, version, self::projectionBase) {
           self::addMember(m::name, m::type);
         };
 

--- a/packages/versioning/src/lib.ts
+++ b/packages/versioning/src/lib.ts
@@ -54,7 +54,7 @@ const libDef = {
         removedBefore: paramMessage`'${"sourceName"}' was removed on version '${"sourceRemovedOn"}' but referencing type '${"targetName"}' removed in version '${"targetRemovedOn"}'.`,
         dependentRemovedBefore: paramMessage`'${"sourceName"}' was removed on version '${"sourceRemovedOn"}' but contains type '${"targetName"}' removed in version '${"targetRemovedOn"}'.`,
         versionedDependencyAddedAfter: paramMessage`'${"sourceName"}' is referencing type '${"targetName"}' added in version '${"targetAddedOn"}' but version used is ${"dependencyVersion"}.`,
-        versionedDependencyRemovedBefore: paramMessage`'${"sourceName"}' is referencing type '${"targetName"}' added in version '${"targetAddedOn"}' but version used is ${"dependencyVersion"}.`,
+        versionedDependencyRemovedBefore: paramMessage`'${"sourceName"}' is referencing type '${"targetName"}' removed in version '${"targetAddedOn"}' but version used is ${"dependencyVersion"}.`,
       },
     },
   },

--- a/packages/versioning/src/versioning.ts
+++ b/packages/versioning/src/versioning.ts
@@ -120,6 +120,7 @@ function getRenamedFrom(p: Program, t: Type): Array<RenamedFrom> | undefined {
 }
 
 /**
+ * @deprecated since version 0.39.0. Use getRenamedFromVersions
  * @returns version when the given type was added if applicable.
  */
 export function getRenamedFromVersion(p: Program, t: Type): Version | undefined {
@@ -139,6 +140,7 @@ export function getRenamedFromVersions(p: Program, t: Type): Version[] | undefin
 }
 
 /**
+ * @deprecated since version 0.39.0. Use getNameAtVersion instead.
  * @returns get old renamed name if applicable.
  */
 export function getRenamedFromOldName(p: Program, t: Type, v: ObjectType): string {
@@ -170,6 +172,7 @@ export function getNameAtVersion(p: Program, t: Type, v: ObjectType): string {
 }
 
 /**
+ * @deprecated since version 0.39.0.
  * @returns version when the given type was added if applicable.
  */
 export function getAddedOn(p: Program, t: Type): Version | undefined {
@@ -178,11 +181,20 @@ export function getAddedOn(p: Program, t: Type): Version | undefined {
 }
 
 /**
+ * @deprecated since version 0.39.0.
  * @returns version when the given type was removed if applicable.
  */
 export function getRemovedOn(p: Program, t: Type): Version | undefined {
   reportDeprecated(p, "Deprecated: getRemovedOn is deprecated.", t);
   return p.stateMap(removedOnKey).get(t)?.[0];
+}
+
+function getAddedOnVersions(p: Program, t: Type): Version[] | undefined {
+  return p.stateMap(addedOnKey).get(t) as Version[];
+}
+
+function getRemovedOnVersions(p: Program, t: Type): Version[] | undefined {
+  return p.stateMap(removedOnKey).get(t) as Version[];
 }
 
 /**
@@ -548,12 +560,26 @@ export function getVersions(p: Program, t: Type): [Namespace, VersionMap] | [] {
 
 // these decorators take a `versionSource` parameter because not all types can walk up to
 // the containing namespace. Model properties, for example.
+/**
+ * @deprecated since version 0.39.0. Use existsAtVersion instead.
+ * @param p
+ * @param type
+ * @param version
+ * @returns
+ */
 export function addedAfter(p: Program, type: Type, version: ObjectType) {
   reportDeprecated(p, "Deprecated: addedAfter is deprecated. Use existsAtVersion instead.", type);
   const appliesAt = appliesAtVersion(getAddedOn, p, type, version);
   return appliesAt === null ? false : !appliesAt;
 }
 
+/**
+ * @deprecated since version 0.39.0. Use existsAtVersion instead.
+ * @param p
+ * @param type
+ * @param version
+ * @returns
+ */
 export function removedOnOrBefore(p: Program, type: Type, version: ObjectType) {
   reportDeprecated(
     p,
@@ -594,8 +620,9 @@ export function getAvailabilityMap(
   // if unversioned then everything exists
   if (allVersions === undefined) return undefined;
 
-  const added = (program.stateMap(addedOnKey).get(type) as Version[]) ?? [];
-  const removed = (program.stateMap(removedOnKey).get(type) as Version[]) ?? [];
+  const added = getAddedOnVersions(program, type) ?? [];
+  const removed = getRemovedOnVersions(program, type) ?? [];
+
   // if there's absolutely no versioning information, return undefined
   // contextually, this might mean it inherits its versioning info from a parent
   // or that it is treated as unversioned
@@ -639,6 +666,13 @@ export function existsAtVersion(p: Program, type: Type, versionKey: ObjectType):
   return [Availability.Added, Availability.Available].includes(isAvail);
 }
 
+/**
+ * @deprecated since version 0.39.0. Use hasDifferentNameAtVersion instead.
+ * @param p
+ * @param type
+ * @param version
+ * @returns
+ */
 export function renamedAfter(p: Program, type: Type, version: ObjectType) {
   reportDeprecated(
     p,

--- a/packages/versioning/test/versioning.test.ts
+++ b/packages/versioning/test/versioning.test.ts
@@ -199,24 +199,26 @@ describe("compiler: versioning", () => {
       );
     });
 
-    it("can rename properties multiple times", async () => {
+    it("can add/remove properties multiple times", async () => {
       const {
         source,
-        projections: [v1, v2, v3, v4, v5],
+        projections: [v1, v2, v3, v4, v5, v6],
       } = await versionedModel(
-        ["v1", "v2", "v3", "v4", "v5"],
+        ["v1", "v2", "v3", "v4", "v5", "v6"],
         `model Test {
-          @renamedFrom(Versions.v2, "a")
-          @renamedFrom(Versions.v3, "b")
-          @renamedFrom(Versions.v5, "c")
-          d: int32;
+          @added(Versions.v2)
+          @removed(Versions.v3)
+          @added(Versions.v5)
+          @removed(Versions.v6)
+          val: int32;
         }`
       );
-      assertHasProperties(v1, ["a"]);
-      assertHasProperties(v2, ["b"]);
-      assertHasProperties(v3, ["c"]);
-      assertHasProperties(v4, ["c"]);
-      assertHasProperties(v5, ["d"]);
+      assertHasProperties(v1, []);
+      assertHasProperties(v2, ["val"]);
+      assertHasProperties(v3, []);
+      assertHasProperties(v4, []);
+      assertHasProperties(v5, ["val"]);
+      assertHasProperties(v6, []);
 
       assertModelProjectsTo(
         [
@@ -225,6 +227,7 @@ describe("compiler: versioning", () => {
           [v3, "v3"],
           [v4, "v4"],
           [v5, "v5"],
+          [v6, "v6"],
         ],
         source
       );


### PR DESCRIPTION
Fixes #1369 so that `@added` and `@removed` can be used multiple times on a symbol.

- Deprecates `addedAfter` and `removedOnOrBefore` since these assumed a single version
- Adds `existsOnVersion` which returns a boolean whether a given symbol should exists for a given version
