### PR TITLE
Implementation of `@typeChangedFrom` decorator

### DIFF
--- a/common/changes/@cadl-lang/compiler/versioning-changeType_2023-01-03-22-38.json
+++ b/common/changes/@cadl-lang/compiler/versioning-changeType_2023-01-03-22-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Added `changeReturnType` projection method for operations.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/versioning/versioning-changeType_2023-01-03-22-38.json
+++ b/common/changes/@cadl-lang/versioning/versioning-changeType_2023-01-03-22-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "Added `@returnTypeChangedFrom` decorator.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/packages/compiler/core/projection-members.ts
+++ b/packages/compiler/core/projection-members.ts
@@ -65,6 +65,20 @@ export function createProjectionMembers(checker: Checker): {
           return voidType;
         });
       },
+      changePropertyType(base) {
+        return createFunctionType((nameT: Type, newType: Type) => {
+          assertType("property name", nameT, "String");
+          const propertyName = nameT.value;
+
+          const prop = base.properties.get(propertyName);
+          if (!prop) {
+            throw new ProjectionError(`Property ${propertyName} not found`);
+          }
+          prop.type = newType;
+
+          return voidType;
+        });
+      },
       addProperty(base) {
         return createFunctionType((nameT: Type, type: Type, defaultT: Type) => {
           assertType("property", nameT, "String");
@@ -90,7 +104,6 @@ export function createProjectionMembers(checker: Checker): {
           return voidType;
         });
       },
-
       deleteProperty(base) {
         return createFunctionType((nameT: Type) => {
           assertType("property", nameT, "String");

--- a/packages/compiler/core/projection-members.ts
+++ b/packages/compiler/core/projection-members.ts
@@ -226,6 +226,12 @@ export function createProjectionMembers(checker: Checker): {
       returnType(base) {
         return base.returnType;
       },
+      changeReturnType(base) {
+        return createFunctionType((newType: Type) => {
+          base.returnType = newType;
+          return voidType;
+        });
+      },
     },
     Interface: {
       ...createBaseMembers(),

--- a/packages/versioning/lib/decorators.cadl
+++ b/packages/versioning/lib/decorators.cadl
@@ -11,6 +11,7 @@ extern dec added(target: unknown, version: EnumMember);
 extern dec removed(target: unknown, version: EnumMember);
 extern dec renamedFrom(target: unknown, version: EnumMember, oldName?: string);
 extern dec madeOptional(target: unknown, version: EnumMember);
+extern dec typeChangedFrom(target: unknown, version: EnumMember, oldType: unknown);
 
 extern fn existsAtVersion(target: unknown, version: EnumMember): boolean;
 extern fn hasDifferentNameAtVersion(target: unknown, version: EnumMember): boolean;

--- a/packages/versioning/lib/versioning.cadl
+++ b/packages/versioning/lib/versioning.cadl
@@ -12,7 +12,7 @@ projection op#v {
     if hasDifferentNameAtVersion(self, version) {
       self::rename(getNameAtVersion(self, version));
     };
-    if hasOldReturnTypeAtVersion(self, version) {
+    if hasDifferentReturnTypeAtVersion(self, version) {
       self::changeReturnType(getReturnTypeBeforeVersion(self, version));
     };
   }
@@ -39,7 +39,7 @@ projection interface#v {
       if !existsAtVersion(operation, version) {
         self::deleteOperation(operation::name);
       };
-      if hasOldReturnTypeAtVersion(operation, version) {
+      if hasDifferentReturnTypeAtVersion(operation, version) {
         operation::changeReturnType(getReturnTypeBeforeVersion(operation, version));
       };
     });
@@ -122,7 +122,7 @@ projection model#v {
           p::setOptional(false);
         };
 
-        if hasOldTypeAtVersion(p, version) {
+        if hasDifferentTypeAtVersion(p, version) {
           self::changePropertyType(p::name, getTypeBeforeVersion(p, version));
         };
       });
@@ -149,7 +149,7 @@ projection model#v {
           p::setOptional(true);
         };
 
-        if hasOldTypeAtVersion(p, version) {
+        if hasDifferentTypeAtVersion(p, version) {
           self::changePropertyType(p::name, p::type);
         };
       });

--- a/packages/versioning/lib/versioning.cadl
+++ b/packages/versioning/lib/versioning.cadl
@@ -115,6 +115,10 @@ projection model#v {
         if madeOptionalAfter(p, version) {
           p::setOptional(false);
         };
+
+        if hasOldTypeAtVersion(p, version) {
+          self::changePropertyType(p::name, getTypeBeforeVersion(p, version));
+        };
       });
     };
   }
@@ -137,6 +141,10 @@ projection model#v {
 
         if madeOptionalAfter(p, version) {
           p::setOptional(true);
+        };
+
+        if hasOldTypeAtVersion(p, version) {
+          self::changePropertyType(p::name, p::type);
         };
       });
     };

--- a/packages/versioning/lib/versioning.cadl
+++ b/packages/versioning/lib/versioning.cadl
@@ -12,6 +12,9 @@ projection op#v {
     if hasDifferentNameAtVersion(self, version) {
       self::rename(getNameAtVersion(self, version));
     };
+    if hasOldReturnTypeAtVersion(self, version) {
+      self::changeReturnType(getReturnTypeBeforeVersion(self, version));
+    };
   }
   from(version) {
     if !existsAtVersion(self, version) {
@@ -35,6 +38,9 @@ projection interface#v {
     self::operations::forEach((operation) => {
       if !existsAtVersion(operation, version) {
         self::deleteOperation(operation::name);
+      };
+      if hasOldReturnTypeAtVersion(operation, version) {
+        operation::changeReturnType(getReturnTypeBeforeVersion(operation, version));
       };
     });
   }

--- a/packages/versioning/src/versioning.ts
+++ b/packages/versioning/src/versioning.ts
@@ -240,17 +240,17 @@ export function getNameAtVersion(p: Program, t: Type, v: ObjectType): string {
 /**
  * @returns get old type if applicable.
  */
-export function getTypeBeforeVersion(p: Program, t: Type, v: ObjectType): any {
+export function getTypeBeforeVersion(p: Program, t: Type, v: ObjectType): Type | undefined {
   const target = toVersion(p, t, v);
   const map = getTypeChangedFrom(p, t);
-  if (!map || !target) return "";
+  if (!map || !target) return undefined;
 
   for (const [key, val] of map) {
     if (target.index < key.index) {
       return val;
     }
   }
-  return "";
+  return undefined;
 }
 
 /**
@@ -790,11 +790,15 @@ export function madeOptionalAfter(p: Program, type: Type, version: ObjectType): 
   return appliesAt === null ? false : !appliesAt;
 }
 
-export function hasOldTypeAtVersion(p: Program, type: Type, version: ObjectType): boolean {
-  return getTypeBeforeVersion(p, type, version) !== "";
+export function hasDifferentTypeAtVersion(p: Program, type: Type, version: ObjectType): boolean {
+  return getTypeBeforeVersion(p, type, version) !== undefined;
 }
 
-export function hasOldReturnTypeAtVersion(p: Program, type: Type, version: ObjectType): boolean {
+export function hasDifferentReturnTypeAtVersion(
+  p: Program,
+  type: Type,
+  version: ObjectType
+): boolean {
   return getReturnTypeBeforeVersion(p, type, version) !== "";
 }
 

--- a/packages/versioning/src/versioning.ts
+++ b/packages/versioning/src/versioning.ts
@@ -4,8 +4,10 @@ import {
   Enum,
   EnumMember,
   getNamespaceFullName,
+  ModelProperty,
   Namespace,
   ObjectType,
+  Operation,
   Program,
   ProjectionApplication,
   reportDeprecated,
@@ -85,7 +87,12 @@ export function getTypeChangedFrom(p: Program, t: Type): Map<Version, Type> | un
   return p.stateMap(typeChangedFromKey).get(t) as Map<Version, Type>;
 }
 
-export function $typeChangedFrom(context: DecoratorContext, t: Type, v: EnumMember, oldType: any) {
+export function $typeChangedFrom(
+  context: DecoratorContext,
+  prop: ModelProperty,
+  v: EnumMember,
+  oldType: any
+) {
   const { program } = context;
 
   const version = checkIsVersion(context.program, v, context.getArgumentTarget(0)!);
@@ -94,11 +101,11 @@ export function $typeChangedFrom(context: DecoratorContext, t: Type, v: EnumMemb
   }
 
   // retrieve statemap to update or create a new one
-  let record = getTypeChangedFrom(program, t) ?? new Map<Version, any>();
+  let record = getTypeChangedFrom(program, prop) ?? new Map<Version, any>();
   record.set(version, oldType);
   // ensure the map is sorted by version
   record = new Map([...record.entries()].sort((a, b) => a[0].index - b[0].index));
-  program.stateMap(typeChangedFromKey).set(t, record);
+  program.stateMap(typeChangedFromKey).set(prop, record);
 }
 
 /**
@@ -113,7 +120,7 @@ export function getReturnTypeChangedFrom(p: Program, t: Type): Map<Version, Type
 
 export function $returnTypeChangedFrom(
   context: DecoratorContext,
-  t: Type,
+  op: Operation,
   v: EnumMember,
   oldReturnType: any
 ) {
@@ -125,11 +132,11 @@ export function $returnTypeChangedFrom(
   }
 
   // retrieve statemap to update or create a new one
-  let record = getReturnTypeChangedFrom(program, t) ?? new Map<Version, any>();
+  let record = getReturnTypeChangedFrom(program, op) ?? new Map<Version, any>();
   record.set(version, oldReturnType);
   // ensure the map is sorted by version
   record = new Map([...record.entries()].sort((a, b) => a[0].index - b[0].index));
-  program.stateMap(returnTypeChangedFromKey).set(t, record);
+  program.stateMap(returnTypeChangedFromKey).set(op, record);
 }
 
 interface RenamedFrom {

--- a/packages/versioning/test/versioning.test.ts
+++ b/packages/versioning/test/versioning.test.ts
@@ -533,6 +533,24 @@ describe("compiler: versioning", () => {
       assertHasVariants(v2.returnType as Union, ["a", "b"]);
     });
 
+    it("can change return types", async () => {
+      const {
+        projections: [v1, v2, v3],
+      } = await versionedOperation(
+        ["v1", "v2", "v3"],
+        `
+        @returnTypeChangedFrom(Versions.v2, string)
+        @returnTypeChangedFrom(Versions.v3, zonedDateTime)  
+        op Test(): MyDate;
+
+        model MyDate {};
+        `
+      );
+      ok((v1.returnType as Scalar).name === "string");
+      ok((v2.returnType as Scalar).name === "zonedDateTime");
+      ok((v3.returnType as Model).name === "MyDate");
+    });
+
     async function versionedOperation(versions: string[], operation: string) {
       const { Test } = (await runner.compile(`
         @versioned(Versions)
@@ -658,6 +676,26 @@ describe("compiler: versioning", () => {
         ],
         source
       );
+    });
+
+    it("can change return types of members", async () => {
+      const {
+        projections: [v1, v2, v3],
+      } = await versionedInterface(
+        ["v1", "v2", "v3"],
+        `
+        interface Test {
+          @returnTypeChangedFrom(Versions.v2, string)
+          @returnTypeChangedFrom(Versions.v3, zonedDateTime)  
+          op foo(): MyDate;  
+        }
+
+        model MyDate {};
+        `
+      );
+      ok((v1.operations.get("foo")!.returnType as Scalar).name === "string");
+      ok((v2.operations.get("foo")!.returnType as Scalar).name === "zonedDateTime");
+      ok((v3.operations.get("foo")!.returnType as Model).name === "MyDate");
     });
 
     it("can version parameters", async () => {

--- a/packages/versioning/test/versioning.test.ts
+++ b/packages/versioning/test/versioning.test.ts
@@ -7,6 +7,7 @@ import {
   Operation,
   ProjectionApplication,
   projectProgram,
+  Scalar,
   Type,
   Union,
 } from "@cadl-lang/compiler";
@@ -277,6 +278,27 @@ describe("compiler: versioning", () => {
         ],
         source
       );
+    });
+
+    it("can change property types", async () => {
+      const {
+        projections: [v1, v2, v3],
+      } = await versionedModel(
+        ["v1", "v2", "v3"],
+        `
+        model Test {
+          @typeChangedFrom(Versions.v2, string)
+          @typeChangedFrom(Versions.v3, zonedDateTime)
+          changed: MyDate;
+        }
+        
+        model MyDate {}
+        `
+      );
+
+      ok((v1.properties.get("changed")!.type as Scalar).name === "string");
+      ok((v2.properties.get("changed")!.type as Scalar).name === "zonedDateTime");
+      ok((v3.properties.get("changed")!.type as Model).name === "MyDate");
     });
 
     async function versionedModel(versions: string[], model: string) {


### PR DESCRIPTION
Fixes: #1372

Adds new decorators:
- `@typeChangedFrom`: works on model properties
- `@returnTypeChangedFrom`: works on operations