### PR TITLE
Minor fixes to public docs website

### DIFF
--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -42,7 +42,7 @@ To get your first Cadl project started run in a fresh directory
 cadl init
 ```
 
-This will prompt you with a few question, pick the `Generic Rest API` template.
+This will prompt you with a few question, pick the `Generic Rest API` template, your project name, and select the `@cadl-lang/openapi3` library.
 
 Next, you can install the dependencies
 

--- a/packages/website/docusaurus.config.js
+++ b/packages/website/docusaurus.config.js
@@ -84,34 +84,34 @@ const config = {
       },
       footer: {
         style: "dark",
-        links: [
-          {
-            title: "Docs",
-            items: [
-              {
-                label: "Introduction",
-                to: "/",
-              },
-              {
-                label: "Language basics",
-                to: "/language-basics/overview",
-              },
-            ],
-          },
-          {
-            title: "Community & Support",
-            items: [
-              {
-                label: "Stack Overflow",
-                href: "https://stackoverflow.microsoft.com/search?q=cadl",
-              },
-              {
-                label: "Microsoft Teams Channel",
-                href: "http://aka.ms/cadl/discussions",
-              },
-            ],
-          },
-        ],
+        // links: [
+        //   {
+        //     title: "Docs",
+        //     items: [
+        //       {
+        //         label: "Introduction",
+        //         to: "/",
+        //       },
+        //       {
+        //         label: "Language basics",
+        //         to: "/language-basics/overview",
+        //       },
+        //     ],
+        //   },
+        //   {
+        //     title: "Community & Support",
+        //     items: [
+        //       {
+        //         label: "Stack Overflow",
+        //         href: "https://stackoverflow.microsoft.com/search?q=cadl",
+        //       },
+        //       {
+        //         label: "Microsoft Teams Channel",
+        //         href: "http://aka.ms/cadl/discussions",
+        //       },
+        //     ],
+        //   },
+        // ],
         copyright: `Copyright © ${new Date().getFullYear()} Microsoft Corp.`,
       },
       prism: {


### PR DESCRIPTION
This PR makes a few minor fixes to the public website.

- Added a little more detail in the section on `cadl init` to help the user through all the prompts
- Removed all the links in the footer.  The StackOverflow and Teams channel links aren't appropriate for the public site -- users outside Microsoft will be blocked.  And the TOC links seemed unnecessary since the TOC is already available in the left nav. I left them as commented out for now -- we can fully remove them if there are no concerns.