### PR TITLE
Fix: `constants` is not available in `fs/promises` in node 16

### DIFF
--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -38,7 +38,7 @@
     "!dist/test/**"
   ],
   "dependencies": {
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@rollup/plugin-virtual": "~3.0.1",
     "@rollup/plugin-commonjs": "~23.0.2",
     "@rollup/plugin-json": "~5.0.1",

--- a/packages/cadl-vscode/package.json
+++ b/packages/cadl-vscode/package.json
@@ -121,7 +121,7 @@
     "@types/mocha": "~10.0.0",
     "@types/node": "~18.11.9",
     "@types/vscode": "~1.53.0",
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@cadl-lang/eslint-config-cadl": "~0.5.0",
     "@cadl-lang/internal-build-utils": "~0.3.2",
     "eslint": "^8.12.0",

--- a/packages/compiler/CHANGELOG.json
+++ b/packages/compiler/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@cadl-lang/compiler",
   "entries": [
     {
+      "version": "0.38.3",
+      "tag": "@cadl-lang/compiler_v0.38.3",
+      "date": "Fri, 09 Dec 2022 22:03:04 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "Fix: `constants` not available in `fs/promise`"
+          }
+        ]
+      }
+    },
+    {
       "version": "0.38.2",
       "tag": "@cadl-lang/compiler_v0.38.2",
       "date": "Fri, 09 Dec 2022 20:43:01 GMT",

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @cadl-lang/compiler
 
-This log was last generated on Fri, 09 Dec 2022 20:43:01 GMT and should not be manually modified.
+This log was last generated on Fri, 09 Dec 2022 22:03:04 GMT and should not be manually modified.
+
+## 0.38.3
+Fri, 09 Dec 2022 22:03:04 GMT
+
+### Patches
+
+- Fix: `constants` not available in `fs/promise`
 
 ## 0.38.2
 Fri, 09 Dec 2022 20:43:01 GMT

--- a/packages/compiler/cmd/runner.ts
+++ b/packages/compiler/cmd/runner.ts
@@ -1,4 +1,4 @@
-import { access, constants, readFile, realpath, stat } from "fs/promises";
+import { access, readFile, realpath, stat } from "fs/promises";
 import { join, resolve } from "path";
 import url from "url";
 import { resolveModule, ResolveModuleHost } from "../core/module-resolver.js";
@@ -28,7 +28,7 @@ export async function runScript(relativePath: string, backupPath: string): Promi
 }
 
 function checkFileExists(file: string) {
-  return access(file, constants.F_OK)
+  return access(file)
     .then(() => true)
     .catch(() => false);
 }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cadl-lang/compiler",
-  "version": "0.38.2",
+  "version": "0.38.3",
   "description": "Cadl Compiler Preview",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/packages/html-program-viewer/package.json
+++ b/packages/html-program-viewer/package.json
@@ -51,7 +51,7 @@
     "!dist/test/**"
   ],
   "peerDependencies": {
-    "@cadl-lang/compiler": "~0.38.2"
+    "@cadl-lang/compiler": "~0.38.3"
   },
   "dependencies": {
     "prettier": "~2.7.1",
@@ -66,7 +66,7 @@
     "@types/prettier": "2.6.0",
     "@types/react": "~18.0.5",
     "@types/react-dom": "~18.0.1",
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@cadl-lang/eslint-config-cadl": "~0.5.0",
     "@babel/core": "^7.0.0",
     "eslint": "^8.12.0",

--- a/packages/library-linter/package.json
+++ b/packages/library-linter/package.json
@@ -51,12 +51,12 @@
     "!dist/test/**"
   ],
   "peerDependencies": {
-    "@cadl-lang/compiler": "~0.38.2"
+    "@cadl-lang/compiler": "~0.38.3"
   },
   "devDependencies": {
     "@types/mocha": "~10.0.0",
     "@types/node": "~18.11.9",
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@cadl-lang/eslint-config-cadl": "~0.5.0",
     "eslint": "^8.12.0",
     "mocha": "~10.1.0",

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -50,12 +50,12 @@
     "!dist/test/**"
   ],
   "peerDependencies": {
-    "@cadl-lang/compiler": "~0.38.2"
+    "@cadl-lang/compiler": "~0.38.3"
   },
   "devDependencies": {
     "@types/mocha": "~10.0.0",
     "@types/node": "~18.11.9",
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@cadl-lang/eslint-config-cadl": "~0.5.0",
     "@cadl-lang/eslint-plugin": "~0.38.0",
     "eslint": "^8.12.0",

--- a/packages/migrate/package.json
+++ b/packages/migrate/package.json
@@ -39,13 +39,13 @@
   ],
   "dependencies": {
     "globby": "~13.1.1",
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@cadl-lang/compiler-v0.37": "npm:@cadl-lang/compiler@0.37.0"
   },
   "devDependencies": {
     "@types/mocha": "~10.0.0",
     "@types/node": "~18.11.9",
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@cadl-lang/eslint-config-cadl": "~0.5.0",
     "@cadl-lang/eslint-plugin": "~0.38.0",
     "eslint": "^8.12.0",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -52,13 +52,13 @@
     "!dist/test/**"
   ],
   "peerDependencies": {
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@cadl-lang/rest": "~0.38.0"
   },
   "devDependencies": {
     "@types/mocha": "~10.0.0",
     "@types/node": "~18.11.9",
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@cadl-lang/rest": "~0.38.0",
     "@cadl-lang/eslint-config-cadl": "~0.5.0",
     "@cadl-lang/library-linter": "~0.38.0",

--- a/packages/openapi3/package.json
+++ b/packages/openapi3/package.json
@@ -53,14 +53,14 @@
   ],
   "peerDependencies": {
     "@cadl-lang/versioning": "~0.38.0",
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@cadl-lang/rest": "~0.38.0",
     "@cadl-lang/openapi": "~0.38.0"
   },
   "devDependencies": {
     "@types/mocha": "~10.0.0",
     "@types/node": "~18.11.9",
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@cadl-lang/rest": "~0.38.0",
     "@cadl-lang/openapi": "~0.38.0",
     "@cadl-lang/versioning": "~0.38.0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@cadl-lang/versioning": "~0.38.0",
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@cadl-lang/rest": "~0.38.0",
     "@cadl-lang/openapi3": "~0.38.0",
     "@cadl-lang/openapi": "~0.38.0",

--- a/packages/prettier-plugin-cadl/package.json
+++ b/packages/prettier-plugin-cadl/package.json
@@ -15,7 +15,7 @@
     "prettier": "~2.7.1"
   },
   "devDependencies": {
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@cadl-lang/internal-build-utils": "~0.3.2",
     "@rollup/plugin-commonjs": "~23.0.2",
     "@rollup/plugin-json": "~5.0.1",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -56,12 +56,12 @@
     "!dist/test/**"
   ],
   "peerDependencies": {
-    "@cadl-lang/compiler": "~0.38.2"
+    "@cadl-lang/compiler": "~0.38.3"
   },
   "devDependencies": {
     "@types/mocha": "~10.0.0",
     "@types/node": "~18.11.9",
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@cadl-lang/eslint-config-cadl": "~0.5.0",
     "@cadl-lang/library-linter": "~0.38.0",
     "@cadl-lang/eslint-plugin": "~0.38.0",

--- a/packages/samples/package.json
+++ b/packages/samples/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "@cadl-lang/versioning": "~0.38.0",
-    "@cadl-lang/compiler": "~0.38.2",
+    "@cadl-lang/compiler": "~0.38.3",
     "@cadl-lang/rest": "~0.38.0",
     "@cadl-lang/openapi": "~0.38.0",
     "@cadl-lang/openapi3": "~0.38.0",

--- a/packages/versioning/package.json
+++ b/packages/versioning/package.json
@@ -52,7 +52,7 @@
     "!dist/test/**"
   ],
   "dependencies": {
-    "@cadl-lang/compiler": "~0.38.2"
+    "@cadl-lang/compiler": "~0.38.3"
   },
   "devDependencies": {
     "@types/mocha": "~10.0.0",


### PR DESCRIPTION
It wasn't really needed anyway as its already the default for access to use constnats.ok