### PR TITLE
Export getAdded/RemovedOnVersions

### DIFF
--- a/common/changes/@cadl-lang/versioning/versioning-ExportAddedRemovedVersions_2022-12-13-23-11.json
+++ b/common/changes/@cadl-lang/versioning/versioning-ExportAddedRemovedVersions_2022-12-13-23-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "Added `getAddedOnVersions` and `getRemovedOnVersions` helper methods.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/packages/versioning/src/versioning.ts
+++ b/packages/versioning/src/versioning.ts
@@ -172,7 +172,7 @@ export function getNameAtVersion(p: Program, t: Type, v: ObjectType): string {
 }
 
 /**
- * @deprecated since version 0.39.0.
+ * @deprecated since version 0.39.0. Use getAddedOnVersions.
  * @returns version when the given type was added if applicable.
  */
 export function getAddedOn(p: Program, t: Type): Version | undefined {
@@ -181,7 +181,7 @@ export function getAddedOn(p: Program, t: Type): Version | undefined {
 }
 
 /**
- * @deprecated since version 0.39.0.
+ * @deprecated since version 0.39.0. Use getRemovedOnVersions.
  * @returns version when the given type was removed if applicable.
  */
 export function getRemovedOn(p: Program, t: Type): Version | undefined {
@@ -189,11 +189,17 @@ export function getRemovedOn(p: Program, t: Type): Version | undefined {
   return p.stateMap(removedOnKey).get(t)?.[0];
 }
 
-function getAddedOnVersions(p: Program, t: Type): Version[] | undefined {
+/**
+ * @returns the versions for which the `@addedOn` decorator was applied.
+ */
+export function getAddedOnVersions(p: Program, t: Type): Version[] | undefined {
   return p.stateMap(addedOnKey).get(t) as Version[];
 }
 
-function getRemovedOnVersions(p: Program, t: Type): Version[] | undefined {
+/**
+ * @returns the versions for which the `@removedOn` decorator was applied.
+ */
+export function getRemovedOnVersions(p: Program, t: Type): Version[] | undefined {
   return p.stateMap(removedOnKey).get(t) as Version[];
 }
 


### PR DESCRIPTION
These methods need to be exported because the symbol keys are not, leaving emitter authors with no way to simply get this metadata.