### PR TITLE
Render @error response as 4XX in OpenAPI 3

### DIFF
--- a/common/changes/@cadl-lang/openapi/openapi3-error-response_2022-12-16-19-48.json
+++ b/common/changes/@cadl-lang/openapi/openapi3-error-response_2022-12-16-19-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi",
+      "comment": "Render @error response as 4XX in OpenAPI 3",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi"
+}

--- a/common/changes/@cadl-lang/openapi3/openapi3-error-response_2022-12-16-19-48.json
+++ b/common/changes/@cadl-lang/openapi3/openapi3-error-response_2022-12-16-19-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Render @error response as 4XX in OpenAPI 3",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/rest/openapi3-error-response_2022-12-16-19-48.json
+++ b/common/changes/@cadl-lang/rest/openapi3-error-response_2022-12-16-19-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/rest",
+      "comment": "Render @error response as 4XX in OpenAPI 3",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/rest"
+}

--- a/docs/standard-library/openapi/openapi.md
+++ b/docs/standard-library/openapi/openapi.md
@@ -76,7 +76,7 @@ See also [metadata](../rest/operations.md#metadata) for more advanced details.
 
 The return type(s) of the Cadl operation are translated into responses for the OpenAPI operation.
 The status code for a response can be specified as a property in the return type model with the [(Http) `@statusCode` decorator][http-statuscode-decorator] (the property name is ignored).
-If the [(built-in) `@error` decorator][error-decorator] is specified on a return type, this return type becomes the "default" response for the operation.
+If the [(built-in) `@error` decorator][error-decorator] is specified on a return type, this return type becomes the "4XX" (client error) response for the operation.
 The media type for a response will be "application/json" unless the return type model includes an explicit `content-type`
 header.
 Models with different status codes and/or media types can be unioned together to describe complex response designs.

--- a/packages/openapi/src/decorators.ts
+++ b/packages/openapi/src/decorators.ts
@@ -82,7 +82,7 @@ function isOpenAPIExtensionKey(key: string): key is ExtensionKey {
  */
 const defaultResponseKey = createStateSymbol("defaultResponse");
 export function $defaultResponse(context: DecoratorContext, entity: Model) {
-  http.setStatusCode(context.program, entity, ["*"]);
+  http.setStatusCode(context.program, entity, ["default"]);
   context.program.stateSet(defaultResponseKey).add(entity);
 }
 

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -488,7 +488,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
   function getOpenAPIStatuscode(response: HttpOperationResponse): string {
     switch (response.statusCode) {
       case "*":
-        return "default";
+        return "4XX";
       default:
         return response.statusCode;
     }
@@ -536,6 +536,9 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
   }
 
   function getResponseDescriptionForStatusCode(statusCode: string) {
+    if (statusCode === "4XX") {
+      return "Client error";
+    }
     if (statusCode === "default") {
       return "An unexpected error response.";
     }

--- a/packages/openapi3/test/return-types.test.ts
+++ b/packages/openapi3/test/return-types.test.ts
@@ -392,7 +392,7 @@ describe("openapi3: return types", () => {
     ok(responses["204"].content === undefined);
   });
 
-  it("defaults status code to default when model has @error decorator", async () => {
+  it("defaults status code to 4XX when model has @error decorator", async () => {
     const res = await openApiFor(
       `
       @error
@@ -413,14 +413,14 @@ describe("openapi3: return types", () => {
     deepStrictEqual(responses["200"].content["application/json"].schema, {
       $ref: "#/components/schemas/Foo",
     });
-    ok(responses["default"]);
-    ok(responses["default"].content);
-    deepStrictEqual(responses["default"].content["application/json"].schema, {
+    ok(responses["4XX"]);
+    ok(responses["4XX"].content);
+    deepStrictEqual(responses["4XX"].content["application/json"].schema, {
       $ref: "#/components/schemas/Error",
     });
   });
 
-  it("defaults status code to default when model has @error decorator and explicit body", async () => {
+  it("defaults status code to 4XX when model has @error decorator and explicit body", async () => {
     const res = await openApiFor(
       `
       @error
@@ -441,9 +441,9 @@ describe("openapi3: return types", () => {
     deepStrictEqual(responses["200"].content["application/json"].schema, {
       $ref: "#/components/schemas/Foo",
     });
-    ok(responses["default"]);
-    ok(responses["default"].content);
-    deepStrictEqual(responses["default"].content["application/json"].schema, {
+    ok(responses["4XX"]);
+    ok(responses["4XX"].content);
+    deepStrictEqual(responses["4XX"].content["application/json"].schema, {
       type: "string",
     });
   });

--- a/packages/rest/src/http/types.ts
+++ b/packages/rest/src/http/types.ts
@@ -281,7 +281,7 @@ export interface RoutePath {
   shared: boolean;
 }
 
-export type StatusCode = `${number}` | "*";
+export type StatusCode = `${number}` | "*" /* error */ | "default";
 export interface HttpOperationResponse {
   statusCode: StatusCode;
   type: Type;

--- a/packages/samples/test/output/documentation/openapi.json
+++ b/packages/samples/test/output/documentation/openapi.json
@@ -21,8 +21,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -49,8 +49,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -87,8 +87,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -125,8 +125,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/grpc-kiosk-example/openapi.json
+++ b/packages/samples/test/output/grpc-kiosk-example/openapi.json
@@ -29,8 +29,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -68,8 +68,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -110,8 +110,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -143,8 +143,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful. "
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -175,8 +175,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -246,8 +246,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -279,8 +279,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful. "
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -308,8 +308,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful. "
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -364,8 +364,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/grpc-library-example/openapi.json
+++ b/packages/samples/test/output/grpc-library-example/openapi.json
@@ -29,8 +29,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -76,8 +76,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -112,8 +112,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -139,8 +139,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful. "
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -175,8 +175,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -221,8 +221,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -271,8 +271,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -307,8 +307,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -334,8 +334,8 @@
           "204": {
             "description": "There is no content to send for this request, but the headers may be useful. "
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/petstore/openapi.json
+++ b/packages/samples/test/output/petstore/openapi.json
@@ -20,8 +20,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -61,8 +61,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -99,8 +99,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -125,8 +125,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -179,8 +179,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/rest/petstore/openapi.json
+++ b/packages/samples/test/output/rest/petstore/openapi.json
@@ -32,8 +32,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -69,8 +69,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -108,8 +108,8 @@
           "200": {
             "description": "Resource deleted successfully."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -147,8 +147,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -183,8 +183,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -241,8 +241,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -289,8 +289,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -328,8 +328,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -365,8 +365,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -422,8 +422,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -468,8 +468,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -516,8 +516,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -562,8 +562,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -620,8 +620,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -658,8 +658,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -697,8 +697,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -734,8 +734,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -773,8 +773,8 @@
           "200": {
             "description": "Resource deleted successfully."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -812,8 +812,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -848,8 +848,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -906,8 +906,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -954,8 +954,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -993,8 +993,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -1030,8 +1030,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/signatures/openapi.json
+++ b/packages/samples/test/output/signatures/openapi.json
@@ -31,8 +31,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -60,8 +60,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -107,8 +107,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -136,8 +136,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/body-boolean/openapi.json
+++ b/packages/samples/test/output/testserver/body-boolean/openapi.json
@@ -25,8 +25,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -45,8 +45,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -89,8 +89,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -116,8 +116,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -157,8 +157,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -186,8 +186,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/body-complex/openapi.json
+++ b/packages/samples/test/output/testserver/body-complex/openapi.json
@@ -22,8 +22,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -42,8 +42,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -80,8 +80,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -100,8 +100,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -138,8 +138,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -158,8 +158,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -196,8 +196,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -216,8 +216,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -254,8 +254,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -274,8 +274,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -312,8 +312,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -332,8 +332,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -370,8 +370,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -390,8 +390,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -428,8 +428,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -448,8 +448,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -486,8 +486,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -506,8 +506,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -544,8 +544,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -564,8 +564,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -602,8 +602,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -622,8 +622,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -660,8 +660,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -680,8 +680,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -718,8 +718,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -738,8 +738,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/body-string/openapi.json
+++ b/packages/samples/test/output/testserver/body-string/openapi.json
@@ -31,8 +31,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -54,8 +54,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -100,8 +100,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -123,8 +123,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -170,8 +170,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -193,8 +193,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -240,8 +240,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -263,8 +263,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -308,8 +308,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -331,8 +331,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -373,8 +373,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -396,8 +396,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -437,8 +437,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -460,8 +460,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/body-time/openapi.json
+++ b/packages/samples/test/output/testserver/body-time/openapi.json
@@ -23,8 +23,8 @@
               }
             }
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {
@@ -43,8 +43,8 @@
           "200": {
             "description": "The request has succeeded."
           },
-          "default": {
-            "description": "An unexpected error response.",
+          "4XX": {
+            "description": "Client error",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/samples/test/output/testserver/multiple-inheritance/openapi.json
+++ b/packages/samples/test/output/testserver/multiple-inheritance/openapi.json
@@ -22,7 +22,7 @@
               }
             }
           },
-          "default": {
+          "4XX": {
             "description": "Unexpected error",
             "content": {
               "application/json": {
@@ -49,7 +49,7 @@
               }
             }
           },
-          "default": {
+          "4XX": {
             "description": "Unexpected error",
             "content": {
               "application/json": {
@@ -87,7 +87,7 @@
               }
             }
           },
-          "default": {
+          "4XX": {
             "description": "Unexpected error",
             "content": {
               "application/json": {
@@ -114,7 +114,7 @@
               }
             }
           },
-          "default": {
+          "4XX": {
             "description": "Unexpected error",
             "content": {
               "application/json": {
@@ -152,7 +152,7 @@
               }
             }
           },
-          "default": {
+          "4XX": {
             "description": "Unexpected error",
             "content": {
               "application/json": {
@@ -179,7 +179,7 @@
               }
             }
           },
-          "default": {
+          "4XX": {
             "description": "Unexpected error",
             "content": {
               "application/json": {
@@ -217,7 +217,7 @@
               }
             }
           },
-          "default": {
+          "4XX": {
             "description": "Unexpected error",
             "content": {
               "application/json": {
@@ -244,7 +244,7 @@
               }
             }
           },
-          "default": {
+          "4XX": {
             "description": "Unexpected error",
             "content": {
               "application/json": {
@@ -282,7 +282,7 @@
               }
             }
           },
-          "default": {
+          "4XX": {
             "description": "Unexpected error",
             "content": {
               "application/json": {
@@ -309,7 +309,7 @@
               }
             }
           },
-          "default": {
+          "4XX": {
             "description": "Unexpected error",
             "content": {
               "application/json": {


### PR DESCRIPTION
This PR changes the handling of @error by the OpenAPI 3 emitter to produce a "4XX" response rather than "default".

This is not removing any capability from the user -- users that want "default" can use the `@defaultResponse` decorator.

Fixes #1344