### PR TITLE
Fix: Issue with referencing spread members

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-spread-references_2022-12-22-20-07.json
+++ b/common/changes/@cadl-lang/compiler/fix-spread-references_2022-12-22-20-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix: Issue with referencing spread members",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -51,6 +51,7 @@ import {
   LiteralType,
   MarshalledValue,
   MemberContainerNode,
+  MemberContainerType,
   MemberExpressionNode,
   MemberNode,
   MemberType,
@@ -540,7 +541,11 @@ export function createChecker(program: Program): Checker {
     }
   }
 
-  function checkMember(node: MemberNode, mapper: TypeMapper | undefined, containerType: Type) {
+  function checkMember(
+    node: MemberNode,
+    mapper: TypeMapper | undefined,
+    containerType: MemberContainerType
+  ) {
     switch (node.kind) {
       case SyntaxKind.ModelProperty:
         return checkModelProperty(node, mapper);
@@ -998,7 +1003,11 @@ export function createChecker(program: Program): Checker {
           if (type) {
             baseType = type;
           } else {
-            baseType = checkMember(sym.declarations[0] as MemberNode, mapper, memberContainer)!;
+            baseType = checkMember(
+              sym.declarations[0] as MemberNode,
+              mapper,
+              memberContainer as MemberContainerType
+            )!;
           }
         } else {
           // don't have a cached type for this symbol, so go grab it and cache it

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -553,6 +553,7 @@ export const enum SymbolFlags {
    * Symbols whose members will be late bound (and stored on the type)
    */
   MemberContainer = Model | Enum | Union | Interface,
+  Member = ModelProperty | EnumMember | UnionVariant | InterfaceMember,
 }
 
 /**

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -761,6 +761,8 @@ export type MemberNode =
   | OperationStatementNode
   | UnionVariantNode;
 
+export type MemberContainerType = Model | Enum | Interface | Union;
+
 /**
  * Type that can be used as members of a container type.
  */


### PR DESCRIPTION
Fixes: 
-  Referencing a `interface extends` member not working at all
- Referencing a spread model property or enum member not working if referenced before declaration