### PR TITLE
Fix playground not updating multi version output

### DIFF
--- a/packages/playground/src/components/editor.tsx
+++ b/packages/playground/src/components/editor.tsx
@@ -28,6 +28,12 @@ export const Editor: FunctionComponent<EditorProps> = ({ model, options, command
     }
   }, []);
 
+  useEffect(() => {
+    if (editorRef.current) {
+      editorRef.current.setModel(model);
+    }
+  }, [model]);
+
   return (
     <div
       className="monaco-editor-container"


### PR DESCRIPTION
Problem happened because we have now different monaco models for the different output files to accomodate different output types but the edtor wasn't updating when the model changed