### PR TITLE
Allow discriminator to be overridden at all levels

### DIFF
--- a/common/changes/@cadl-lang/compiler/compiler-OverrideParentLiteral_2023-01-09-22-26.json
+++ b/common/changes/@cadl-lang/compiler/compiler-OverrideParentLiteral_2023-01-09-22-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Allow override of discriminator propery literals.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/compiler/compiler-OverrideParentLiteral_2023-01-09-22-26.json
+++ b/common/changes/@cadl-lang/compiler/compiler-OverrideParentLiteral_2023-01-09-22-26.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@cadl-lang/compiler",
-      "comment": "Allow override of discriminator propery literals.",
+      "comment": "Allow override of discriminator property literals.",
       "type": "none"
     }
   ],


### PR DESCRIPTION
Address part of issue https://github.com/Azure/cadl-azure/issues/2219.

The current rule is that children can override parent properties if the parent is an intrinsic type and the child is a literal. This PR allows children to override parent literals with a different literal if the property is a discriminator. Otherwise the following will not work:
```
@discriminator("kind")
model Fish {
  name: string;
  kind: string;
}

model Salmon extends Fish {
  kind: "salmon";
}

model SmartSalmon extends Salmon {
  kind: "smartSalmon";
}
```

**TODO**

- [ ] Add test case