### PR TITLE
Overhaul versioned dependency decorators.

### DIFF
--- a/common/changes/@cadl-lang/openapi3/versioning-OverhaulVersionDecorators_2023-01-13-00-44.json
+++ b/common/changes/@cadl-lang/openapi3/versioning-OverhaulVersionDecorators_2023-01-13-00-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/common/changes/@cadl-lang/versioning/versioning-OverhaulVersionDecorators_2023-01-13-00-44.json
+++ b/common/changes/@cadl-lang/versioning/versioning-OverhaulVersionDecorators_2023-01-13-00-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/versioning",
+      "comment": "Adds the @useDependency decorator. Deprecates the @versionedDependency decorator.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/versioning"
+}

--- a/packages/openapi3/test/versioning.test.ts
+++ b/packages/openapi3/test/versioning.test.ts
@@ -8,10 +8,15 @@ describe("openapi3: versioning", () => {
     const { v1, v2, v3 } = await openApiFor(
       `
       @versioned(Versions)
-      @versionedDependency([[Versions.v1, MyLibrary.Versions.A], [Versions.v2, MyLibrary.Versions.B], [Versions.v3, MyLibrary.Versions.C]])
       @service({title: "My Service", version: "hi"})
       namespace MyService {
-        enum Versions {"v1", "v2", "v3"}
+        enum Versions {
+          @useDependency(MyLibrary.Versions.A)
+          "v1",
+          @useDependency(MyLibrary.Versions.B)
+          "v2",
+          @useDependency(MyLibrary.Versions.C)
+          "v3"}
         model Test {
           prop1: string;
           @added(Versions.v2) prop2: string;
@@ -125,7 +130,7 @@ describe("openapi3: versioning", () => {
     }
     @armNamespace
     @service({title: "Widgets 'r' Us"})
-    @versionedDependency(Contoso.Library.Versions.v1)
+    @useDependency(Contoso.Library.Versions.v1)
     namespace Contoso.WidgetService {
       model Widget {
         @key
@@ -157,7 +162,7 @@ describe("openapi3: versioning", () => {
       }
       
       @service({title: "Service"})
-      @versionedDependency(Library.Versions.v1)
+      @useDependency(Library.Versions.v1)
       namespace Service {
         model Widget {
           details?: WidgetDetails;

--- a/packages/samples/use-versioned-lib/main.cadl
+++ b/packages/samples/use-versioned-lib/main.cadl
@@ -8,7 +8,7 @@ using Cadl.Versioning;
 @service({
   title: "Pet Store Service",
 })
-@versionedDependency(Library.Versions.v1_0)
+@useDependency(Library.Versions.v1_0)
 namespace VersionedApi;
 using Cadl.Http;
 

--- a/packages/samples/versioning/main.cadl
+++ b/packages/samples/versioning/main.cadl
@@ -5,7 +5,6 @@ import "./library.cadl";
 using Cadl.Versioning;
 using Cadl.Rest;
 
-@versionedDependency([[Versions.v1, Library.Versions.v1_0], [Versions.v2, Library.Versions.v1_1]])
 @service({
   title: "Pet Store Service",
 })
@@ -14,7 +13,10 @@ namespace VersionedApi;
 using Cadl.Http;
 
 enum Versions {
+  @useDependency(Library.Versions.v1_0)
   v1,
+
+  @useDependency(Library.Versions.v1_1)
   v2,
 }
 

--- a/packages/versioning/README.md
+++ b/packages/versioning/README.md
@@ -50,7 +50,7 @@ See [`@versionedDependency`](#versioneddependency) decorator for information abo
 Decorators:
 
 - [`@versioned`](#versioned) <!-- no toc -->
-- [`@versionedDependency`](#versioneddependency)
+- [`@useDependency`](#usedependency)
 - [`@added`](#added)
 - [`@removed`](#removed)
 - [`@renamedFrom`](#renamedfrom)
@@ -71,14 +71,14 @@ enum Versions {
 }
 ```
 
-### `@versionedDependency`
+### `@useDependency`
 
 When using elements from another versioned namespace, the consuming namespace **MUST** specify which version of the consumed namespace to use even if the consuming namespace is not versioned itself.
 
-The decorator either takes:
+The decorator can either target:
 
-- a single `enum member` if using the same version or the consuming namespace is not versioned.
-- a mapping of consuming namespace version to consumed namespace version
+- an unversioned namespace.
+- individual enum members of a versioned namespace's version enum.
 
 If we have a library with the following definition:
 
@@ -97,7 +97,7 @@ Pick a specific version to be used for all version of the service.
 
 ```cadl
 @versioned(Versions)
-@versionedDependency(MyLib.Versions.v1_1)
+@useDependency(MyLib.Versions.v1_1)
 namespace MyService1;
 
 enum Version {
@@ -110,7 +110,7 @@ enum Version {
 Service is not versioned, pick which version of `MyLib` should be used.
 
 ```cadl
-@versionedDependency(MyLib.Versions.v1_1)
+@useDependency(MyLib.Versions.v1_1)
 namespace NonVersionedService;
 ```
 
@@ -118,19 +118,16 @@ Select mapping of version to use
 
 ```cadl
 @versioned(Versions)
-@versionedDependency([
-  [Versions.v1, MyLib.Versions.v1_1], // V1 use lib v1_1
-  [Versions.v2, MyLib.Versions.v1_1], // V2 use lib v1_1
-  [Versions.v3, MyLib.Versions.v2],   // V3 use lib v2
-])
 namespace MyService1;
 
 enum Version {
+  @useDependency(MyLib.Versions.v1_1) // V1 use lib v1_1
   v1,
+  @useDependency(MyLib.Versions.v1_1) // V2 use lib v1_1
   v2,
+  @useDependency(MyLib.Versions.v2) // V3 use lib v2
   v3,
 }
-
 ```
 
 ### `@added`

--- a/packages/versioning/lib/decorators.cadl
+++ b/packages/versioning/lib/decorators.cadl
@@ -5,6 +5,7 @@ using Cadl.Reflection;
 namespace Cadl.Versioning;
 
 extern dec versioned(target: Namespace, versions: Enum);
+extern dec useDependency(target: EnumMember | Namespace, ...versionRecords: EnumMember[]);
 extern dec versionedDependency(target: Namespace, mapping: EnumMember | [EnumMember, EnumMember][]);
 
 extern dec added(target: unknown, version: EnumMember);

--- a/packages/versioning/src/lib.ts
+++ b/packages/versioning/src/lib.ts
@@ -67,7 +67,7 @@ const libDef = {
       severity: "error",
       messages: {
         default:
-          "The useDependency decorator can only be used on a Namespace if the namespace is unversioned.",
+          "The useDependency decorator can only be used on a Namespace if the namespace is unversioned. For versioned namespaces, put the useDependency decorator on the version enum members.",
       },
     },
     "made-optional-not-optional": {

--- a/packages/versioning/src/lib.ts
+++ b/packages/versioning/src/lib.ts
@@ -42,7 +42,7 @@ const libDef = {
     "using-versioned-library": {
       severity: "error",
       messages: {
-        default: paramMessage`Namespace '${"sourceNs"}' is referencing types from versioned namespace '${"targetNs"}' but didn't specify which versions with @versionedDependency.`,
+        default: paramMessage`Namespace '${"sourceNs"}' is referencing types from versioned namespace '${"targetNs"}' but didn't specify which versions with @useDependency.`,
       },
     },
     "invalid-renamed-from-value": {
@@ -61,6 +61,13 @@ const libDef = {
         dependentRemovedBefore: paramMessage`'${"sourceName"}' was removed on version '${"sourceRemovedOn"}' but contains type '${"targetName"}' removed in version '${"targetRemovedOn"}'.`,
         versionedDependencyAddedAfter: paramMessage`'${"sourceName"}' is referencing type '${"targetName"}' added in version '${"targetAddedOn"}' but version used is ${"dependencyVersion"}.`,
         versionedDependencyRemovedBefore: paramMessage`'${"sourceName"}' is referencing type '${"targetName"}' removed in version '${"targetAddedOn"}' but version used is ${"dependencyVersion"}.`,
+      },
+    },
+    "incompatible-versioned-namespace-use-dependency": {
+      severity: "error",
+      messages: {
+        default:
+          "The useDependency decorator can only be used on a Namespace if the namespace is unversioned.",
       },
     },
     "made-optional-not-optional": {

--- a/packages/versioning/src/validate.ts
+++ b/packages/versioning/src/validate.ts
@@ -136,7 +136,6 @@ function validateVersionedNamespaceUsage(
     const dependencies = source && getVersionDependencies(program, source);
     for (const target of targets) {
       const targetVersionedNamespace = findVersionedNamespace(program, target);
-
       if (
         targetVersionedNamespace !== undefined &&
         !(source && (isSubNamespace(target, source) || isSubNamespace(source, target))) &&

--- a/packages/versioning/src/versioning.ts
+++ b/packages/versioning/src/versioning.ts
@@ -20,6 +20,8 @@ const addedOnKey = createStateSymbol("addedOn");
 const removedOnKey = createStateSymbol("removedOn");
 const versionsKey = createStateSymbol("versions");
 const versionDependencyKey = createStateSymbol("versionDependency");
+const useDependencyNamespaceKey = createStateSymbol("useDependencyNamespace");
+const useDependencyEnumKey = createStateSymbol("useDependencyEnum");
 const renamedFromKey = createStateSymbol("renamedFrom");
 const madeOptionalKey = createStateSymbol("madeOptional");
 const typeChangedFromKey = createStateSymbol("typeChangedFrom");
@@ -366,12 +368,108 @@ export function findVersionedNamespace(
   return undefined;
 }
 
+export function $useDependency(
+  context: DecoratorContext,
+  target: EnumMember | Namespace,
+  ...versionRecords: EnumMember[]
+) {
+  const versions: Array<Version> = [];
+  // ensure only valid versions are passed in
+  for (const record of versionRecords) {
+    const ver = checkIsVersion(context.program, record, context.getArgumentTarget(0)!);
+    if (ver) {
+      versions.push(ver);
+    }
+  }
+
+  if (target.kind === "Namespace") {
+    let state = context.program.stateMap(useDependencyNamespaceKey).get(target) as Version[];
+    if (!state) {
+      state = versions;
+    } else {
+      state.push(...versions);
+    }
+    context.program.stateMap(useDependencyNamespaceKey).set(target, state);
+  } else if (target.kind === "EnumMember") {
+    const targetEnum = target.enum;
+    let state = context.program.stateMap(useDependencyEnumKey).get(targetEnum) as Map<
+      EnumMember,
+      Version
+    >;
+    if (!state) {
+      state = new Map<EnumMember, Version>();
+    }
+    for (const v of versions) {
+      state.set(target, v);
+    }
+    context.program.stateMap(useDependencyEnumKey).set(targetEnum, state);
+  }
+}
+
+export function getUseDependencies(
+  program: Program,
+  target: Namespace | Enum,
+  searchEnum: boolean = true
+): Map<Namespace, Map<Version, Version> | Version> | undefined {
+  const result = new Map<Namespace, Map<Version, Version> | Version>();
+  if (target.kind === "Namespace") {
+    const data = program.stateMap(useDependencyNamespaceKey).get(target) as Version[];
+    if (!data) {
+      if (!searchEnum) {
+        return undefined;
+      }
+      const versionMap = getVersion(program, target);
+      if (!versionMap) {
+        return undefined;
+      }
+      const versions = versionMap.getVersions();
+      if (!versions.length) {
+        return undefined;
+      }
+      return getUseDependencies(program, versions[0].enumMember.enum);
+    }
+    for (const v of data) {
+      result.set(v.namespace, v);
+    }
+  } else if (target.kind === "Enum") {
+    const data = program.stateMap(useDependencyEnumKey).get(target) as Map<EnumMember, Version>;
+    if (!data) {
+      return undefined;
+    }
+    const resolved = resolveVersionDependency(program, data);
+    if (resolved instanceof Map) {
+      for (const [enumVer, value] of resolved) {
+        const targetNamespace = value.enumMember.enum.namespace;
+        if (!targetNamespace) {
+          // FIXME: Log diagnostic here???
+          return undefined;
+        }
+        let subMap = result.get(targetNamespace) as Map<Version, Version>;
+        if (subMap) {
+          subMap.set(enumVer, value);
+        } else {
+          subMap = new Map([[enumVer, value]]);
+        }
+        result.set(targetNamespace, subMap);
+      }
+    }
+  }
+  return result;
+}
+
 export function $versionedDependency(
   context: DecoratorContext,
   referenceNamespace: Namespace,
   versionRecord: Tuple | EnumMember
 ) {
   const { program } = context;
+
+  reportDeprecated(
+    program,
+    "@versionedDependency is deprecated. Use @useDependency instead.",
+    context.decoratorTarget
+  );
+
   let state = program.stateMap(versionDependencyKey).get(referenceNamespace) as Map<
     Namespace,
     Version | Map<EnumMember, Version>
@@ -443,7 +541,11 @@ function findVersionDependencyForNamespace(program: Program, namespace: Namespac
   let current: Namespace | undefined = namespace;
 
   while (current) {
-    const data = program.stateMap(versionDependencyKey).get(current);
+    // TODO: Remove versionDependencyKey when this deprecated decorator is removed.
+    const data =
+      program.stateMap(useDependencyNamespaceKey).get(current) ??
+      program.stateMap(useDependencyEnumKey).get(current) ??
+      program.stateMap(versionDependencyKey).get(current);
     if (data !== undefined) {
       return data;
     }
@@ -457,6 +559,13 @@ export function getVersionDependencies(
   program: Program,
   namespace: Namespace
 ): Map<Namespace, Map<Version, Version> | Version> | undefined {
+  // TODO: Remove this when @versionedDependency is removed and update all references to
+  // use getUseDependencies directly
+  const useDeps = getUseDependencies(program, namespace);
+  if (useDeps) {
+    return useDeps;
+  }
+
   const data = findVersionDependencyForNamespace(program, namespace);
   if (data === undefined) {
     return undefined;
@@ -468,7 +577,10 @@ export function getVersionDependencies(
   return result;
 }
 
-function resolveVersionDependency(program: Program, data: Map<EnumMember, Version> | Version) {
+function resolveVersionDependency(
+  program: Program,
+  data: Map<EnumMember, Version> | Version
+): Map<Version, Version> | Version {
   if (!(data instanceof Map)) {
     return data;
   }

--- a/packages/versioning/src/versioning.ts
+++ b/packages/versioning/src/versioning.ts
@@ -446,7 +446,11 @@ export function getUseDependencies(
       for (const [enumVer, value] of resolved) {
         const targetNamespace = value.enumMember.enum.namespace;
         if (!targetNamespace) {
-          // FIXME: Log diagnostic here???
+          reportDiagnostic(program, {
+            code: "version-not-found",
+            target: value.enumMember.enum,
+            format: { version: value.enumMember.name, enumName: value.enumMember.enum.name },
+          });
           return undefined;
         }
         let subMap = result.get(targetNamespace) as Map<Version, Version>;

--- a/packages/versioning/test/incompatible-versioning.test.ts
+++ b/packages/versioning/test/incompatible-versioning.test.ts
@@ -453,24 +453,6 @@ describe("versioning: validate incompatible references", () => {
 });
 
 describe("versioning (deprecated): validate incompatible references (@versionedDependency)", () => {
-  let runner: BasicTestRunner;
-
-  beforeEach(async () => {
-    const host = await createVersioningTestHost();
-    runner = createTestWrapper(host, {
-      wrapper: (code) => `
-      import "@cadl-lang/versioning";
-
-      using Cadl.Versioning;
-      
-      @versioned(Versions)
-      namespace TestService {
-        enum Versions {v1, v2, v3, v4}
-        ${code}
-      }`,
-    });
-  });
-
   describe("with @versionedDependency", () => {
     let runner: BasicTestRunner;
 

--- a/packages/versioning/test/incompatible-versioning.test.ts
+++ b/packages/versioning/test/incompatible-versioning.test.ts
@@ -337,7 +337,7 @@ describe("versioning: validate incompatible references", () => {
     });
   });
 
-  describe("with versioned dependencies", () => {
+  describe("with @useDependency", () => {
     let runner: BasicTestRunner;
 
     beforeEach(async () => {
@@ -354,6 +354,141 @@ describe("versioning: validate incompatible references", () => {
           model Foo {}
         }
 
+        @versioned(Versions)
+        namespace TestService {
+          enum Versions {
+            @useDependency(VersionedLib.Versions.l1)
+            v1,
+            @useDependency(VersionedLib.Versions.l1)
+            v2,
+            @useDependency(VersionedLib.Versions.l2)
+            v3,
+            @useDependency(VersionedLib.Versions.l2)
+            v4
+          }
+
+          @added(Versions.v1)
+          op test(): VersionedLib.Foo;
+        }
+      `);
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/versioning/incompatible-versioned-reference",
+        message:
+          "'TestService.test' was added on version 'v1' but referencing type 'VersionedLib.Foo' added in version 'v3'.",
+      });
+    });
+
+    it("doesn't emit diagnostic if all version use the same one", async () => {
+      // Here Foo was added in v2 which makes it only available in 1 & 2.
+      const diagnostics = await runner.diagnose(`
+        @versioned(Versions)
+        namespace VersionedLib {
+          enum Versions {l1, l2}
+          @added(Versions.l2)
+          model Foo {}
+        }
+
+        @versioned(Versions)
+        namespace TestService {
+          enum Versions {
+            @useDependency(VersionedLib.Versions.l2)
+            v1,
+            @useDependency(VersionedLib.Versions.l2)
+            v2,
+            @useDependency(VersionedLib.Versions.l2)
+            v3,
+            @useDependency(VersionedLib.Versions.l2)
+            v4
+          }
+          op test(): VersionedLib.Foo;
+        }
+      `);
+      expectDiagnosticEmpty(diagnostics);
+    });
+
+    it("emit diagnostic when using item that was added in a later version of library", async () => {
+      // Here Foo was added in v2 but version 1 was selected.
+      const diagnostics = await runner.diagnose(`
+        @versioned(Versions)
+        namespace VersionedLib {
+          enum Versions {l1, l2}
+          @added(Versions.l2)
+          model Foo {}
+        }
+
+        @useDependency(VersionedLib.Versions.l1)
+        namespace TestService {
+          op test(): VersionedLib.Foo;
+        }
+      `);
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/versioning/incompatible-versioned-reference",
+        message:
+          "'TestService.test' is referencing type 'VersionedLib.Foo' added in version 'l2' but version used is l1.",
+      });
+    });
+
+    it("emit diagnostic when using item that was removed in an earlier version of library", async () => {
+      // Here Foo was removed in v2 but version 2 was selected.
+      const diagnostics = await runner.diagnose(`
+        @versioned(Versions)
+        namespace VersionedLib {
+          enum Versions {l1, l2}
+          @removed(Versions.l2)
+          model Foo {}
+        }
+
+        @useDependency(VersionedLib.Versions.l2)
+        namespace TestService {
+          op test(): VersionedLib.Foo;
+        }
+      `);
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/versioning/incompatible-versioned-reference",
+        message:
+          "'TestService.test' is referencing type 'VersionedLib.Foo' removed in version 'l2' but version used is l2.",
+      });
+    });
+  });
+});
+
+describe("versioning (deprecated): validate incompatible references (@versionedDependency)", () => {
+  let runner: BasicTestRunner;
+
+  beforeEach(async () => {
+    const host = await createVersioningTestHost();
+    runner = createTestWrapper(host, {
+      wrapper: (code) => `
+      import "@cadl-lang/versioning";
+
+      using Cadl.Versioning;
+      
+      @versioned(Versions)
+      namespace TestService {
+        enum Versions {v1, v2, v3, v4}
+        ${code}
+      }`,
+    });
+  });
+
+  describe("with @versionedDependency", () => {
+    let runner: BasicTestRunner;
+
+    beforeEach(async () => {
+      runner = await createVersioningTestRunner();
+    });
+
+    it("emit diagnostic when referencing incompatible version via version dependency", async () => {
+      // Here Foo was added in v2 which makes it only available in 1 & 2.
+      const diagnostics = await runner.diagnose(`
+        @versioned(Versions)
+        namespace VersionedLib {
+          enum Versions {l1, l2}
+          @added(Versions.l2)
+          model Foo {}
+        }
+
+        #suppress "deprecated"
         @versioned(Versions)
         @versionedDependency([
           [Versions.v1, VersionedLib.Versions.l1],
@@ -385,8 +520,9 @@ describe("versioning: validate incompatible references", () => {
           model Foo {}
         }
 
+        #suppress "deprecated"
         @versioned(Versions)
-         @versionedDependency([
+        @versionedDependency([
           [Versions.v1, VersionedLib.Versions.l2],
           [Versions.v2, VersionedLib.Versions.l2],
           [Versions.v3, VersionedLib.Versions.l2],
@@ -410,6 +546,7 @@ describe("versioning: validate incompatible references", () => {
           model Foo {}
         }
 
+        #suppress "deprecated"
         @versionedDependency(VersionedLib.Versions.l1)
         namespace TestService {
           op test(): VersionedLib.Foo;
@@ -432,6 +569,7 @@ describe("versioning: validate incompatible references", () => {
           model Foo {}
         }
 
+        #suppress "deprecated"
         @versionedDependency(VersionedLib.Versions.l2)
         namespace TestService {
           op test(): VersionedLib.Foo;

--- a/packages/versioning/test/versioned-dependencies.test.ts
+++ b/packages/versioning/test/versioned-dependencies.test.ts
@@ -46,7 +46,7 @@ describe("versioning: reference versioned library", () => {
   describe("when project is not-versioned", () => {
     it("use a versioned library given version", async () => {
       const { MyService, Test } = (await runner.compile(`
-        @versionedDependency(VersionedLib.Versions.l1)
+        @useDependency(VersionedLib.Versions.l1)
         @test namespace MyService {
           @test model Test extends VersionedLib.Foo {}
         } 
@@ -62,17 +62,17 @@ describe("versioning: reference versioned library", () => {
       assertFooV1(Foo);
     });
 
-    it("emit diagnostic if passing version mapping", async () => {
+    it("emit diagnostic if passing anything but an enum member", async () => {
       const diagnostics = await runner.diagnose(`
-        @versionedDependency([[VersionedLib.Versions.l1, VersionedLib.Versions.l1]])
+        @useDependency([[VersionedLib.Versions.l1, VersionedLib.Versions.l1]])
         namespace MyService {
           model Test extends VersionedLib.Foo {}
         } 
     `);
       expectDiagnostics(diagnostics, {
-        code: "@cadl-lang/versioning/versioned-dependency-not-picked",
+        code: "invalid-argument",
         message:
-          "The versionedDependency decorator must provide a version of the dependency 'VersionedLib'.",
+          "Argument '[[VersionedLib.Versions.l1, VersionedLib.Versions.l1]]' is not assignable to parameter of type 'Cadl.Reflection.EnumMember'",
       });
     });
   });
@@ -81,9 +81,13 @@ describe("versioning: reference versioned library", () => {
     it("use a versioned library given version", async () => {
       const { MyService, Test } = (await runner.compile(`
         @versioned(Versions)
-        @versionedDependency([[Versions.v1, VersionedLib.Versions.l1], [Versions.v2, VersionedLib.Versions.l2]])
         @test namespace MyService {
-          enum Versions {v1, v2}
+          enum Versions {
+            @useDependency(VersionedLib.Versions.l1)
+            v1,
+            @useDependency(VersionedLib.Versions.l2)
+            v2
+          }
           @test model Test extends VersionedLib.Foo {}
         } 
     `)) as { MyService: Namespace; Test: Model };
@@ -105,9 +109,13 @@ describe("versioning: reference versioned library", () => {
     it("use the same versioned library version for multiple service versions", async () => {
       const { MyService, Test } = (await runner.compile(`
         @versioned(Versions)
-        @versionedDependency([[Versions.v1, VersionedLib.Versions.l1], [Versions.v2, VersionedLib.Versions.l1]])
         @test namespace MyService {
-          enum Versions {v1, v2}
+          enum Versions {
+            @useDependency(VersionedLib.Versions.l1)
+            v1,
+            @useDependency(VersionedLib.Versions.l1)
+            v2
+          }
           @test model Test extends VersionedLib.Foo {}
         } 
     `)) as { MyService: Namespace; Test: Model };
@@ -126,24 +134,24 @@ describe("versioning: reference versioned library", () => {
       assertFooV1(FooV2);
     });
 
-    it("emit diagnostic if passing a specific version", async () => {
+    it("emit diagnostic if @useDependency and @versioned are used on a Namespace", async () => {
       const diagnostics = await runner.diagnose(`
         @versioned(Versions)
-        @versionedDependency(VersionedLib.Versions.l1)
+        @useDependency(VersionedLib.Versions.l1)
         namespace MyService {
           enum Versions {v1, v2}
           model Test extends VersionedLib.Foo {}
         } 
     `);
       expectDiagnostics(diagnostics, {
-        code: "@cadl-lang/versioning/versioned-dependency-record-not-mapping",
+        code: "@cadl-lang/versioning/incompatible-versioned-namespace-use-dependency",
         message:
-          "The versionedDependency decorator must provide a model mapping local versions to dependency 'VersionedLib' versions",
+          "The useDependency decorator can only be used on a Namespace if the namespace is unversioned.",
       });
     });
   });
 
-  describe("when using versioned library without @versionedDependency", () => {
+  describe("when using versioned library without @useDependency", () => {
     it("emit diagnostic when used in extends", async () => {
       const diagnostics = await runner.diagnose(`
         namespace MyService {
@@ -153,7 +161,7 @@ describe("versioning: reference versioned library", () => {
       expectDiagnostics(diagnostics, {
         code: "@cadl-lang/versioning/using-versioned-library",
         message:
-          "Namespace 'MyService' is referencing types from versioned namespace 'VersionedLib' but didn't specify which versions with @versionedDependency.",
+          "Namespace 'MyService' is referencing types from versioned namespace 'VersionedLib' but didn't specify which versions with @useDependency.",
       });
     });
 
@@ -168,7 +176,7 @@ describe("versioning: reference versioned library", () => {
       expectDiagnostics(diagnostics, {
         code: "@cadl-lang/versioning/using-versioned-library",
         message:
-          "Namespace 'MyService' is referencing types from versioned namespace 'VersionedLib' but didn't specify which versions with @versionedDependency.",
+          "Namespace 'MyService' is referencing types from versioned namespace 'VersionedLib' but didn't specify which versions with @useDependency.",
       });
     });
 
@@ -179,7 +187,7 @@ describe("versioning: reference versioned library", () => {
       expectDiagnostics(diagnostics, {
         code: "@cadl-lang/versioning/using-versioned-library",
         message:
-          "Namespace '' is referencing types from versioned namespace 'VersionedLib' but didn't specify which versions with @versionedDependency.",
+          "Namespace '' is referencing types from versioned namespace 'VersionedLib' but didn't specify which versions with @useDependency.",
       });
     });
 
@@ -267,6 +275,267 @@ describe("versioning: reference versioned library", () => {
           model Foo {}
         }
 
+        @useDependency(Lib.Versions.v1)
+        namespace MyService {
+          namespace SubNamespace {
+            op use(): Lib.Foo;
+          }
+        }
+
+    `);
+      expectDiagnosticEmpty(diagnostics);
+    });
+
+    it("succeed if sub namespace of versioned service reference versioned library", async () => {
+      const diagnostics = await runner.diagnose(`
+        @versioned(Versions)
+        namespace Lib {
+          enum Versions {v1, v2}
+          
+          model Foo {}
+        }
+
+        @versioned(Versions)
+        namespace MyService {
+          enum Versions {
+            @useDependency(Lib.Versions.v1)
+            m1
+          }
+          namespace SubNamespace {
+            op use(): Lib.Foo;
+          }
+        }
+
+    `);
+      expectDiagnosticEmpty(diagnostics);
+    });
+
+    it("succeed if versioned service reference sub namespace type", async () => {
+      const diagnostics = await runner.diagnose(`
+        @versioned(Versions)
+        namespace MyService {
+          enum Versions {m1}
+
+          op use(): SubNamespace.Foo;
+          namespace SubNamespace {
+            model Foo {}
+          }
+        }
+
+    `);
+      expectDiagnosticEmpty(diagnostics);
+    });
+
+    it("succeed reference versioned library sub namespace", async () => {
+      const diagnostics = await runner.diagnose(`
+        @versioned(Versions)
+        namespace Lib {
+          enum Versions {v1, v2}
+
+          namespace LibSub {
+            model Foo {}
+          }
+        }
+
+        @versioned(Versions)
+        namespace MyService {
+          enum Versions {
+            @useDependency(Lib.Versions.v1)
+            m1
+          }
+          namespace ServiceSub {
+            op use(): Lib.LibSub.Foo;
+          }
+        }
+
+    `);
+      expectDiagnosticEmpty(diagnostics);
+    });
+
+    it("emit diagnostic when used in properties of generic type", async () => {
+      const diagnostics = await runner.diagnose(`
+        namespace MyService {
+          model Test<T> {
+            t: T;
+            foo: VersionedLib.Foo
+          }
+        } 
+    `);
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/versioning/using-versioned-library",
+        message:
+          "Namespace 'MyService' is referencing types from versioned namespace 'VersionedLib' but didn't specify which versions with @useDependency.",
+      });
+    });
+  });
+});
+
+describe("versioning (deprecated): reference versioned library (@versionedDependency)", () => {
+  let runner: BasicTestRunner;
+
+  beforeEach(async () => {
+    const host = await createVersioningTestHost();
+    runner = createTestWrapper(host, {
+      wrapper: (code) => `
+      import "@cadl-lang/versioning";
+
+      using Cadl.Versioning;
+
+      @versioned(Versions)
+      namespace VersionedLib {
+        enum Versions {l1, l2}
+        model Foo {
+          name: string;
+          @added(Versions.l2) age: int32;
+        }
+      }
+      ${code}`,
+    });
+  });
+
+  function assertFooV1(foo: Model) {
+    ok(foo.properties.has("name"));
+    ok(!foo.properties.has("age"), "Age was added in version 2 and version 1 was selected.");
+  }
+
+  function assertFooV2(Foo: Model) {
+    ok(Foo.properties.has("name"));
+    ok(Foo.properties.has("age"), "Age was added in version 2 and version 1 was selected.");
+  }
+
+  describe("when project is not-versioned", () => {
+    it("use a versioned library given version", async () => {
+      const { MyService, Test } = (await runner.compile(`
+        #suppress "deprecated"
+        @versionedDependency(VersionedLib.Versions.l1)
+        @test namespace MyService {
+          @test model Test extends VersionedLib.Foo {}
+        } 
+    `)) as { MyService: Namespace; Test: Model };
+      const versions = buildVersionProjections(runner.program, MyService);
+      strictEqual(versions.length, 1);
+      strictEqual(versions[0].version, undefined);
+      strictEqual(versions[0].projections.length, 1);
+
+      const projector = projectProgram(runner.program, versions[0].projections, Test).projector;
+      const Foo = (projector.projectedTypes.get(Test) as any).baseModel;
+
+      assertFooV1(Foo);
+    });
+
+    it("emit diagnostic if passing version mapping", async () => {
+      const diagnostics = await runner.diagnose(`
+        #suppress "deprecated"
+        @versionedDependency([[VersionedLib.Versions.l1, VersionedLib.Versions.l1]])
+        namespace MyService {
+          model Test extends VersionedLib.Foo {}
+        } 
+    `);
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/versioning/versioned-dependency-not-picked",
+        message:
+          "The versionedDependency decorator must provide a version of the dependency 'VersionedLib'.",
+      });
+    });
+  });
+
+  describe("when project is versioned", () => {
+    it("use a versioned library given version", async () => {
+      const { MyService, Test } = (await runner.compile(`
+        #suppress "deprecated"
+        @versioned(Versions)
+        @versionedDependency([[Versions.v1, VersionedLib.Versions.l1], [Versions.v2, VersionedLib.Versions.l2]])
+        @test namespace MyService {
+          enum Versions {v1, v2}
+          @test model Test extends VersionedLib.Foo {}
+        } 
+    `)) as { MyService: Namespace; Test: Model };
+      const versions = buildVersionProjections(runner.program, MyService);
+      strictEqual(versions.length, 2);
+      strictEqual(versions[0].version, "v1");
+      strictEqual(versions[1].version, "v2");
+
+      const projectorV1 = projectProgram(runner.program, versions[0].projections, Test).projector;
+      const FooV1 = (projectorV1.projectedTypes.get(Test) as any).baseModel;
+
+      assertFooV1(FooV1);
+
+      const projectorV2 = projectProgram(runner.program, versions[1].projections, Test).projector;
+      const FooV2 = (projectorV2.projectedTypes.get(Test) as any).baseModel;
+      assertFooV2(FooV2);
+    });
+
+    it("use the same versioned library version for multiple service versions", async () => {
+      const { MyService, Test } = (await runner.compile(`
+        #suppress "deprecated"
+        @versioned(Versions)
+        @versionedDependency([[Versions.v1, VersionedLib.Versions.l1], [Versions.v2, VersionedLib.Versions.l1]])
+        @test namespace MyService {
+          enum Versions {v1, v2}
+          @test model Test extends VersionedLib.Foo {}
+        } 
+    `)) as { MyService: Namespace; Test: Model };
+      const versions = buildVersionProjections(runner.program, MyService);
+      strictEqual(versions.length, 2);
+      strictEqual(versions[0].version, "v1");
+      strictEqual(versions[1].version, "v2");
+
+      const projectorV1 = projectProgram(runner.program, versions[0].projections, Test).projector;
+      const FooV1 = (projectorV1.projectedTypes.get(Test) as any).baseModel;
+
+      assertFooV1(FooV1);
+
+      const projectorV2 = projectProgram(runner.program, versions[1].projections, Test).projector;
+      const FooV2 = (projectorV2.projectedTypes.get(Test) as any).baseModel;
+      assertFooV1(FooV2);
+    });
+
+    it("emit diagnostic if passing a specific version", async () => {
+      const diagnostics = await runner.diagnose(`
+        #suppress "deprecated"
+        @versioned(Versions)
+        @versionedDependency(VersionedLib.Versions.l1)
+        namespace MyService {
+          enum Versions {v1, v2}
+          model Test extends VersionedLib.Foo {}
+        } 
+    `);
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/versioning/versioned-dependency-record-not-mapping",
+        message:
+          "The versionedDependency decorator must provide a model mapping local versions to dependency 'VersionedLib' versions",
+      });
+    });
+  });
+
+  describe("sub namespace of versioned namespace", () => {
+    it("doesn't emit diagnostic when parent namespace is versioned and using type from it", async () => {
+      const diagnostics = await runner.diagnose(`
+        @versioned(Versions)
+        namespace DemoService {
+          enum Versions {v1, v2}
+          
+          model Foo {}
+
+          namespace SubNamespace {
+            op use(): Foo;
+          }
+        }
+
+    `);
+      expectDiagnosticEmpty(diagnostics);
+    });
+
+    it("doesn't emit diagnostic when referencing to versioned library from subnamespace with parent namespace with versioned dependency", async () => {
+      const diagnostics = await runner.diagnose(`
+        @versioned(Versions)
+        namespace Lib {
+          enum Versions {v1, v2}
+          
+          model Foo {}
+        }
+
+        #suppress "deprecated"
         @versionedDependency(Lib.Versions.v1)
         namespace MyService {
           namespace SubNamespace {
@@ -287,6 +556,7 @@ describe("versioning: reference versioned library", () => {
           model Foo {}
         }
 
+        #suppress "deprecated"
         @versioned(Versions)
         @versionedDependency([[Versions.m1, Lib.Versions.v1]])
         namespace MyService {
@@ -327,6 +597,7 @@ describe("versioning: reference versioned library", () => {
           }
         }
 
+        #suppress "deprecated"
         @versioned(Versions)
         @versionedDependency([[Versions.m1, Lib.Versions.v1]])
         namespace MyService {
@@ -352,9 +623,132 @@ describe("versioning: reference versioned library", () => {
       expectDiagnostics(diagnostics, {
         code: "@cadl-lang/versioning/using-versioned-library",
         message:
-          "Namespace 'MyService' is referencing types from versioned namespace 'VersionedLib' but didn't specify which versions with @versionedDependency.",
+          "Namespace 'MyService' is referencing types from versioned namespace 'VersionedLib' but didn't specify which versions with @useDependency.",
       });
     });
+  });
+});
+
+describe("versioning (deprecated): dependencies (@versionedDependency)", () => {
+  let runner: BasicTestRunner;
+
+  beforeEach(async () => {
+    runner = await createVersioningTestRunner();
+  });
+
+  it("can spread versioned model from another library", async () => {
+    const { MyService, Test } = (await runner.compile(`
+      @versioned(Versions)
+      namespace VersionedLib {
+        enum Versions {l1, l2}
+        model Spread<T> {
+          t: string;
+          ...T;
+        }
+      }
+
+      #suppress "deprecated"
+      @versioned(Versions)
+      @versionedDependency([[Versions.v1, VersionedLib.Versions.l1], [Versions.v2, VersionedLib.Versions.l2]])
+      @test namespace MyService {
+        enum Versions {v1, v2}
+
+        model Spreadable {
+          a: int32;
+          @added(Versions.v2) b: int32;
+        }
+        @test model Test extends VersionedLib.Spread<Spreadable> {}
+      }
+      `)) as { MyService: Namespace; Test: Model };
+
+    const [v1, v2] = runProjections(runner.program, MyService);
+
+    const SpreadInstance1 = (v1.projectedTypes.get(Test) as any).baseModel;
+    assertHasProperties(SpreadInstance1, ["t", "a"]);
+    const SpreadInstance2 = (v2.projectedTypes.get(Test) as any).baseModel;
+    assertHasProperties(SpreadInstance2, ["t", "a", "b"]);
+  });
+
+  it("can handle when the versions name are the same across different libraries", async () => {
+    const { MyService, Test } = (await runner.compile(`
+      @versioned(Versions)
+      namespace VersionedLib {
+        enum Versions {v1, v2}
+        model Spread<T> {
+          t: string;
+          ...T;
+        }
+      }
+
+      #suppress "deprecated"
+      @versioned(Versions)
+      @versionedDependency([[Versions.v1, VersionedLib.Versions.v1], [Versions.v2, VersionedLib.Versions.v2]])
+      @test namespace MyService {
+        enum Versions {v1, v2}
+
+        model Spreadable {
+          a: int32;
+          @added(Versions.v2) b: int32;
+        }
+        @test model Test extends VersionedLib.Spread<Spreadable> {}
+      }
+      `)) as { MyService: Namespace; Test: Model };
+
+    const [v1, v2] = runProjections(runner.program, MyService);
+
+    const SpreadInstance1 = (v1.projectedTypes.get(Test) as any).baseModel;
+    assertHasProperties(SpreadInstance1, ["t", "a"]);
+    const SpreadInstance2 = (v2.projectedTypes.get(Test) as any).baseModel;
+    assertHasProperties(SpreadInstance2, ["t", "a", "b"]);
+  });
+
+  // Test for https://github.com/microsoft/cadl/issues/760
+  it("have a nested service namespace", async () => {
+    const { MyService } = (await runner.compile(`
+        #suppress "deprecated"
+        @service({title: "Test"})
+        @versionedDependency(Lib.Versions.v1)
+        @test("MyService")
+        namespace MyOrg.MyService {
+
+        }
+
+        @versioned(Versions)
+        namespace Lib {
+          enum Versions {
+            v1: "v1",
+          }
+        }
+      `)) as { MyService: Namespace };
+
+    const [v1] = runProjections(runner.program, MyService);
+    ok(v1.projectedTypes.get(MyService));
+  });
+
+  // Test for https://github.com/microsoft/cadl/issues/786
+  it("have a nested service namespace and libraries sharing common parent namespace", async () => {
+    const { MyService } = (await runner.compile(`
+        #suppress "deprecated"
+        @service({title: "Test"})
+        @versionedDependency(Lib.One.Versions.v1)
+        @test("MyService")
+        namespace MyOrg.MyService {
+
+        }
+
+        @versioned(Versions)
+        namespace Lib.One {
+          enum Versions { v1: "v1" }
+        }
+        
+        #suppress "deprecated"
+        @versionedDependency(Lib.One.Versions.v1)
+        namespace Lib.Two { }
+
+      `)) as { MyService: Namespace };
+
+    const [v1] = runProjections(runner.program, MyService);
+    ok(v1.projectedTypes.get(MyService));
   });
 });
 
@@ -407,9 +801,13 @@ describe("versioning: dependencies", () => {
       }
 
       @versioned(Versions)
-      @versionedDependency([[Versions.v1, VersionedLib.Versions.l1], [Versions.v2, VersionedLib.Versions.l2]])
       @test namespace MyService {
-        enum Versions {v1, v2}
+        enum Versions {
+          @useDependency(VersionedLib.Versions.l1)
+          v1,
+          @useDependency(VersionedLib.Versions.l2)
+          v2
+        }
 
         model Spreadable {
           a: int32;
@@ -439,9 +837,13 @@ describe("versioning: dependencies", () => {
       }
 
       @versioned(Versions)
-      @versionedDependency([[Versions.v1, VersionedLib.Versions.v1], [Versions.v2, VersionedLib.Versions.v2]])
       @test namespace MyService {
-        enum Versions {v1, v2}
+        enum Versions {
+          @useDependency(VersionedLib.Versions.v1)
+          v1,
+          @useDependency(VersionedLib.Versions.v2)
+          v2
+        }
 
         model Spreadable {
           a: int32;
@@ -463,7 +865,7 @@ describe("versioning: dependencies", () => {
   it("have a nested service namespace", async () => {
     const { MyService } = (await runner.compile(`
         @service({title: "Test"})
-        @versionedDependency(Lib.Versions.v1)
+        @useDependency(Lib.Versions.v1)
         @test("MyService")
         namespace MyOrg.MyService {
 
@@ -485,7 +887,7 @@ describe("versioning: dependencies", () => {
   it("have a nested service namespace and libraries sharing common parent namespace", async () => {
     const { MyService } = (await runner.compile(`
         @service({title: "Test"})
-        @versionedDependency(Lib.One.Versions.v1)
+        @useDependency(Lib.One.Versions.v1)
         @test("MyService")
         namespace MyOrg.MyService {
 
@@ -496,7 +898,7 @@ describe("versioning: dependencies", () => {
           enum Versions { v1: "v1" }
         }
         
-        @versionedDependency(Lib.One.Versions.v1)
+        @useDependency(Lib.One.Versions.v1)
         namespace Lib.Two { }
 
       `)) as { MyService: Namespace };

--- a/packages/versioning/test/versioned-dependencies.test.ts
+++ b/packages/versioning/test/versioned-dependencies.test.ts
@@ -146,7 +146,29 @@ describe("versioning: reference versioned library", () => {
       expectDiagnostics(diagnostics, {
         code: "@cadl-lang/versioning/incompatible-versioned-namespace-use-dependency",
         message:
-          "The useDependency decorator can only be used on a Namespace if the namespace is unversioned.",
+          "The useDependency decorator can only be used on a Namespace if the namespace is unversioned. For versioned namespaces, put the useDependency decorator on the version enum members.",
+      });
+    });
+
+    it("emit diagnostic if @useDependency is used on an enum that isn't in the namespace.", async () => {
+      const diagnostics = await runner.diagnose(`
+        enum TestServiceVersions {
+          @useDependency(VersionedLib.Versions.l1)
+          v1,
+          @useDependency(VersionedLib.Versions.l2)
+          v2,
+        }
+
+        @versioned(TestServiceVersions)
+        namespace TestService {
+          @added(TestServiceVersions.v2)
+          op test(): VersionedLib.Foo;
+        }
+      `);
+      expectDiagnostics(diagnostics, {
+        code: "@cadl-lang/versioning/version-not-found",
+        message:
+          "The provided version 'v2' from 'TestServiceVersions' is not declared as a version enum. Use '@versioned(TestServiceVersions)' on the containing namespace.",
       });
     });
   });


### PR DESCRIPTION
Fixes #1356.

This PR:
- Adds the `@useDependency` decorator, which can be used on a Namespace or EnumMember
- **Deprecates** the `@versionedDependency` decorator

The general approach here for testing:
- for OpenAPI I converted the tests to use the new `@useDependency` decorator
- Within versioning, I copies a set of all tests using `@versionedDependency` and labeled those tests with a "(deprecated @versionedDependency)" identifier.
- I updated the original tests to use `@useDependency`.