### PR TITLE
Change the sample in feed

### DIFF
--- a/eng/feeds/data-plane/cadl-project.yaml
+++ b/eng/feeds/data-plane/cadl-project.yaml
@@ -34,5 +34,5 @@ options:
       name: "@azure-rest/{{#normalizePackageName}}{{parameters.ServiceNamespace}}{{/normalizePackageName}}-rest"
       description: "{{parameters.ServiceNamespace}} Service"
   "@azure-tools/cadl-java":
-    emitter-output-dir: "{java-sdk-folder}/sdk/{service-directory-name}/azure-{{#normalizePackageName}}{{parameters.ServiceNamespace}}{{/normalizePackageName}}"
+    emitter-output-dir: "{java-sdk-folder}/sdk/{service-directory-name}/{{#normalizePackageName}}{{parameters.ServiceNamespace}}{{/normalizePackageName}}"
     namespace: com.{{#toLowerCase}}{{parameters.ServiceNamespace}}{{/toLowerCase}}

--- a/eng/feeds/data-plane/client.cadl
+++ b/eng/feeds/data-plane/client.cadl
@@ -2,3 +2,4 @@
  * PLACEHOLDER
  * Add readme and sample
  */
+import "./main.cadl";

--- a/eng/feeds/data-plane/examples/2022-11-01-preview/Widgets_ListWidgetsSample.json
+++ b/eng/feeds/data-plane/examples/2022-11-01-preview/Widgets_ListWidgetsSample.json
@@ -5,9 +5,6 @@
     "top": 8,
     "skip": 15,
     "maxpagesize": 27,
-    "select": [
-      "type1"
-    ],
     "api-version": "2022-11-01-preview"
   },
   "responses": {

--- a/eng/feeds/data-plane/main.cadl
+++ b/eng/feeds/data-plane/main.cadl
@@ -28,8 +28,20 @@ model Widget {
   @visibility("read")
   name: string;
 
-  @doc("The ID of the widget's manufacturer.")
+  @doc("The ID of the manufacturer.")
   manufacturerId: string;
+
+  @doc("The faked shared model.")
+  sharedModel?: FakedSharedModel;
+}
+
+@doc("Faked shared model")
+model FakedSharedModel {
+  @doc("The tag.")
+  tag: string;
+
+  @doc("The created date.")
+  createdDate: zonedDateTime;
 }
 
 interface Widgets {
@@ -51,7 +63,7 @@ interface Widgets {
   listWidgets is ResourceList<
     Widget,
     {
-      parameters: StandardListQueryParameters & SelectQueryParameter;
+      parameters: StandardListQueryParameters;
     }
   >;
 }


### PR DESCRIPTION
Besides the change in this PR, please add a new line in the end of generated package.jsonbecause the linter in swagger pipeline asks it.

Also, the `service-directory-name` is not expected. When I run cadl init in folder `specification/contoso/TestPackage`, the `service-directory-name` is always `TestPackage`, which is unexpected, and I expect it to be contoso.