### PR TITLE
Add Model type to Cadl.Reflection

### DIFF
--- a/common/changes/@cadl-lang/compiler/reflectionModel_2023-01-11-09-23.json
+++ b/common/changes/@cadl-lang/compiler/reflectionModel_2023-01-11-09-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add type Model to Cadl.Reflection",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/lib/reflection.cadl
+++ b/packages/compiler/lib/reflection.cadl
@@ -1,5 +1,6 @@
 namespace Cadl.Reflection;
 
+model Model {}
 model ModelProperty {}
 model Interface {}
 model Enum {}


### PR DESCRIPTION
We have such decorator to be added:
```
extern dec exclude(target: Model);
```
However, `Model` is not in the Cadl.Reflection