### PR TITLE
Removing Azure alias for cadl init.

### DIFF
--- a/common/changes/@cadl-lang/compiler/azhang_remove_azure_init_2023-01-12-23-05.json
+++ b/common/changes/@cadl-lang/compiler/azhang_remove_azure_init_2023-01-12-23-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "undo `azure` alias for cadl init. Will continue to rely on URL.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/common/changes/@cadl-lang/compiler/azhang_remove_azure_init_2023-01-12-23-05.json
+++ b/common/changes/@cadl-lang/compiler/azhang_remove_azure_init_2023-01-12-23-05.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@cadl-lang/compiler",
-      "comment": "undo `azure` alias for cadl init. Will continue to rely on URL.",
+      "comment": "",
       "type": "none"
     }
   ],

--- a/packages/compiler/init/init.ts
+++ b/packages/compiler/init/init.ts
@@ -88,11 +88,6 @@ export async function initCadlProject(
   directory: string,
   templatesUrl?: string
 ) {
-  if (templatesUrl?.toLowerCase() === "azure") {
-    templatesUrl =
-      "https://raw.githubusercontent.com/microsoft/cadl/main/eng/feeds/azure-scaffolding.json";
-  }
-
   if (!(await confirmDirectoryEmpty(directory))) {
     return;
   }


### PR DESCRIPTION
We will continue to use URL. Will have a short aka link.

Follow-up item to moving feed to Azure repo will be in a separate PR. Moving to Azure/Cadl after SH team records demo this week.