### PR TITLE
Convert Ref objects to ref string in OpenAPI YAML output

### DIFF
--- a/common/changes/@cadl-lang/openapi3/fix-openapi-yaml_2023-01-17-15-17.json
+++ b/common/changes/@cadl-lang/openapi3/fix-openapi-yaml_2023-01-17-15-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Convert Ref objects to ref string in OpenAPI YAML output",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1467,7 +1467,7 @@ function serializeDocument(root: OpenAPI3Document, fileType: FileType): string {
       return yaml.dump(root, {
         noRefs: true,
         replacer: function (key, value) {
-          return key === "$ref" && value instanceof Ref ? value.value! : value;
+          return value instanceof Ref ? value.toJSON() : value;
         },
       });
   }

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1464,7 +1464,12 @@ function serializeDocument(root: OpenAPI3Document, fileType: FileType): string {
     case "json":
       return prettierOutput(JSON.stringify(root, null, 2));
     case "yaml":
-      return yaml.dump(root, { noRefs: true });
+      return yaml.dump(root, {
+        noRefs: true,
+        replacer: function (key, value) {
+          return key === "$ref" && value instanceof Ref ? value.value! : value;
+        },
+      });
   }
 }
 

--- a/packages/samples/test/output/binary/openapi.yaml
+++ b/packages/samples/test/output/binary/openapi.yaml
@@ -14,14 +14,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/HasBytes'
+                $ref: '#/components/schemas/HasBytes'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/HasBytes'
+              $ref: '#/components/schemas/HasBytes'
   /test/textPlain:
     post:
       operationId: BytesMethod_textPlain

--- a/packages/samples/test/output/documentation/openapi.yaml
+++ b/packages/samples/test/output/documentation/openapi.yaml
@@ -14,15 +14,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Resp'
+                $ref: '#/components/schemas/Resp'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
   /foo/ModelDocDescriptions:
     get:
       operationId: Foo_withModelDocDescriptions
@@ -33,15 +31,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RespWithDocs'
+                $ref: '#/components/schemas/RespWithDocs'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ErrorWithDocs'
+                $ref: '#/components/schemas/ErrorWithDocs'
   /foo/NotFoundWithDocs:
     get:
       operationId: Foo_withStatusCodeDocs
@@ -52,22 +48,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Resp'
+                $ref: '#/components/schemas/Resp'
         '404':
           description: The server cannot find the requested resource.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/NotFoundWithDocsResp'
+                $ref: '#/components/schemas/NotFoundWithDocsResp'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
   /foo/NotFoundDefaultDocs:
     get:
       operationId: Foo_withDefaultDescNotFound
@@ -78,22 +71,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RespWithDocs'
+                $ref: '#/components/schemas/RespWithDocs'
         '404':
           description: The server cannot find the requested resource.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/NotFoundResp'
+                $ref: '#/components/schemas/NotFoundResp'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     Resp:

--- a/packages/samples/test/output/grpc-kiosk-example/openapi.yaml
+++ b/packages/samples/test/output/grpc-kiosk-example/openapi.yaml
@@ -18,21 +18,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Kiosk'
+                $ref: '#/components/schemas/Kiosk'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/Kiosk'
+              $ref: '#/components/schemas/Kiosk'
     get:
       tags:
         - Display
@@ -45,15 +42,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ListKiosksResponse'
+                $ref: '#/components/schemas/ListKiosksResponse'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
   /v1/kiosks/{id}:
     get:
       tags:
@@ -73,15 +68,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Kiosk'
+                $ref: '#/components/schemas/Kiosk'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
     delete:
       tags:
         - Display
@@ -104,8 +97,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
   /v1/signs:
     post:
       tags:
@@ -119,21 +111,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Sign'
+                $ref: '#/components/schemas/Sign'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/Sign'
+              $ref: '#/components/schemas/Sign'
     get:
       tags:
         - Display
@@ -146,8 +135,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ListSignsResponse'
+                $ref: '#/components/schemas/ListSignsResponse'
   /v1/signs/{id}:
     get:
       tags:
@@ -167,15 +155,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Sign'
+                $ref: '#/components/schemas/Sign'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
     delete:
       tags:
         - Display
@@ -198,8 +184,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
   /v1/signs/{sign_id}:
     post:
       tags:
@@ -218,8 +203,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
       requestBody:
         content:
           application/json:
@@ -248,15 +232,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/GetSignIdResponse'
+                $ref: '#/components/schemas/GetSignIdResponse'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
 components:
   parameters:
     SetSignIdForKioskIdsRequest.sign_id:
@@ -279,17 +261,14 @@ components:
           description: name of device hardware
         size:
           allOf:
-            - $ref:
-                value: '#/components/schemas/ScreenSize'
+            - $ref: '#/components/schemas/ScreenSize'
           description: screen size
         location:
           allOf:
-            - $ref:
-                value: '#/components/schemas/LatLng'
+            - $ref: '#/components/schemas/LatLng'
           description: kiosk location
         create_time:
-          $ref:
-            value: '#/components/schemas/Timestamp'
+          $ref: '#/components/schemas/Timestamp'
       description: Describes a hardware device that can display signs.
       required:
         - name
@@ -306,8 +285,7 @@ components:
         details:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/ProtobufAny'
+            $ref: '#/components/schemas/ProtobufAny'
           x-cadl-name: ProtobufAny[]
       description: An unexpected error response.
     ListKiosksResponse:
@@ -316,8 +294,7 @@ components:
         kiosks:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/Kiosk'
+            $ref: '#/components/schemas/Kiosk'
           x-cadl-name: Kiosk[]
       description: A successful response.
     Sign:
@@ -350,8 +327,7 @@ components:
         signs:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/Sign'
+            $ref: '#/components/schemas/Sign'
           x-cadl-name: Sign[]
       description: A successful response.
     GetSignIdResponse:

--- a/packages/samples/test/output/grpc-library-example/openapi.yaml
+++ b/packages/samples/test/output/grpc-library-example/openapi.yaml
@@ -18,22 +18,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Shelf'
+                $ref: '#/components/schemas/Shelf'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
       requestBody:
         description: The shelf to create.
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/Shelf'
+              $ref: '#/components/schemas/Shelf'
     get:
       tags:
         - LibraryService
@@ -50,15 +47,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ListShelvesResponse'
+                $ref: '#/components/schemas/ListShelvesResponse'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
   /v1/shelves/{name}:
     get:
       tags:
@@ -73,15 +68,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Shelf'
+                $ref: '#/components/schemas/Shelf'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
     delete:
       tags:
         - LibraryService
@@ -99,8 +92,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
   /v1/shelves/{name}:merge:
     post:
       tags:
@@ -127,22 +119,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Shelf'
+                $ref: '#/components/schemas/Shelf'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
       requestBody:
         description: The name of the shelf we're removing books from and deleting.
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/shelf_name'
+              $ref: '#/components/schemas/shelf_name'
   /v1/shelves/{name}/books:
     post:
       tags:
@@ -157,22 +146,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Book'
+                $ref: '#/components/schemas/Book'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
       requestBody:
         description: The book to create.
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/Book'
+              $ref: '#/components/schemas/Book'
     get:
       tags:
         - LibraryService
@@ -194,15 +180,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ListBooksResponse'
+                $ref: '#/components/schemas/ListBooksResponse'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
   /v1/shelves/shelf_name/books/{name}:
     get:
       tags:
@@ -217,15 +201,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Book'
+                $ref: '#/components/schemas/Book'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
     delete:
       tags:
         - LibraryService
@@ -243,8 +225,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/RpcStatus'
+                $ref: '#/components/schemas/RpcStatus'
 components:
   parameters:
     GetShelfRequest:
@@ -333,8 +314,7 @@ components:
       properties:
         name:
           allOf:
-            - $ref:
-                value: '#/components/schemas/shelf_name'
+            - $ref: '#/components/schemas/shelf_name'
           description: |-
             The resource name of the shelf.
             Shelf names have the form `shelves/{shelf_id}`.
@@ -356,8 +336,7 @@ components:
         details:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/ProtobufAny'
+            $ref: '#/components/schemas/ProtobufAny'
           x-cadl-name: ProtobufAny[]
       description: An unexpected error response.
     ListShelvesResponse:
@@ -366,8 +345,7 @@ components:
         shelves:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/Shelf'
+            $ref: '#/components/schemas/Shelf'
           x-cadl-name: Shelf[]
           description: The list of shelves.
         next_page_token:
@@ -397,8 +375,7 @@ components:
       properties:
         name:
           allOf:
-            - $ref:
-                value: '#/components/schemas/book_name'
+            - $ref: '#/components/schemas/book_name'
           description: |-
             The resource name of the book.
             Book names have the form `shelves/{shelf_id}/books/{book_id}`.
@@ -421,8 +398,7 @@ components:
         books:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/Book'
+            $ref: '#/components/schemas/Book'
           x-cadl-name: Book[]
           description: The list of books.
         next_page_token:
@@ -446,8 +422,7 @@ components:
       properties:
         body:
           allOf:
-            - $ref:
-                value: '#/components/schemas/Shelf'
+            - $ref: '#/components/schemas/Shelf'
           description: The shelf to create.
       description: Request message for LibraryService.CreateShelf.
       required:
@@ -491,8 +466,7 @@ components:
       properties:
         other_shelf_name:
           allOf:
-            - $ref:
-                value: '#/components/schemas/shelf_name'
+            - $ref: '#/components/schemas/shelf_name'
           description: The name of the shelf we're removing books from and deleting.
       description: |-
         Describes the shelf being removed (other_shelf_name) and updated
@@ -504,8 +478,7 @@ components:
       properties:
         book:
           allOf:
-            - $ref:
-                value: '#/components/schemas/Book'
+            - $ref: '#/components/schemas/Book'
           description: The book to create.
       description: Request message for LibraryService.CreateBook.
       required:
@@ -533,13 +506,11 @@ components:
       properties:
         name:
           allOf:
-            - $ref:
-                value: '#/components/schemas/book_name'
+            - $ref: '#/components/schemas/book_name'
           description: The name of the book to update.
         book:
           allOf:
-            - $ref:
-                value: '#/components/schemas/Book'
+            - $ref: '#/components/schemas/Book'
           description: The book to update with. The name must match or be empty.
       description: Request message for LibraryService.UpdateBook.
       required:
@@ -550,13 +521,11 @@ components:
       properties:
         name:
           allOf:
-            - $ref:
-                value: '#/components/schemas/book_name'
+            - $ref: '#/components/schemas/book_name'
           description: The name of the book to move.
         other_shelf_name:
           allOf:
-            - $ref:
-                value: '#/components/schemas/shelf_name'
+            - $ref: '#/components/schemas/shelf_name'
           description: The name of the destination shelf.
       description: |-
         Describes what book to move (name) and what shelf we're moving it

--- a/packages/samples/test/output/multiple-types-union/openapi.yaml
+++ b/packages/samples/test/output/multiple-types-union/openapi.yaml
@@ -15,8 +15,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Pet'
+                $ref: '#/components/schemas/Pet'
 components:
   parameters:
     ApiVersionParam:
@@ -28,10 +27,8 @@ components:
   schemas:
     Pet:
       anyOf:
-        - $ref:
-            value: '#/components/schemas/Cat'
-        - $ref:
-            value: '#/components/schemas/Dog'
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
     ApiVersionParam:
       type: object
       properties: {}
@@ -56,8 +53,7 @@ components:
         - type
         - nextWalkTime
       allOf:
-        - $ref:
-            value: '#/components/schemas/PetBase'
+        - $ref: '#/components/schemas/PetBase'
     Cat:
       type: object
       properties:
@@ -72,5 +68,4 @@ components:
         - type
         - catnipDose
       allOf:
-        - $ref:
-            value: '#/components/schemas/PetBase'
+        - $ref: '#/components/schemas/PetBase'

--- a/packages/samples/test/output/nested/openapi.yaml
+++ b/packages/samples/test/output/nested/openapi.yaml
@@ -19,8 +19,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/SubA.SubSubA.Thing'
+              $ref: '#/components/schemas/SubA.SubSubA.Thing'
   /sub/b:
     post:
       operationId: SubB_doSomething
@@ -36,8 +35,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/SubB.Thing'
+              $ref: '#/components/schemas/SubB.Thing'
   /:
     post:
       operationId: SubC_anotherOp
@@ -56,11 +54,9 @@ paths:
               type: object
               properties:
                 thing:
-                  $ref:
-                    value: '#/components/schemas/SubA.Thing'
+                  $ref: '#/components/schemas/SubA.Thing'
                 thing2:
-                  $ref:
-                    value: '#/components/schemas/SubA.Thing'
+                  $ref: '#/components/schemas/SubA.Thing'
               required:
                 - thing
                 - thing2

--- a/packages/samples/test/output/nullable/openapi.yaml
+++ b/packages/samples/test/output/nullable/openapi.yaml
@@ -20,16 +20,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/HasNullables'
+                $ref: '#/components/schemas/HasNullables'
       requestBody:
         content:
           application/json:
             schema:
               type: object
               allOf:
-                - $ref:
-                    value: '#/components/schemas/AnotherModel'
+                - $ref: '#/components/schemas/AnotherModel'
               nullable: true
               x-cadl-name: AnotherModel | null
 components:
@@ -57,8 +55,7 @@ components:
         modelOrNull:
           type: object
           allOf:
-            - $ref:
-                value: '#/components/schemas/AnotherModel'
+            - $ref: '#/components/schemas/AnotherModel'
           nullable: true
           x-cadl-name: AnotherModel | null
         literalsOrNull:

--- a/packages/samples/test/output/openapi-extensions/openapi.yaml
+++ b/packages/samples/test/output/openapi-extensions/openapi.yaml
@@ -14,8 +14,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Foo'
+                $ref: '#/components/schemas/Foo'
 components:
   schemas:
     Foo:
@@ -51,8 +50,7 @@ components:
           enum:
             - 12
         other:
-          $ref:
-            value: '#/components/schemas/NestedConfig'
+          $ref: '#/components/schemas/NestedConfig'
       required:
         - name
         - age

--- a/packages/samples/test/output/optional/openapi.yaml
+++ b/packages/samples/test/output/optional/openapi.yaml
@@ -20,8 +20,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/HasOptional'
+                $ref: '#/components/schemas/HasOptional'
       requestBody:
         content:
           application/json:
@@ -62,8 +61,7 @@ components:
           default: foo
         optionalEnum:
           allOf:
-            - $ref:
-                value: '#/components/schemas/MyEnum'
+            - $ref: '#/components/schemas/MyEnum'
           default: a
     MyEnum:
       type: string

--- a/packages/samples/test/output/param-decorators/openapi.yaml
+++ b/packages/samples/test/output/param-decorators/openapi.yaml
@@ -29,8 +29,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Thing'
+                $ref: '#/components/schemas/Thing'
     put:
       operationId: Operations_putThing
       parameters:
@@ -41,14 +40,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Thing'
+                $ref: '#/components/schemas/Thing'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/Thing'
+              $ref: '#/components/schemas/Thing'
 components:
   parameters:
     NameParameter:

--- a/packages/samples/test/output/petstore/openapi.yaml
+++ b/packages/samples/test/output/petstore/openapi.yaml
@@ -23,8 +23,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     get:
       operationId: Pets_read
       description: Returns a pet. Supports eTags.
@@ -36,8 +35,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Pet'
+                $ref: '#/components/schemas/Pet'
         '304':
           description: >-
             The client has made a conditional request and the resource has not
@@ -45,15 +43,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Pet'
+                $ref: '#/components/schemas/Pet'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
   /pets:
     get:
       operationId: Pets_list
@@ -70,15 +66,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetListResults'
+                $ref: '#/components/schemas/PetListResults'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     post:
       operationId: Pets_create
       parameters: []
@@ -88,21 +82,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Pet'
+                $ref: '#/components/schemas/Pet'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/Pet'
+              $ref: '#/components/schemas/Pet'
   /pets/{petId}/toys:
     get:
       operationId: ListPetToysResponse_list
@@ -123,15 +114,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ToyListResults'
+                $ref: '#/components/schemas/ToyListResults'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
 components:
   parameters:
     PetId:
@@ -160,8 +149,7 @@ components:
         items:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/Pet'
+            $ref: '#/components/schemas/Pet'
           x-cadl-name: Pet[]
         nextLink:
           type: string
@@ -188,8 +176,7 @@ components:
         items:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/Toy'
+            $ref: '#/components/schemas/Toy'
           x-cadl-name: Toy[]
         nextLink:
           type: string

--- a/packages/samples/test/output/polymorphism/openapi.yaml
+++ b/packages/samples/test/output/polymorphism/openapi.yaml
@@ -31,10 +31,8 @@ components:
       discriminator:
         propertyName: kind
         mapping:
-          cat:
-            value: '#/components/schemas/Cat'
-          dog:
-            value: '#/components/schemas/Dog'
+          cat: '#/components/schemas/Cat'
+          dog: '#/components/schemas/Dog'
       required:
         - name
     Cat:

--- a/packages/samples/test/output/polymorphism/openapi.yaml
+++ b/packages/samples/test/output/polymorphism/openapi.yaml
@@ -14,8 +14,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Pet'
+                $ref: '#/components/schemas/Pet'
 components:
   schemas:
     Pet:
@@ -52,8 +51,7 @@ components:
         - kind
         - meow
       allOf:
-        - $ref:
-            value: '#/components/schemas/Pet'
+        - $ref: '#/components/schemas/Pet'
     Dog:
       type: object
       properties:
@@ -67,5 +65,4 @@ components:
         - kind
         - bark
       allOf:
-        - $ref:
-            value: '#/components/schemas/Pet'
+        - $ref: '#/components/schemas/Pet'

--- a/packages/samples/test/output/projected-names/openapi.yaml
+++ b/packages/samples/test/output/projected-names/openapi.yaml
@@ -19,8 +19,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/WithProjectedNames'
+                $ref: '#/components/schemas/WithProjectedNames'
 components:
   schemas:
     WithProjectedNames:

--- a/packages/samples/test/output/rest/petstore/openapi.yaml
+++ b/packages/samples/test/output/rest/petstore/openapi.yaml
@@ -21,15 +21,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Pet'
+                $ref: '#/components/schemas/Pet'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
     patch:
       operationId: Pets_update
       description: Updates an existing instance of the resource.
@@ -46,21 +44,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Pet'
+                $ref: '#/components/schemas/Pet'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/PetUpdate'
+              $ref: '#/components/schemas/PetUpdate'
     delete:
       operationId: Pets_delete
       description: Deletes an existing instance of the resource.
@@ -79,8 +74,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
   /pets:
     post:
       operationId: Pets_create
@@ -92,28 +86,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Pet'
+                $ref: '#/components/schemas/Pet'
         '201':
           description: Resource create operation completed successfully.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Pet'
+                $ref: '#/components/schemas/Pet'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/PetCreate'
+              $ref: '#/components/schemas/PetCreate'
     get:
       operationId: Pets_list
       description: Lists all instances of the resource.
@@ -124,15 +114,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetCollectionWithNextLink'
+                $ref: '#/components/schemas/PetCollectionWithNextLink'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
   /pets/{petId}/checkups/{checkupId}:
     patch:
       operationId: PetCheckups_CreateOrUpdate
@@ -156,28 +144,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Checkup'
+                $ref: '#/components/schemas/Checkup'
         '201':
           description: Resource create operation completed successfully.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Checkup'
+                $ref: '#/components/schemas/Checkup'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/CheckupUpdate'
+              $ref: '#/components/schemas/CheckupUpdate'
   /pets/{petId}/checkups:
     get:
       operationId: PetCheckups_List
@@ -195,15 +179,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/CheckupCollectionWithNextLink'
+                $ref: '#/components/schemas/CheckupCollectionWithNextLink'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
   /pets/{petId}/insurance:
     get:
       operationId: PetInsurance_Get
@@ -221,15 +203,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Insurance'
+                $ref: '#/components/schemas/Insurance'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
     patch:
       operationId: PetInsurance_Update
       description: Updates the singleton resource.
@@ -246,21 +226,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Insurance'
+                $ref: '#/components/schemas/Insurance'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/InsuranceUpdate'
+              $ref: '#/components/schemas/InsuranceUpdate'
   /pets/{petId}/toys/{toyId}:
     get:
       operationId: Toys_get
@@ -284,15 +261,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Toy'
+                $ref: '#/components/schemas/Toy'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
   /pets/{petId}/toys:
     get:
       operationId: Toys_list
@@ -314,15 +289,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ToyCollectionWithNextLink'
+                $ref: '#/components/schemas/ToyCollectionWithNextLink'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
   /pets/{petId}/toys/{toyId}/insurance:
     get:
       operationId: ToyInsurance_Get
@@ -346,15 +319,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Insurance'
+                $ref: '#/components/schemas/Insurance'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
     patch:
       operationId: ToyInsurance_Update
       description: Updates the singleton resource.
@@ -377,21 +348,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Insurance'
+                $ref: '#/components/schemas/Insurance'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/InsuranceUpdate'
+              $ref: '#/components/schemas/InsuranceUpdate'
   /checkups/{checkupId}:
     patch:
       operationId: Checkups_createOrUpdate
@@ -409,28 +377,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Checkup'
+                $ref: '#/components/schemas/Checkup'
         '201':
           description: Resource create operation completed successfully.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Checkup'
+                $ref: '#/components/schemas/Checkup'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/CheckupUpdate'
+              $ref: '#/components/schemas/CheckupUpdate'
   /checkups:
     get:
       operationId: Checkups_list
@@ -442,15 +406,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/CheckupCollectionWithNextLink'
+                $ref: '#/components/schemas/CheckupCollectionWithNextLink'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
   /owners/{ownerId}:
     get:
       operationId: Owners_get
@@ -468,15 +430,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Owner'
+                $ref: '#/components/schemas/Owner'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
     patch:
       operationId: Owners_update
       description: Updates an existing instance of the resource.
@@ -493,21 +453,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Owner'
+                $ref: '#/components/schemas/Owner'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/OwnerUpdate'
+              $ref: '#/components/schemas/OwnerUpdate'
     delete:
       operationId: Owners_delete
       description: Deletes an existing instance of the resource.
@@ -526,8 +483,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
   /owners:
     post:
       operationId: Owners_create
@@ -539,28 +495,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Owner'
+                $ref: '#/components/schemas/Owner'
         '201':
           description: Resource create operation completed successfully.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Owner'
+                $ref: '#/components/schemas/Owner'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/OwnerCreate'
+              $ref: '#/components/schemas/OwnerCreate'
     get:
       operationId: Owners_list
       description: Lists all instances of the resource.
@@ -571,15 +523,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/OwnerCollectionWithNextLink'
+                $ref: '#/components/schemas/OwnerCollectionWithNextLink'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
   /owners/{ownerId}/checkups/{checkupId}:
     patch:
       operationId: OwnerCheckups_CreateOrUpdate
@@ -603,28 +553,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Checkup'
+                $ref: '#/components/schemas/Checkup'
         '201':
           description: Resource create operation completed successfully.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Checkup'
+                $ref: '#/components/schemas/Checkup'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/CheckupUpdate'
+              $ref: '#/components/schemas/CheckupUpdate'
   /owners/{ownerId}/checkups:
     get:
       operationId: OwnerCheckups_List
@@ -642,15 +588,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/CheckupCollectionWithNextLink'
+                $ref: '#/components/schemas/CheckupCollectionWithNextLink'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
   /owners/{ownerId}/insurance:
     get:
       operationId: OwnerInsurance_Get
@@ -668,15 +612,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Insurance'
+                $ref: '#/components/schemas/Insurance'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
     patch:
       operationId: OwnerInsurance_Update
       description: Updates the singleton resource.
@@ -693,21 +635,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Insurance'
+                $ref: '#/components/schemas/Insurance'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetStoreError'
+                $ref: '#/components/schemas/PetStoreError'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/InsuranceUpdate'
+              $ref: '#/components/schemas/InsuranceUpdate'
 components:
   schemas:
     Pet:
@@ -786,8 +725,7 @@ components:
         value:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/Pet'
+            $ref: '#/components/schemas/Pet'
           x-cadl-name: Pet[]
           description: The items on this page
         nextLink:
@@ -826,8 +764,7 @@ components:
         value:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/Checkup'
+            $ref: '#/components/schemas/Checkup'
           x-cadl-name: Checkup[]
           description: The items on this page
         nextLink:
@@ -886,8 +823,7 @@ components:
         value:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/Toy'
+            $ref: '#/components/schemas/Toy'
           x-cadl-name: Toy[]
           description: The items on this page
         nextLink:
@@ -940,8 +876,7 @@ components:
         value:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/Owner'
+            $ref: '#/components/schemas/Owner'
           x-cadl-name: Owner[]
           description: The items on this page
         nextLink:

--- a/packages/samples/test/output/signatures/openapi.yaml
+++ b/packages/samples/test/output/signatures/openapi.yaml
@@ -20,15 +20,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/CodeSignAccount'
+                $ref: '#/components/schemas/CodeSignAccount'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ErrorDetails'
+                $ref: '#/components/schemas/ErrorDetails'
   /codeSignAccounts:
     post:
       operationId: CodeSignAccounts_create
@@ -40,21 +38,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/CodeSignAccount'
+                $ref: '#/components/schemas/CodeSignAccount'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ErrorDetails'
+                $ref: '#/components/schemas/ErrorDetails'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/CodeSignAccount'
+              $ref: '#/components/schemas/CodeSignAccount'
   /accountProfiles/{name}:
     get:
       operationId: AccountProfiles_get
@@ -71,15 +66,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/AccountProfile'
+                $ref: '#/components/schemas/AccountProfile'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ErrorDetails'
+                $ref: '#/components/schemas/ErrorDetails'
   /accountProfiles:
     post:
       operationId: AccountProfiles_create
@@ -91,21 +84,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/AccountProfile'
+                $ref: '#/components/schemas/AccountProfile'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ErrorDetails'
+                $ref: '#/components/schemas/ErrorDetails'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/AccountProfile'
+              $ref: '#/components/schemas/AccountProfile'
 components:
   schemas:
     CodeSignAccount:

--- a/packages/samples/test/output/tags/openapi.yaml
+++ b/packages/samples/test/output/tags/openapi.yaml
@@ -63,8 +63,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref:
-                    value: '#/components/schemas/Resp'
+                  $ref: '#/components/schemas/Resp'
                 x-cadl-name: Resp[]
   /bar/{id}:
     post:

--- a/packages/samples/test/output/testserver/body-boolean/openapi.yaml
+++ b/packages/samples/test/output/testserver/body-boolean/openapi.yaml
@@ -23,8 +23,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: bool_putTrue
       description: Set Boolean value true
@@ -37,8 +36,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
@@ -65,8 +63,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: bool_putFalse
       description: Set Boolean value false
@@ -83,8 +80,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
@@ -109,8 +105,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
   /bool/invalid:
     get:
       operationId: bool_getInvalid
@@ -128,8 +123,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     Error:

--- a/packages/samples/test/output/testserver/body-complex/openapi.yaml
+++ b/packages/samples/test/output/testserver/body-complex/openapi.yaml
@@ -15,15 +15,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Basic'
+                $ref: '#/components/schemas/Basic'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: Complex_putValid
       description: 'Please put {id: 2, name: ''abc'', color: ''Magenta''}'
@@ -36,14 +34,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/Basic'
+              $ref: '#/components/schemas/Basic'
   /complex/primitive/integer:
     get:
       operationId: Complex_getInt
@@ -55,15 +51,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/IntWrapper'
+                $ref: '#/components/schemas/IntWrapper'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: Complex_putInt
       description: Put complex types with integer properties
@@ -76,14 +70,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/IntWrapper'
+              $ref: '#/components/schemas/IntWrapper'
   /complex/primitive/long:
     get:
       operationId: Complex_getLong
@@ -95,15 +87,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/LongWrapper'
+                $ref: '#/components/schemas/LongWrapper'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: Complex_putLong
       description: Put complex types with long properties
@@ -116,14 +106,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/LongWrapper'
+              $ref: '#/components/schemas/LongWrapper'
   /complex/primitive/float:
     get:
       operationId: Complex_getFloat
@@ -135,15 +123,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/FloatWrapper'
+                $ref: '#/components/schemas/FloatWrapper'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: Complex_putFloat
       description: Put complex types with float properties
@@ -156,14 +142,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/FloatWrapper'
+              $ref: '#/components/schemas/FloatWrapper'
   /complex/primitive/double:
     get:
       operationId: Complex_getDouble
@@ -175,15 +159,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/DoubleWrapper'
+                $ref: '#/components/schemas/DoubleWrapper'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: Complex_putDouble
       description: Put complex types with double properties
@@ -196,14 +178,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/DoubleWrapper'
+              $ref: '#/components/schemas/DoubleWrapper'
   /complex/primitive/bool:
     get:
       operationId: Complex_getBool
@@ -215,15 +195,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/BooleanWrapper'
+                $ref: '#/components/schemas/BooleanWrapper'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: Complex_putBool
       description: Put complex types with bool properties
@@ -236,14 +214,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/BooleanWrapper'
+              $ref: '#/components/schemas/BooleanWrapper'
   /complex/primitive/string:
     get:
       operationId: Complex_getString
@@ -255,15 +231,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/StringWrapper'
+                $ref: '#/components/schemas/StringWrapper'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: Complex_putString
       description: Put complex types with string properties
@@ -276,14 +250,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/StringWrapper'
+              $ref: '#/components/schemas/StringWrapper'
   /complex/primitive/date:
     get:
       operationId: Complex_getPlainDate
@@ -295,15 +267,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PlainDateWrapper'
+                $ref: '#/components/schemas/PlainDateWrapper'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: Complex_putPlainDate
       description: Put complex types with date properties
@@ -316,14 +286,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/PlainDateWrapper'
+              $ref: '#/components/schemas/PlainDateWrapper'
   /complex/primitive/datetime:
     get:
       operationId: Complex_getZonedDateTime
@@ -335,15 +303,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/DateTimeWrapper'
+                $ref: '#/components/schemas/DateTimeWrapper'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: Complex_putZonedDateTime
       description: Put complex types with DateTime properties
@@ -356,14 +322,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/DateTimeWrapper'
+              $ref: '#/components/schemas/DateTimeWrapper'
   /complex/primitive/duration:
     get:
       operationId: Complex_getZonedDuration
@@ -375,15 +339,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/DurationWrapper'
+                $ref: '#/components/schemas/DurationWrapper'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: Complex_putZonedDuration
       description: Put complex types with Duration properties
@@ -396,14 +358,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/DurationWrapper'
+              $ref: '#/components/schemas/DurationWrapper'
   /complex/primitive/bytes:
     get:
       operationId: Complex_getBytes
@@ -415,15 +375,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/BytesWrapper'
+                $ref: '#/components/schemas/BytesWrapper'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: Complex_putBytes
       description: Put complex types with bytes properties
@@ -436,14 +394,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/BytesWrapper'
+              $ref: '#/components/schemas/BytesWrapper'
   /complex/array/valid:
     get:
       operationId: Complex_getArray
@@ -455,15 +411,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ArrayWrapper'
+                $ref: '#/components/schemas/ArrayWrapper'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: Complex_putArray
       description: Put complex types with array properties
@@ -476,14 +430,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/ArrayWrapper'
+              $ref: '#/components/schemas/ArrayWrapper'
   /complex/dictionary/typed/valid:
     get:
       operationId: Dictionary_getDictionary
@@ -495,15 +447,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/DictionaryWrapper'
+                $ref: '#/components/schemas/DictionaryWrapper'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: Dictionary_putArray
       description: Put complex types with dictionary property
@@ -516,14 +466,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/DictionaryWrapper'
+              $ref: '#/components/schemas/DictionaryWrapper'
 components:
   schemas:
     Basic:
@@ -541,8 +489,7 @@ components:
             Name property with a very long description that does not fit on a
             single line and a line break.
         color:
-          $ref:
-            value: '#/components/schemas/CMYKColors'
+          $ref: '#/components/schemas/CMYKColors'
       required:
         - id
         - name

--- a/packages/samples/test/output/testserver/body-string/openapi.yaml
+++ b/packages/samples/test/output/testserver/body-string/openapi.yaml
@@ -26,8 +26,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       tags:
         - String Operations
@@ -42,8 +41,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
@@ -72,8 +70,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       tags:
         - String Operations
@@ -88,8 +85,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
@@ -121,8 +117,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       tags:
         - String Operations
@@ -139,8 +134,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
@@ -173,8 +167,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       tags:
         - String Operations
@@ -192,8 +185,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
@@ -221,8 +213,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       tags:
         - String Operations
@@ -237,8 +228,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
@@ -258,15 +248,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Colors'
+                $ref: '#/components/schemas/Colors'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       tags:
         - String Operations
@@ -281,14 +269,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/Colors'
+              $ref: '#/components/schemas/Colors'
   /string/enum/constant:
     get:
       tags:
@@ -302,15 +288,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Colors'
+                $ref: '#/components/schemas/Colors'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       tags:
         - String Operations
@@ -325,14 +309,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/Colors'
+              $ref: '#/components/schemas/Colors'
 components:
   schemas:
     Error:

--- a/packages/samples/test/output/testserver/body-time/openapi.yaml
+++ b/packages/samples/test/output/testserver/body-time/openapi.yaml
@@ -22,8 +22,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
     put:
       operationId: Time_put
       description: Put time value "08:07:56"
@@ -36,8 +35,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error'
       requestBody:
         content:
           application/json:

--- a/packages/samples/test/output/testserver/media-types/openapi.yaml
+++ b/packages/samples/test/output/testserver/media-types/openapi.yaml
@@ -21,24 +21,19 @@ paths:
         content:
           application/pdf:
             schema:
-              $ref:
-                value: '#/components/schemas/SourcePath'
+              $ref: '#/components/schemas/SourcePath'
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/SourcePath'
+              $ref: '#/components/schemas/SourcePath'
           image/jpeg:
             schema:
-              $ref:
-                value: '#/components/schemas/SourcePath'
+              $ref: '#/components/schemas/SourcePath'
           image/png:
             schema:
-              $ref:
-                value: '#/components/schemas/SourcePath'
+              $ref: '#/components/schemas/SourcePath'
           image/tiff:
             schema:
-              $ref:
-                value: '#/components/schemas/SourcePath'
+              $ref: '#/components/schemas/SourcePath'
   /mediatypes/contentTypeWithEncoding:
     post:
       operationId: contentTypeWithEncoding
@@ -58,8 +53,7 @@ paths:
         content:
           text/plain:
             schema:
-              $ref:
-                value: '#/components/schemas/SourcePath'
+              $ref: '#/components/schemas/SourcePath'
 components:
   schemas:
     SourcePath:
@@ -78,8 +72,7 @@ components:
       properties:
         input:
           allOf:
-            - $ref:
-                value: '#/components/schemas/SourcePath'
+            - $ref: '#/components/schemas/SourcePath'
           description: Input parameter.
       required:
         - input

--- a/packages/samples/test/output/testserver/multiple-inheritance/openapi.yaml
+++ b/packages/samples/test/output/testserver/multiple-inheritance/openapi.yaml
@@ -15,8 +15,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Horse'
+                $ref: '#/components/schemas/Horse'
         default:
           description: Unexpected error
           content:
@@ -44,8 +43,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/Horse'
+              $ref: '#/components/schemas/Horse'
   /multipleInheritance/pet:
     get:
       operationId: MultipleInheritance_getPet
@@ -57,8 +55,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Pet'
+                $ref: '#/components/schemas/Pet'
         default:
           description: Unexpected error
           content:
@@ -86,8 +83,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/Pet'
+              $ref: '#/components/schemas/Pet'
   /multipleInheritance/feline:
     get:
       operationId: MultipleInheritance_getFeline
@@ -99,8 +95,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Feline'
+                $ref: '#/components/schemas/Feline'
         default:
           description: Unexpected error
           content:
@@ -128,8 +123,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/Feline'
+              $ref: '#/components/schemas/Feline'
   /multipleInheritance/cat:
     get:
       operationId: MultipleInheritance_getCat
@@ -143,8 +137,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Cat'
+                $ref: '#/components/schemas/Cat'
         default:
           description: Unexpected error
           content:
@@ -174,8 +167,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/Cat'
+              $ref: '#/components/schemas/Cat'
   /multipleInheritance/kitten:
     get:
       operationId: MultipleInheritance_getKitten
@@ -189,8 +181,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Kitten'
+                $ref: '#/components/schemas/Kitten'
         default:
           description: Unexpected error
           content:
@@ -220,8 +211,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/Kitten'
+              $ref: '#/components/schemas/Kitten'
 components:
   schemas:
     Horse:
@@ -232,8 +222,7 @@ components:
       required:
         - isAShowHorse
       allOf:
-        - $ref:
-            value: '#/components/schemas/Pet'
+        - $ref: '#/components/schemas/Pet'
     Pet:
       type: object
       properties:
@@ -252,8 +241,7 @@ components:
         - meows
         - hisses
       allOf:
-        - $ref:
-            value: '#/components/schemas/Pet'
+        - $ref: '#/components/schemas/Pet'
     Cat:
       type: object
       properties:
@@ -262,8 +250,7 @@ components:
       required:
         - likesMilk
       allOf:
-        - $ref:
-            value: '#/components/schemas/Feline'
+        - $ref: '#/components/schemas/Feline'
     Kitten:
       type: object
       properties:
@@ -272,8 +259,7 @@ components:
       required:
         - eatsMiceYet
       allOf:
-        - $ref:
-            value: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Cat'
     ErrorResponse:
       type: object
       properties:

--- a/packages/samples/test/output/use-versioned-lib/openapi.yaml
+++ b/packages/samples/test/output/use-versioned-lib/openapi.yaml
@@ -14,8 +14,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/Library.PetToy'
+                $ref: '#/components/schemas/Library.PetToy'
 components:
   schemas:
     Library.PetToy:

--- a/packages/samples/test/output/versioning/openapi.v1.yaml
+++ b/packages/samples/test/output/versioning/openapi.v1.yaml
@@ -15,8 +15,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetBase'
+                $ref: '#/components/schemas/PetBase'
   /walkCat:
     post:
       operationId: MyService_walkCat
@@ -48,8 +47,7 @@ components:
         favoriteToys:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/Library.PetToy'
+            $ref: '#/components/schemas/Library.PetToy'
           x-cadl-name: Library.PetToy[]
       discriminator:
         propertyName: type
@@ -84,8 +82,7 @@ components:
         - nextWalkTime
         - walkerName
       allOf:
-        - $ref:
-            value: '#/components/schemas/PetBase'
+        - $ref: '#/components/schemas/PetBase'
     Library.PetToy:
       type: object
       properties:

--- a/packages/samples/test/output/versioning/openapi.v1.yaml
+++ b/packages/samples/test/output/versioning/openapi.v1.yaml
@@ -52,8 +52,7 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          dog:
-            value: '#/components/schemas/Dog'
+          dog: '#/components/schemas/Dog'
       required:
         - name
         - favoriteToys

--- a/packages/samples/test/output/versioning/openapi.v2.yaml
+++ b/packages/samples/test/output/versioning/openapi.v2.yaml
@@ -15,8 +15,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/PetBase'
+                $ref: '#/components/schemas/PetBase'
   /walkDog:
     post:
       operationId: MyService_walkDog
@@ -48,8 +47,7 @@ components:
         favoriteToys:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/Library.PetToy'
+            $ref: '#/components/schemas/Library.PetToy'
           x-cadl-name: Library.PetToy[]
       discriminator:
         propertyName: type
@@ -91,8 +89,7 @@ components:
         - nextWalkTime
         - commandList
       allOf:
-        - $ref:
-            value: '#/components/schemas/PetBase'
+        - $ref: '#/components/schemas/PetBase'
     Cat:
       type: object
       properties:
@@ -107,8 +104,7 @@ components:
         - type
         - catnipDose
       allOf:
-        - $ref:
-            value: '#/components/schemas/PetBase'
+        - $ref: '#/components/schemas/PetBase'
     Library.PetToy:
       type: object
       properties:

--- a/packages/samples/test/output/versioning/openapi.v2.yaml
+++ b/packages/samples/test/output/versioning/openapi.v2.yaml
@@ -52,10 +52,8 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          dog:
-            value: '#/components/schemas/Dog'
-          cat:
-            value: '#/components/schemas/Cat'
+          dog: '#/components/schemas/Dog'
+          cat: '#/components/schemas/Cat'
       required:
         - name
         - favoriteToys

--- a/packages/samples/test/output/visibility/openapi.yaml
+++ b/packages/samples/test/output/visibility/openapi.yaml
@@ -28,8 +28,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ReadablePersonRead'
+                $ref: '#/components/schemas/ReadablePersonRead'
   /hello:
     post:
       operationId: Hello_create
@@ -40,14 +39,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ReadablePersonRead'
+                $ref: '#/components/schemas/ReadablePersonRead'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/WritablePersonCreate'
+              $ref: '#/components/schemas/WritablePersonCreate'
     put:
       operationId: Hello_update
       parameters: []
@@ -57,14 +54,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ReadablePersonRead'
+                $ref: '#/components/schemas/ReadablePersonRead'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/WriteableOptionalPerson'
+              $ref: '#/components/schemas/WriteableOptionalPerson'
     get:
       operationId: Hello_list
       parameters: []
@@ -79,8 +74,7 @@ paths:
                   items:
                     type: array
                     items:
-                      $ref:
-                        value: '#/components/schemas/PersonReadItem'
+                      $ref: '#/components/schemas/PersonReadItem'
                     x-cadl-name: Person[]
                 required:
                   - items
@@ -94,14 +88,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref:
-                  value: '#/components/schemas/ReadablePersonRead'
+                $ref: '#/components/schemas/ReadablePersonRead'
       requestBody:
         content:
           application/json:
             schema:
-              $ref:
-                value: '#/components/schemas/PersonUpdate'
+              $ref: '#/components/schemas/PersonUpdate'
 components:
   schemas:
     ReadablePersonRead:
@@ -119,8 +111,7 @@ components:
         relatives:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/PersonRelativeReadItem'
+            $ref: '#/components/schemas/PersonRelativeReadItem'
           x-cadl-name: PersonRelative[]
       required:
         - id
@@ -143,8 +134,7 @@ components:
         relatives:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/PersonRelative'
+            $ref: '#/components/schemas/PersonRelative'
           x-cadl-name: PersonRelative[]
       required:
         - id
@@ -164,8 +154,7 @@ components:
         relatives:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/PersonRelativeCreateItem'
+            $ref: '#/components/schemas/PersonRelativeCreateItem'
           x-cadl-name: PersonRelative[]
       required:
         - secret
@@ -184,8 +173,7 @@ components:
         relatives:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/PersonRelative'
+            $ref: '#/components/schemas/PersonRelative'
           x-cadl-name: PersonRelative[]
       required:
         - secret
@@ -204,8 +192,7 @@ components:
         relatives:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/PersonRelative'
+            $ref: '#/components/schemas/PersonRelative'
           x-cadl-name: PersonRelative[]
     PersonReadItem:
       type: object
@@ -222,8 +209,7 @@ components:
         relatives:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/PersonRelativeReadItem'
+            $ref: '#/components/schemas/PersonRelativeReadItem'
           x-cadl-name: PersonRelative[]
       required:
         - id
@@ -241,8 +227,7 @@ components:
         relatives:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/PersonRelativeUpdateItem'
+            $ref: '#/components/schemas/PersonRelativeUpdateItem'
           x-cadl-name: PersonRelative[]
     Person:
       type: object
@@ -261,8 +246,7 @@ components:
         relatives:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/PersonRelative'
+            $ref: '#/components/schemas/PersonRelative'
           x-cadl-name: PersonRelative[]
       required:
         - id
@@ -283,8 +267,7 @@ components:
         relatives:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/PersonRelativeCreateItem'
+            $ref: '#/components/schemas/PersonRelativeCreateItem'
           x-cadl-name: PersonRelative[]
       required:
         - secret
@@ -301,8 +284,7 @@ components:
         relatives:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/PersonRelativeUpdateItem'
+            $ref: '#/components/schemas/PersonRelativeUpdateItem'
           x-cadl-name: PersonRelative[]
       required:
         - name
@@ -312,8 +294,7 @@ components:
       type: object
       properties:
         person:
-          $ref:
-            value: '#/components/schemas/Person'
+          $ref: '#/components/schemas/Person'
         relationship:
           type: string
       required:
@@ -323,8 +304,7 @@ components:
       type: object
       properties:
         person:
-          $ref:
-            value: '#/components/schemas/PersonReadItem'
+          $ref: '#/components/schemas/PersonReadItem'
         relationship:
           type: string
       required:
@@ -334,8 +314,7 @@ components:
       type: object
       properties:
         person:
-          $ref:
-            value: '#/components/schemas/PersonCreateItem'
+          $ref: '#/components/schemas/PersonCreateItem'
         relationship:
           type: string
       required:
@@ -345,8 +324,7 @@ components:
       type: object
       properties:
         person:
-          $ref:
-            value: '#/components/schemas/PersonUpdateItem'
+          $ref: '#/components/schemas/PersonUpdateItem'
         relationship:
           type: string
       required:
@@ -369,6 +347,5 @@ components:
         relatives:
           type: array
           items:
-            $ref:
-              value: '#/components/schemas/PersonRelative'
+            $ref: '#/components/schemas/PersonRelative'
           x-cadl-name: PersonRelative[]


### PR DESCRIPTION
This issue fixes #1546 which reports that the OpenAPI emitter's new YAML output encodes `$ref`s as a sub-object with a `value` property.  This change uses the `replacer` option of `yaml.dump` to ensure that `Ref` objects get written out correctly as a string path.