### PR TITLE
fix parsing of logical and in projections

### DIFF
--- a/common/changes/@cadl-lang/compiler/fix-logical-and-parse_2023-01-18-07-11.json
+++ b/common/changes/@cadl-lang/compiler/fix-logical-and-parse_2023-01-18-07-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Bug: properly parse logical and (`&&`) expressions in projections",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/parser.ts
+++ b/packages/compiler/core/parser.ts
@@ -1679,7 +1679,7 @@ function createParser(code: string | SourceFile, options: ParseOptions = {}): Pa
           kind: SyntaxKind.ProjectionLogicalExpression,
           op: "&&",
           left: expr,
-          right: parseIdentifier(),
+          right: parseProjectionEqualityExpressionOrHigher(),
           ...finishNode(pos),
         };
       } else {

--- a/packages/compiler/test/parser.test.ts
+++ b/packages/compiler/test/parser.test.ts
@@ -691,8 +691,10 @@ describe("compiler: parser", () => {
     describe("projection expressions", () => {
       const exprs = [
         `x || y`,
+        `x > 10 || y < 20`,
         `x || y || z`,
         `x && y`,
+        `x > 10 && y < 20`,
         `x && y && z`,
         `x && y || z && q`,
         `x || y && z || q`,

--- a/packages/spec/src/spec.emu.html
+++ b/packages/spec/src/spec.emu.html
@@ -558,8 +558,8 @@ ProjectionLogicalOrExpression :
     ProjectionLogicalOrExpression `||` ProjectionLogicalAndExpression
 
 ProjectionLogicalAndExpression :
-    ProjectionRelationalExpression
-    ProjectionLogicalAndExpression `&&` ProjectionRelationalExpression
+    ProjectionEqualityExpression
+    ProjectionLogicalAndExpression `&&` ProjectionEqualityExpression
 
 ProjectionEqualityExpression :
     ProjectionRelationalExpression


### PR DESCRIPTION
I noticed that both the spec and the implementation were fairly mangled. Previously we only parse logical and with identifiers, which is wrong and mostly useless. With this PR, logical and works with other expressions as expected. Spec wise, equality expressions were not referenced anywhere, so the spec is updated to put them in their proper place.