### PR TITLE
Allow operations parameters to target ModelProperty

### DIFF
--- a/common/changes/@cadl-lang/openapi3/openapi3-ModelPropertyCrash_2023-01-20-23-22.json
+++ b/common/changes/@cadl-lang/openapi3/openapi3-ModelPropertyCrash_2023-01-20-23-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Fix issue where operation parameters could not target a ModelProperty.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/test/parameters.test.ts
+++ b/packages/openapi3/test/parameters.test.ts
@@ -42,6 +42,26 @@ describe("openapi3: parameters", () => {
     strictEqual(res.paths["/"].get.parameters[1].style, "simple");
   });
 
+  it("create a query param that is a model property", async () => {
+    const res = await openApiFor(
+      `
+      op test(@query id: UserContext.id): void;
+      
+      model UserContext {
+        id: string;
+      }
+      `
+    );
+    deepStrictEqual(res.paths["/"].get.parameters[0], {
+      in: "query",
+      name: "id",
+      required: true,
+      schema: {
+        type: "string",
+      },
+    });
+  });
+
   it("create an header param", async () => {
     const res = await openApiFor(
       `


### PR DESCRIPTION
Fix #1391.

Companion PR that fixes this same bug in autorest: https://github.com/Azure/cadl-azure/pull/2466