### PR TITLE
add Model type to Cadl.Reflection

### DIFF
--- a/common/changes/@cadl-lang/compiler/add_model_to_reflection_2023-01-31-17-31.json
+++ b/common/changes/@cadl-lang/compiler/add_model_to_reflection_2023-01-31-17-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "add Model to Cadl.Reflection for external decorator docs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/lib/reflection.cadl
+++ b/packages/compiler/lib/reflection.cadl
@@ -8,3 +8,4 @@ model Namespace {}
 model Operation {}
 model Union {}
 model UnionVariant {}
+model Model {}


### PR DESCRIPTION
I want to be able to specify a `Model` in my external decorator docs