### PR TITLE
Sort OpenAPI 3 output

### DIFF
--- a/common/changes/@cadl-lang/openapi3/sort-openapi-emit_2023-02-01-22-32.json
+++ b/common/changes/@cadl-lang/openapi3/sort-openapi-emit_2023-02-01-22-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/openapi3",
+      "comment": "Sort OpenAPI 3 output",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/openapi3"
+}

--- a/packages/openapi3/src/openapi.ts
+++ b/packages/openapi3/src/openapi.ts
@@ -1467,6 +1467,7 @@ function createOAPIEmitter(program: Program, options: ResolvedOpenAPI3EmitterOpt
 }
 
 function serializeDocument(root: OpenAPI3Document, fileType: FileType): string {
+  sortOpenAPIDocument(root);
   switch (fileType) {
     case "json":
       return prettierOutput(JSON.stringify(root, null, 2));
@@ -1487,5 +1488,24 @@ function prettierOutput(output: string) {
 class ErrorTypeFoundError extends Error {
   constructor() {
     super("Error type found in evaluated Cadl output");
+  }
+}
+
+function sortObjectByKeys<T extends Record<string, unknown>>(obj: T): T {
+  return Object.keys(obj)
+    .sort()
+    .reduce((sortedObj: any, key: string) => {
+      sortedObj[key] = obj[key];
+      return sortedObj;
+    }, {});
+}
+
+function sortOpenAPIDocument(doc: OpenAPI3Document): void {
+  doc.paths = sortObjectByKeys(doc.paths);
+  if (doc.components?.schemas) {
+    doc.components.schemas = sortObjectByKeys(doc.components.schemas);
+  }
+  if (doc.components?.parameters) {
+    doc.components.parameters = sortObjectByKeys(doc.components.parameters);
   }
 }

--- a/packages/openapi3/test/openapi-output.test.ts
+++ b/packages/openapi3/test/openapi-output.test.ts
@@ -36,7 +36,7 @@ describe("openapi3: types included", () => {
     `,
       {}
     );
-    deepStrictEqual(Object.keys(output.components!.schemas!), ["Referenced", "NotReferenced"]);
+    deepStrictEqual(Object.keys(output.components!.schemas!), ["NotReferenced", "Referenced"]);
   });
 
   it("emit only referenced types when using omit-unreachable-types", async () => {

--- a/packages/samples/test/output/binary/openapi.yaml
+++ b/packages/samples/test/output/binary/openapi.yaml
@@ -20,24 +20,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/HasBytes'
-  /test/textPlain:
-    post:
-      operationId: BytesMethod_textPlain
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            text/plain:
-              schema:
-                type: string
-                format: byte
-      requestBody:
-        content:
-          text/plain:
-            schema:
-              type: string
-              format: byte
   /test/binaryFile:
     post:
       operationId: BytesMethod_genericBinaryFile
@@ -74,6 +56,24 @@ paths:
             schema:
               type: string
               format: binary
+  /test/textPlain:
+    post:
+      operationId: BytesMethod_textPlain
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            text/plain:
+              schema:
+                type: string
+                format: byte
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+              format: byte
 components:
   schemas:
     HasBytes:

--- a/packages/samples/test/output/documentation/openapi.yaml
+++ b/packages/samples/test/output/documentation/openapi.yaml
@@ -38,29 +38,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorWithDocs'
-  /foo/NotFoundWithDocs:
-    get:
-      operationId: Foo_withStatusCodeDocs
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Resp'
-        '404':
-          description: The server cannot find the requested resource.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotFoundWithDocsResp'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
   /foo/NotFoundDefaultDocs:
     get:
       operationId: Foo_withDefaultDescNotFound
@@ -84,16 +61,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /foo/NotFoundWithDocs:
+    get:
+      operationId: Foo_withStatusCodeDocs
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Resp'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundWithDocsResp'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
-    Resp:
-      type: object
-      properties:
-        value:
-          type: integer
-          format: int32
-      required:
-        - value
     Error:
       type: object
       properties:
@@ -102,15 +94,6 @@ components:
           format: int32
       required:
         - code
-    RespWithDocs:
-      type: object
-      properties:
-        value:
-          type: integer
-          format: int32
-      description: Response from @doc
-      required:
-        - value
     ErrorWithDocs:
       type: object
       properties:
@@ -120,6 +103,13 @@ components:
       description: Error from @doc
       required:
         - code
+    NotFoundResp:
+      type: object
+      properties:
+        details:
+          type: string
+      required:
+        - details
     NotFoundWithDocsResp:
       type: object
       properties:
@@ -128,10 +118,20 @@ components:
       description: Not found
       required:
         - details
-    NotFoundResp:
+    Resp:
       type: object
       properties:
-        details:
-          type: string
+        value:
+          type: integer
+          format: int32
       required:
-        - details
+        - value
+    RespWithDocs:
+      type: object
+      properties:
+        value:
+          type: integer
+          format: int32
+      description: Response from @doc
+      required:
+        - value

--- a/packages/samples/test/output/grpc-kiosk-example/openapi.yaml
+++ b/packages/samples/test/output/grpc-kiosk-example/openapi.yaml
@@ -98,6 +98,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
+  /v1/kiosks/{kiosk_id}/sign:
+    get:
+      tags:
+        - Display
+      operationId: Display_getSignIdForKioskId
+      description: Get the sign that should be displayed on a kiosk.
+      parameters:
+        - name: kiosk_id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetSignIdResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RpcStatus'
   /v1/signs:
     post:
       tags:
@@ -213,32 +239,6 @@ paths:
                 type: integer
                 format: int32
               x-cadl-name: int32[]
-  /v1/kiosks/{kiosk_id}/sign:
-    get:
-      tags:
-        - Display
-      operationId: Display_getSignIdForKioskId
-      description: Get the sign that should be displayed on a kiosk.
-      parameters:
-        - name: kiosk_id
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int32
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetSignIdResponse'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RpcStatus'
 components:
   parameters:
     SetSignIdForKioskIdsRequest.sign_id:
@@ -249,6 +249,21 @@ components:
         type: integer
         format: int32
   schemas:
+    GetSignIdForKioskIdRequest:
+      type: object
+      properties:
+        kiosk_id:
+          type: integer
+          format: int32
+      required:
+        - kiosk_id
+    GetSignIdResponse:
+      type: object
+      properties:
+        sign_id:
+          type: integer
+          format: int32
+      description: A successful response.
     Kiosk:
       type: object
       properties:
@@ -274,6 +289,55 @@ components:
         - name
         - size
         - location
+    LatLng:
+      type: object
+      properties:
+        latitude:
+          type: number
+          format: double
+        longitude:
+          type: number
+          format: double
+      description: >-
+        An object that represents a latitude/longitude pair. This is expressed
+        as a
+
+        pair of doubles to represent degrees latitude and degrees longitude.
+        Unless
+
+        specified otherwise, this must conform to the
+
+        <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
+
+        standard</a>. Values must be within normalized ranges.
+      required:
+        - latitude
+        - longitude
+    ListKiosksResponse:
+      type: object
+      properties:
+        kiosks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Kiosk'
+          x-cadl-name: Kiosk[]
+      description: A successful response.
+    ListSignsResponse:
+      type: object
+      properties:
+        signs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Sign'
+          x-cadl-name: Sign[]
+      description: A successful response.
+    ProtobufAny:
+      type: object
+      properties:
+        typeUrl:
+          type: string
+        value:
+          type: string
     RpcStatus:
       type: object
       properties:
@@ -288,55 +352,6 @@ components:
             $ref: '#/components/schemas/ProtobufAny'
           x-cadl-name: ProtobufAny[]
       description: An unexpected error response.
-    ListKiosksResponse:
-      type: object
-      properties:
-        kiosks:
-          type: array
-          items:
-            $ref: '#/components/schemas/Kiosk'
-          x-cadl-name: Kiosk[]
-      description: A successful response.
-    Sign:
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int32
-          description: unique id
-        name:
-          type: string
-          description: name of sign
-        text:
-          type: string
-          description: text to display
-        image:
-          type: string
-          format: byte
-          description: image to display
-      description: |-
-        Describes a digital sign.
-        Signs can include text, images, or both.
-      required:
-        - name
-        - text
-        - image
-    ListSignsResponse:
-      type: object
-      properties:
-        signs:
-          type: array
-          items:
-            $ref: '#/components/schemas/Sign'
-          x-cadl-name: Sign[]
-      description: A successful response.
-    GetSignIdResponse:
-      type: object
-      properties:
-        sign_id:
-          type: integer
-          format: int32
-      description: A successful response.
     ScreenSize:
       type: object
       properties:
@@ -365,38 +380,30 @@ components:
       required:
         - kiosk_ids
         - sign_id
-    GetSignIdForKioskIdRequest:
+    Sign:
       type: object
       properties:
-        kiosk_id:
+        id:
           type: integer
           format: int32
+          description: unique id
+        name:
+          type: string
+          description: name of sign
+        text:
+          type: string
+          description: text to display
+        image:
+          type: string
+          format: byte
+          description: image to display
+      description: |-
+        Describes a digital sign.
+        Signs can include text, images, or both.
       required:
-        - kiosk_id
-    LatLng:
-      type: object
-      properties:
-        latitude:
-          type: number
-          format: double
-        longitude:
-          type: number
-          format: double
-      description: >-
-        An object that represents a latitude/longitude pair. This is expressed
-        as a
-
-        pair of doubles to represent degrees latitude and degrees longitude.
-        Unless
-
-        specified otherwise, this must conform to the
-
-        <a href="http://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf">WGS84
-
-        standard</a>. Values must be within normalized ranges.
-      required:
-        - latitude
-        - longitude
+        - name
+        - text
+        - image
     Timestamp:
       type: object
       properties:
@@ -410,10 +417,3 @@ components:
       required:
         - seconds
         - nanos
-    ProtobufAny:
-      type: object
-      properties:
-        typeUrl:
-          type: string
-        value:
-          type: string

--- a/packages/samples/test/output/grpc-library-example/openapi.yaml
+++ b/packages/samples/test/output/grpc-library-example/openapi.yaml
@@ -54,6 +54,45 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
+  /v1/shelves/shelf_name/books/{name}:
+    get:
+      tags:
+        - LibraryService
+      operationId: LibraryService_getBook
+      description: Gets a book. Returns NOT_FOUND if the book does not exist.
+      parameters:
+        - $ref: '#/components/parameters/GetBookRequest'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Book'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RpcStatus'
+    delete:
+      tags:
+        - LibraryService
+      operationId: LibraryService_deleteBook
+      description: Deletes a book. Returns NOT_FOUND if the book does not exist.
+      parameters:
+        - $ref: '#/components/parameters/DeleteBookRequest'
+      responses:
+        '204':
+          description: >-
+            There is no content to send for this request, but the headers may be
+            useful. 
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RpcStatus'
   /v1/shelves/{name}:
     get:
       tags:
@@ -93,45 +132,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-  /v1/shelves/{name}:merge:
-    post:
-      tags:
-        - LibraryService
-      operationId: LibraryService_mergeShelves
-      description: >-
-        Merges two shelves by adding all books from the shelf named
-
-        `other_shelf_name` to shelf `name`, and deletes
-
-        `other_shelf_name`. Returns the updated shelf.
-
-        The book ids of the moved books may not be the same as the original
-        books.
-
-        Returns NOT_FOUND if either shelf does not exist.
-
-        This call is a no-op if the specified shelves are the same.
-      parameters:
-        - $ref: '#/components/parameters/MergeShelvesRequest.name'
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Shelf'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RpcStatus'
-      requestBody:
-        description: The name of the shelf we're removing books from and deleting.
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/shelf_name'
   /v1/shelves/{name}/books:
     post:
       tags:
@@ -187,52 +187,92 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-  /v1/shelves/shelf_name/books/{name}:
-    get:
+  /v1/shelves/{name}:merge:
+    post:
       tags:
         - LibraryService
-      operationId: LibraryService_getBook
-      description: Gets a book. Returns NOT_FOUND if the book does not exist.
+      operationId: LibraryService_mergeShelves
+      description: >-
+        Merges two shelves by adding all books from the shelf named
+
+        `other_shelf_name` to shelf `name`, and deletes
+
+        `other_shelf_name`. Returns the updated shelf.
+
+        The book ids of the moved books may not be the same as the original
+        books.
+
+        Returns NOT_FOUND if either shelf does not exist.
+
+        This call is a no-op if the specified shelves are the same.
       parameters:
-        - $ref: '#/components/parameters/GetBookRequest'
+        - $ref: '#/components/parameters/MergeShelvesRequest.name'
       responses:
         '200':
           description: The request has succeeded.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Book'
+                $ref: '#/components/schemas/Shelf'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RpcStatus'
-    delete:
-      tags:
-        - LibraryService
-      operationId: LibraryService_deleteBook
-      description: Deletes a book. Returns NOT_FOUND if the book does not exist.
-      parameters:
-        - $ref: '#/components/parameters/DeleteBookRequest'
-      responses:
-        '204':
-          description: >-
-            There is no content to send for this request, but the headers may be
-            useful. 
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RpcStatus'
+      requestBody:
+        description: The name of the shelf we're removing books from and deleting.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/shelf_name'
 components:
   parameters:
+    CreateBookRequest.name:
+      name: name
+      in: path
+      required: true
+      description: The name of the shelf in which the book is created.
+      schema:
+        type: string
+        pattern: shelves/\w+
+    DeleteBookRequest:
+      name: name
+      in: path
+      required: true
+      description: The name of the book to delete.
+      schema:
+        type: string
+        pattern: shelves/\w+/books/\w+
+    DeleteShelfRequest:
+      name: name
+      in: path
+      required: true
+      description: The name of the shelf to delete.
+      schema:
+        type: string
+        pattern: shelves/\w+
+    GetBookRequest:
+      name: name
+      in: path
+      required: true
+      description: The name of the book to retrieve.
+      schema:
+        type: string
+        pattern: shelves/\w+/books/\w+
     GetShelfRequest:
       name: name
       in: path
       required: true
       description: The name of the shelf to retrieve.
+      schema:
+        type: string
+        pattern: shelves/\w+
+    ListBooksRequest.name:
+      name: name
+      in: path
+      required: true
+      description: The name of the shelf whose books we'd like to list.
       schema:
         type: string
         pattern: shelves/\w+
@@ -260,14 +300,6 @@ components:
         returned from the previous call to `ListShelves` method.
       schema:
         type: string
-    DeleteShelfRequest:
-      name: name
-      in: path
-      required: true
-      description: The name of the shelf to delete.
-      schema:
-        type: string
-        pattern: shelves/\w+
     MergeShelvesRequest.name:
       name: name
       in: path
@@ -276,100 +308,7 @@ components:
       schema:
         type: string
         pattern: shelves/\w+
-    CreateBookRequest.name:
-      name: name
-      in: path
-      required: true
-      description: The name of the shelf in which the book is created.
-      schema:
-        type: string
-        pattern: shelves/\w+
-    GetBookRequest:
-      name: name
-      in: path
-      required: true
-      description: The name of the book to retrieve.
-      schema:
-        type: string
-        pattern: shelves/\w+/books/\w+
-    ListBooksRequest.name:
-      name: name
-      in: path
-      required: true
-      description: The name of the shelf whose books we'd like to list.
-      schema:
-        type: string
-        pattern: shelves/\w+
-    DeleteBookRequest:
-      name: name
-      in: path
-      required: true
-      description: The name of the book to delete.
-      schema:
-        type: string
-        pattern: shelves/\w+/books/\w+
   schemas:
-    Shelf:
-      type: object
-      properties:
-        name:
-          allOf:
-            - $ref: '#/components/schemas/shelf_name'
-          description: |-
-            The resource name of the shelf.
-            Shelf names have the form `shelves/{shelf_id}`.
-            The name is ignored when creating a shelf.
-        theme:
-          type: string
-          description: The theme of the shelf
-      description: A Shelf contains a collection of books with a theme.
-      required:
-        - name
-    RpcStatus:
-      type: object
-      properties:
-        code:
-          type: integer
-          format: int32
-        message:
-          type: string
-        details:
-          type: array
-          items:
-            $ref: '#/components/schemas/ProtobufAny'
-          x-cadl-name: ProtobufAny[]
-      description: An unexpected error response.
-    ListShelvesResponse:
-      type: object
-      properties:
-        shelves:
-          type: array
-          items:
-            $ref: '#/components/schemas/Shelf'
-          x-cadl-name: Shelf[]
-          description: The list of shelves.
-        next_page_token:
-          type: string
-          description: >-
-            A token to retrieve next page of results.
-
-            Pass this value in the
-
-            [ListShelvesRequest.page_token][google.example.library.v1.ListShelvesRequest.page_token]
-
-            field in the subsequent call to `ListShelves` method to retrieve the
-            next
-
-            page of results.
-      description: Response message for LibraryService.ListShelves.
-      required:
-        - shelves
-    shelf_name:
-      type: string
-      description: |-
-        The name of a shelf.
-        Shelf names have the form `shelves/{shelf_id}`.
-      pattern: shelves/\w+
     Book:
       type: object
       properties:
@@ -392,6 +331,50 @@ components:
       description: A single book in the library.
       required:
         - name
+    CreateBookRequest:
+      type: object
+      properties:
+        book:
+          allOf:
+            - $ref: '#/components/schemas/Book'
+          description: The book to create.
+      description: Request message for LibraryService.CreateBook.
+      required:
+        - book
+    CreateShelfRequest:
+      type: object
+      properties:
+        body:
+          allOf:
+            - $ref: '#/components/schemas/Shelf'
+          description: The shelf to create.
+      description: Request message for LibraryService.CreateShelf.
+      required:
+        - body
+    DeleteBookRequest:
+      type: object
+      properties: {}
+      description: Request message for LibraryService.DeleteBook.
+    DeleteShelfRequest:
+      type: object
+      properties: {}
+      description: Request message for LibraryService.DeleteShelf.
+    Empty:
+      type: object
+      properties: {}
+      description: No body returned
+    GetBookRequest:
+      type: object
+      properties: {}
+      description: Request message for LibraryService.GetBook.
+    GetShelfRequest:
+      type: object
+      properties: {}
+      description: Request message for LibraryService.GetShelf.
+    ListBooksRequest:
+      type: object
+      properties: {}
+      description: Request message for LibraryService.ListBooks.
     ListBooksResponse:
       type: object
       properties:
@@ -417,27 +400,6 @@ components:
       description: Response message for LibraryService.ListBooks.
       required:
         - books
-    CreateShelfRequest:
-      type: object
-      properties:
-        body:
-          allOf:
-            - $ref: '#/components/schemas/Shelf'
-          description: The shelf to create.
-      description: Request message for LibraryService.CreateShelf.
-      required:
-        - body
-    ProtobufAny:
-      type: object
-      properties:
-        typeUrl:
-          type: string
-        value:
-          type: string
-    GetShelfRequest:
-      type: object
-      properties: {}
-      description: Request message for LibraryService.GetShelf.
     ListRequestBase:
       type: object
       properties: {}
@@ -457,10 +419,31 @@ components:
             next
 
             page of results.
-    DeleteShelfRequest:
+    ListShelvesResponse:
       type: object
-      properties: {}
-      description: Request message for LibraryService.DeleteShelf.
+      properties:
+        shelves:
+          type: array
+          items:
+            $ref: '#/components/schemas/Shelf'
+          x-cadl-name: Shelf[]
+          description: The list of shelves.
+        next_page_token:
+          type: string
+          description: >-
+            A token to retrieve next page of results.
+
+            Pass this value in the
+
+            [ListShelvesRequest.page_token][google.example.library.v1.ListShelvesRequest.page_token]
+
+            field in the subsequent call to `ListShelves` method to retrieve the
+            next
+
+            page of results.
+      description: Response message for LibraryService.ListShelves.
+      required:
+        - shelves
     MergeShelvesRequest:
       type: object
       properties:
@@ -473,49 +456,6 @@ components:
         (name) in this merge
       required:
         - other_shelf_name
-    CreateBookRequest:
-      type: object
-      properties:
-        book:
-          allOf:
-            - $ref: '#/components/schemas/Book'
-          description: The book to create.
-      description: Request message for LibraryService.CreateBook.
-      required:
-        - book
-    book_name:
-      type: string
-      description: |-
-        The name of a book.
-        Book names have the form `shelves/{shelf_id}/books/{book_id}`
-      pattern: shelves/\w+/books/\w+
-    GetBookRequest:
-      type: object
-      properties: {}
-      description: Request message for LibraryService.GetBook.
-    ListBooksRequest:
-      type: object
-      properties: {}
-      description: Request message for LibraryService.ListBooks.
-    DeleteBookRequest:
-      type: object
-      properties: {}
-      description: Request message for LibraryService.DeleteBook.
-    UpdateBookRequest:
-      type: object
-      properties:
-        name:
-          allOf:
-            - $ref: '#/components/schemas/book_name'
-          description: The name of the book to update.
-        book:
-          allOf:
-            - $ref: '#/components/schemas/Book'
-          description: The book to update with. The name must match or be empty.
-      description: Request message for LibraryService.UpdateBook.
-      required:
-        - name
-        - book
     MoveBookRequest:
       type: object
       properties:
@@ -533,7 +473,67 @@ components:
       required:
         - name
         - other_shelf_name
-    Empty:
+    ProtobufAny:
       type: object
-      properties: {}
-      description: No body returned
+      properties:
+        typeUrl:
+          type: string
+        value:
+          type: string
+    RpcStatus:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProtobufAny'
+          x-cadl-name: ProtobufAny[]
+      description: An unexpected error response.
+    Shelf:
+      type: object
+      properties:
+        name:
+          allOf:
+            - $ref: '#/components/schemas/shelf_name'
+          description: |-
+            The resource name of the shelf.
+            Shelf names have the form `shelves/{shelf_id}`.
+            The name is ignored when creating a shelf.
+        theme:
+          type: string
+          description: The theme of the shelf
+      description: A Shelf contains a collection of books with a theme.
+      required:
+        - name
+    UpdateBookRequest:
+      type: object
+      properties:
+        name:
+          allOf:
+            - $ref: '#/components/schemas/book_name'
+          description: The name of the book to update.
+        book:
+          allOf:
+            - $ref: '#/components/schemas/Book'
+          description: The book to update with. The name must match or be empty.
+      description: Request message for LibraryService.UpdateBook.
+      required:
+        - name
+        - book
+    book_name:
+      type: string
+      description: |-
+        The name of a book.
+        Book names have the form `shelves/{shelf_id}/books/{book_id}`
+      pattern: shelves/\w+/books/\w+
+    shelf_name:
+      type: string
+      description: |-
+        The name of a shelf.
+        Shelf names have the form `shelves/{shelf_id}`.
+      pattern: shelves/\w+

--- a/packages/samples/test/output/multiple-types-union/openapi.yaml
+++ b/packages/samples/test/output/multiple-types-union/openapi.yaml
@@ -25,35 +25,9 @@ components:
       schema:
         type: string
   schemas:
-    Pet:
-      anyOf:
-        - $ref: '#/components/schemas/Cat'
-        - $ref: '#/components/schemas/Dog'
     ApiVersionParam:
       type: object
       properties: {}
-    PetBase:
-      type: object
-      properties:
-        name:
-          type: string
-      required:
-        - name
-    Dog:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - dog
-        nextWalkTime:
-          type: string
-          format: date-time
-      required:
-        - type
-        - nextWalkTime
-      allOf:
-        - $ref: '#/components/schemas/PetBase'
     Cat:
       type: object
       properties:
@@ -69,3 +43,29 @@ components:
         - catnipDose
       allOf:
         - $ref: '#/components/schemas/PetBase'
+    Dog:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - dog
+        nextWalkTime:
+          type: string
+          format: date-time
+      required:
+        - type
+        - nextWalkTime
+      allOf:
+        - $ref: '#/components/schemas/PetBase'
+    Pet:
+      anyOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+    PetBase:
+      type: object
+      properties:
+        name:
+          type: string
+      required:
+        - name

--- a/packages/samples/test/output/nested/openapi.yaml
+++ b/packages/samples/test/output/nested/openapi.yaml
@@ -4,6 +4,31 @@ info:
   version: '0000-00-00'
 tags: []
 paths:
+  /:
+    post:
+      operationId: SubC_anotherOp
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                thing:
+                  $ref: '#/components/schemas/SubA.Thing'
+                thing2:
+                  $ref: '#/components/schemas/SubA.Thing'
+              required:
+                - thing
+                - thing2
+              x-cadl-name: SubC.(anonymous model)
   /sub/a/subsub:
     post:
       operationId: SubSubA_doSomething
@@ -36,31 +61,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SubB.Thing'
-  /:
-    post:
-      operationId: SubC_anotherOp
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                thing:
-                  $ref: '#/components/schemas/SubA.Thing'
-                thing2:
-                  $ref: '#/components/schemas/SubA.Thing'
-              required:
-                - thing
-                - thing2
-              x-cadl-name: SubC.(anonymous model)
 components:
   schemas:
     SubA.SubSubA.Thing:
@@ -70,7 +70,7 @@ components:
           type: string
       required:
         - name
-    SubB.Thing:
+    SubA.Thing:
       type: object
       properties:
         id:
@@ -78,7 +78,7 @@ components:
           format: int64
       required:
         - id
-    SubA.Thing:
+    SubB.Thing:
       type: object
       properties:
         id:

--- a/packages/samples/test/output/param-decorators/openapi.yaml
+++ b/packages/samples/test/output/param-decorators/openapi.yaml
@@ -58,6 +58,16 @@ components:
         format: UUID
         pattern: ^[a-zA-Z0-9-]{3,24}$
   schemas:
+    NameParameter:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Name parameter
+          format: UUID
+          pattern: ^[a-zA-Z0-9-]{3,24}$
+      required:
+        - name
     Thing:
       type: object
       properties:
@@ -69,13 +79,3 @@ components:
       required:
         - name
         - id
-    NameParameter:
-      type: object
-      properties:
-        name:
-          type: string
-          description: Name parameter
-          format: UUID
-          pattern: ^[a-zA-Z0-9-]{3,24}$
-      required:
-        - name

--- a/packages/samples/test/output/petstore/openapi.yaml
+++ b/packages/samples/test/output/petstore/openapi.yaml
@@ -9,47 +9,6 @@ info:
     `special-key` to test the authorization filters.
 tags: []
 paths:
-  /pets/{petId}:
-    delete:
-      operationId: Pets_delete
-      description: Delete a pet.
-      parameters:
-        - $ref: '#/components/parameters/PetId'
-      responses:
-        '200':
-          description: The request has succeeded.
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-    get:
-      operationId: Pets_read
-      description: Returns a pet. Supports eTags.
-      parameters:
-        - $ref: '#/components/parameters/PetId'
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pet'
-        '304':
-          description: >-
-            The client has made a conditional request and the resource has not
-            been modified.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pet'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
   /pets:
     get:
       operationId: Pets_list
@@ -94,6 +53,47 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Pet'
+  /pets/{petId}:
+    delete:
+      operationId: Pets_delete
+      description: Delete a pet.
+      parameters:
+        - $ref: '#/components/parameters/PetId'
+      responses:
+        '200':
+          description: The request has succeeded.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    get:
+      operationId: Pets_read
+      description: Returns a pet. Supports eTags.
+      parameters:
+        - $ref: '#/components/parameters/PetId'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '304':
+          description: >-
+            The client has made a conditional request and the resource has not
+            been modified.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /pets/{petId}/toys:
     get:
       operationId: ListPetToysResponse_list
@@ -143,18 +143,6 @@ components:
       required:
         - code
         - message
-    PetListResults:
-      type: object
-      properties:
-        items:
-          type: array
-          items:
-            $ref: '#/components/schemas/Pet'
-          x-cadl-name: Pet[]
-        nextLink:
-          type: string
-      required:
-        - items
     Pet:
       type: object
       properties:
@@ -170,14 +158,17 @@ components:
       required:
         - name
         - age
-    ToyListResults:
+    PetId:
+      type: object
+      properties: {}
+    PetListResults:
       type: object
       properties:
         items:
           type: array
           items:
-            $ref: '#/components/schemas/Toy'
-          x-cadl-name: Toy[]
+            $ref: '#/components/schemas/Pet'
+          x-cadl-name: Pet[]
         nextLink:
           type: string
       required:
@@ -197,6 +188,15 @@ components:
         - id
         - petId
         - name
-    PetId:
+    ToyListResults:
       type: object
-      properties: {}
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Toy'
+          x-cadl-name: Toy[]
+        nextLink:
+          type: string
+      required:
+        - items

--- a/packages/samples/test/output/polymorphism/openapi.yaml
+++ b/packages/samples/test/output/polymorphism/openapi.yaml
@@ -17,24 +17,6 @@ paths:
                 $ref: '#/components/schemas/Pet'
 components:
   schemas:
-    Pet:
-      type: object
-      properties:
-        kind:
-          type: string
-          description: Discriminator property for Pet.
-        name:
-          type: string
-        weight:
-          type: number
-          format: float
-      discriminator:
-        propertyName: kind
-        mapping:
-          cat: '#/components/schemas/Cat'
-          dog: '#/components/schemas/Dog'
-      required:
-        - name
     Cat:
       type: object
       properties:
@@ -64,3 +46,21 @@ components:
         - bark
       allOf:
         - $ref: '#/components/schemas/Pet'
+    Pet:
+      type: object
+      properties:
+        kind:
+          type: string
+          description: Discriminator property for Pet.
+        name:
+          type: string
+        weight:
+          type: number
+          format: float
+      discriminator:
+        propertyName: kind
+        mapping:
+          cat: '#/components/schemas/Cat'
+          dog: '#/components/schemas/Dog'
+      required:
+        - name

--- a/packages/samples/test/output/rest/petstore/openapi.yaml
+++ b/packages/samples/test/output/rest/petstore/openapi.yaml
@@ -4,145 +4,11 @@ info:
   version: '2021-03-25'
 tags: []
 paths:
-  /pets/{petId}:
+  /checkups:
     get:
-      operationId: Pets_get
-      description: Gets an instance of the resource.
-      parameters:
-        - $ref: '#/components/parameters/PetKey'
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pet'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetStoreError'
-    patch:
-      operationId: Pets_update
-      description: Updates an existing instance of the resource.
-      parameters:
-        - $ref: '#/components/parameters/PetKey'
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pet'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetStoreError'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PetUpdate'
-    delete:
-      operationId: Pets_delete
-      description: Deletes an existing instance of the resource.
-      parameters:
-        - $ref: '#/components/parameters/PetKey'
-      responses:
-        '200':
-          description: Resource deleted successfully.
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetStoreError'
-  /pets:
-    post:
-      operationId: Pets_create
-      description: Creates a new instance of the resource.
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pet'
-        '201':
-          description: Resource create operation completed successfully.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pet'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetStoreError'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PetCreate'
-    get:
-      operationId: Pets_list
+      operationId: Checkups_list
       description: Lists all instances of the resource.
       parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetCollectionWithNextLink'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetStoreError'
-  /pets/{petId}/checkups/{checkupId}:
-    patch:
-      operationId: PetCheckups_CreateOrUpdate
-      description: Creates or update a instance of the extension resource.
-      parameters:
-        - $ref: '#/components/parameters/PetKey'
-        - $ref: '#/components/parameters/CheckupKey'
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Checkup'
-        '201':
-          description: Resource create operation completed successfully.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Checkup'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetStoreError'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CheckupUpdate'
-  /pets/{petId}/checkups:
-    get:
-      operationId: PetCheckups_List
-      description: Lists all instances of the extension resource.
-      parameters:
-        - $ref: '#/components/parameters/PetKey'
       responses:
         '200':
           description: The request has succeeded.
@@ -156,135 +22,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PetStoreError'
-  /pets/{petId}/insurance:
-    get:
-      operationId: PetInsurance_Get
-      description: Gets the singleton resource.
-      parameters:
-        - $ref: '#/components/parameters/PetKey'
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Insurance'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetStoreError'
-    patch:
-      operationId: PetInsurance_Update
-      description: Updates the singleton resource.
-      parameters:
-        - $ref: '#/components/parameters/PetKey'
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Insurance'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetStoreError'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/InsuranceUpdate'
-  /pets/{petId}/toys/{toyId}:
-    get:
-      operationId: Toys_get
-      description: Gets an instance of the resource.
-      parameters:
-        - $ref: '#/components/parameters/ToyKey.petId'
-        - $ref: '#/components/parameters/ToyKey.toyId'
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Toy'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetStoreError'
-  /pets/{petId}/toys:
-    get:
-      operationId: Toys_list
-      parameters:
-        - $ref: '#/components/parameters/ToyParentKey'
-        - name: nameFilter
-          in: query
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ToyCollectionWithNextLink'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetStoreError'
-  /pets/{petId}/toys/{toyId}/insurance:
-    get:
-      operationId: ToyInsurance_Get
-      description: Gets the singleton resource.
-      parameters:
-        - $ref: '#/components/parameters/ToyKey.petId'
-        - $ref: '#/components/parameters/ToyKey.toyId'
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Insurance'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetStoreError'
-    patch:
-      operationId: ToyInsurance_Update
-      description: Updates the singleton resource.
-      parameters:
-        - $ref: '#/components/parameters/ToyKey.petId'
-        - $ref: '#/components/parameters/ToyKey.toyId'
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Insurance'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetStoreError'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/InsuranceUpdate'
   /checkups/{checkupId}:
     patch:
       operationId: Checkups_createOrUpdate
@@ -315,9 +52,37 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CheckupUpdate'
-  /checkups:
+  /owners:
+    post:
+      operationId: Owners_create
+      description: Creates a new instance of the resource.
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Owner'
+        '201':
+          description: Resource create operation completed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Owner'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetStoreError'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OwnerCreate'
     get:
-      operationId: Checkups_list
+      operationId: Owners_list
       description: Lists all instances of the resource.
       parameters: []
       responses:
@@ -326,7 +91,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CheckupCollectionWithNextLink'
+                $ref: '#/components/schemas/OwnerCollectionWithNextLink'
         default:
           description: An unexpected error response.
           content:
@@ -389,46 +154,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PetStoreError'
-  /owners:
-    post:
-      operationId: Owners_create
-      description: Creates a new instance of the resource.
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Owner'
-        '201':
-          description: Resource create operation completed successfully.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Owner'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetStoreError'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/OwnerCreate'
+  /owners/{ownerId}/checkups:
     get:
-      operationId: Owners_list
-      description: Lists all instances of the resource.
-      parameters: []
+      operationId: OwnerCheckups_List
+      description: Lists all instances of the extension resource.
+      parameters:
+        - $ref: '#/components/parameters/OwnerKey'
       responses:
         '200':
           description: The request has succeeded.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OwnerCollectionWithNextLink'
+                $ref: '#/components/schemas/CheckupCollectionWithNextLink'
         default:
           description: An unexpected error response.
           content:
@@ -466,25 +204,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CheckupUpdate'
-  /owners/{ownerId}/checkups:
-    get:
-      operationId: OwnerCheckups_List
-      description: Lists all instances of the extension resource.
-      parameters:
-        - $ref: '#/components/parameters/OwnerKey'
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CheckupCollectionWithNextLink'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PetStoreError'
   /owners/{ownerId}/insurance:
     get:
       operationId: OwnerInsurance_Get
@@ -527,17 +246,305 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/InsuranceUpdate'
+  /pets:
+    post:
+      operationId: Pets_create
+      description: Creates a new instance of the resource.
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '201':
+          description: Resource create operation completed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetStoreError'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PetCreate'
+    get:
+      operationId: Pets_list
+      description: Lists all instances of the resource.
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetCollectionWithNextLink'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetStoreError'
+  /pets/{petId}:
+    get:
+      operationId: Pets_get
+      description: Gets an instance of the resource.
+      parameters:
+        - $ref: '#/components/parameters/PetKey'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetStoreError'
+    patch:
+      operationId: Pets_update
+      description: Updates an existing instance of the resource.
+      parameters:
+        - $ref: '#/components/parameters/PetKey'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetStoreError'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PetUpdate'
+    delete:
+      operationId: Pets_delete
+      description: Deletes an existing instance of the resource.
+      parameters:
+        - $ref: '#/components/parameters/PetKey'
+      responses:
+        '200':
+          description: Resource deleted successfully.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetStoreError'
+  /pets/{petId}/checkups:
+    get:
+      operationId: PetCheckups_List
+      description: Lists all instances of the extension resource.
+      parameters:
+        - $ref: '#/components/parameters/PetKey'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckupCollectionWithNextLink'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetStoreError'
+  /pets/{petId}/checkups/{checkupId}:
+    patch:
+      operationId: PetCheckups_CreateOrUpdate
+      description: Creates or update a instance of the extension resource.
+      parameters:
+        - $ref: '#/components/parameters/PetKey'
+        - $ref: '#/components/parameters/CheckupKey'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Checkup'
+        '201':
+          description: Resource create operation completed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Checkup'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetStoreError'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CheckupUpdate'
+  /pets/{petId}/insurance:
+    get:
+      operationId: PetInsurance_Get
+      description: Gets the singleton resource.
+      parameters:
+        - $ref: '#/components/parameters/PetKey'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Insurance'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetStoreError'
+    patch:
+      operationId: PetInsurance_Update
+      description: Updates the singleton resource.
+      parameters:
+        - $ref: '#/components/parameters/PetKey'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Insurance'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetStoreError'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InsuranceUpdate'
+  /pets/{petId}/toys:
+    get:
+      operationId: Toys_list
+      parameters:
+        - $ref: '#/components/parameters/ToyParentKey'
+        - name: nameFilter
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToyCollectionWithNextLink'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetStoreError'
+  /pets/{petId}/toys/{toyId}:
+    get:
+      operationId: Toys_get
+      description: Gets an instance of the resource.
+      parameters:
+        - $ref: '#/components/parameters/ToyKey.petId'
+        - $ref: '#/components/parameters/ToyKey.toyId'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Toy'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetStoreError'
+  /pets/{petId}/toys/{toyId}/insurance:
+    get:
+      operationId: ToyInsurance_Get
+      description: Gets the singleton resource.
+      parameters:
+        - $ref: '#/components/parameters/ToyKey.petId'
+        - $ref: '#/components/parameters/ToyKey.toyId'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Insurance'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetStoreError'
+    patch:
+      operationId: ToyInsurance_Update
+      description: Updates the singleton resource.
+      parameters:
+        - $ref: '#/components/parameters/ToyKey.petId'
+        - $ref: '#/components/parameters/ToyKey.toyId'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Insurance'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetStoreError'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InsuranceUpdate'
 components:
   parameters:
-    PetKey:
-      name: petId
+    CheckupKey:
+      name: checkupId
       in: path
       required: true
       schema:
         type: integer
         format: int32
-    CheckupKey:
-      name: checkupId
+    OwnerKey:
+      name: ownerId
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int64
+    PetKey:
+      name: petId
       in: path
       required: true
       schema:
@@ -564,109 +571,7 @@ components:
       schema:
         type: integer
         format: int32
-    OwnerKey:
-      name: ownerId
-      in: path
-      required: true
-      schema:
-        type: integer
-        format: int64
   schemas:
-    Pet:
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int32
-        name:
-          type: string
-        tag:
-          type: string
-        age:
-          type: integer
-          format: int32
-          minimum: 0
-          maximum: 20
-        ownerId:
-          type: integer
-          format: int64
-      required:
-        - id
-        - name
-        - age
-        - ownerId
-    PetStoreError:
-      type: object
-      properties:
-        code:
-          type: integer
-          format: int32
-        message:
-          type: string
-      required:
-        - code
-        - message
-    PetUpdate:
-      type: object
-      properties:
-        name:
-          type: string
-        tag:
-          type: string
-        age:
-          type: integer
-          format: int32
-          minimum: 0
-          maximum: 20
-        ownerId:
-          type: integer
-          format: int64
-      description: The template for adding optional properties.
-    PetCreate:
-      type: object
-      properties:
-        name:
-          type: string
-        tag:
-          type: string
-        age:
-          type: integer
-          format: int32
-          minimum: 0
-          maximum: 20
-        ownerId:
-          type: integer
-          format: int64
-      description: The template for adding updateable properties.
-      required:
-        - name
-        - age
-        - ownerId
-    PetCollectionWithNextLink:
-      type: object
-      properties:
-        value:
-          type: array
-          items:
-            $ref: '#/components/schemas/Pet'
-          x-cadl-name: Pet[]
-          description: The items on this page
-        nextLink:
-          type: string
-          format: uri
-          description: The link to the next page of items
-          x-cadl-name: Rest.ResourceLocation
-      description: Paged response of Pet items
-      required:
-        - value
-    CheckupUpdate:
-      type: object
-      properties:
-        vetName:
-          type: string
-        notes:
-          type: string
-      description: The template for adding optional properties.
     Checkup:
       type: object
       properties:
@@ -698,6 +603,14 @@ components:
       description: Paged response of Checkup items
       required:
         - value
+    CheckupUpdate:
+      type: object
+      properties:
+        vetName:
+          type: string
+        notes:
+          type: string
+      description: The template for adding optional properties.
     Insurance:
       type: object
       properties:
@@ -724,6 +637,146 @@ components:
         deductible:
           type: integer
           format: int32
+      description: The template for adding optional properties.
+    Owner:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        age:
+          type: integer
+          format: int32
+      required:
+        - id
+        - name
+        - age
+    OwnerCollectionWithNextLink:
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Owner'
+          x-cadl-name: Owner[]
+          description: The items on this page
+        nextLink:
+          type: string
+          format: uri
+          description: The link to the next page of items
+          x-cadl-name: Rest.ResourceLocation
+      description: Paged response of Owner items
+      required:
+        - value
+    OwnerCreate:
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
+          format: int32
+      description: The template for adding updateable properties.
+      required:
+        - name
+        - age
+    OwnerUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
+          format: int32
+      description: The template for adding optional properties.
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+        tag:
+          type: string
+        age:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 20
+        ownerId:
+          type: integer
+          format: int64
+      required:
+        - id
+        - name
+        - age
+        - ownerId
+    PetCollectionWithNextLink:
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Pet'
+          x-cadl-name: Pet[]
+          description: The items on this page
+        nextLink:
+          type: string
+          format: uri
+          description: The link to the next page of items
+          x-cadl-name: Rest.ResourceLocation
+      description: Paged response of Pet items
+      required:
+        - value
+    PetCreate:
+      type: object
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+        age:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 20
+        ownerId:
+          type: integer
+          format: int64
+      description: The template for adding updateable properties.
+      required:
+        - name
+        - age
+        - ownerId
+    PetStoreError:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+      required:
+        - code
+        - message
+    PetUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        tag:
+          type: string
+        age:
+          type: integer
+          format: int32
+          minimum: 0
+          maximum: 20
+        ownerId:
+          type: integer
+          format: int64
       description: The template for adding optional properties.
     Toy:
       type: object
@@ -755,58 +808,5 @@ components:
           description: The link to the next page of items
           x-cadl-name: Rest.ResourceLocation
       description: Paged response of Toy items
-      required:
-        - value
-    Owner:
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int64
-        name:
-          type: string
-        age:
-          type: integer
-          format: int32
-      required:
-        - id
-        - name
-        - age
-    OwnerUpdate:
-      type: object
-      properties:
-        name:
-          type: string
-        age:
-          type: integer
-          format: int32
-      description: The template for adding optional properties.
-    OwnerCreate:
-      type: object
-      properties:
-        name:
-          type: string
-        age:
-          type: integer
-          format: int32
-      description: The template for adding updateable properties.
-      required:
-        - name
-        - age
-    OwnerCollectionWithNextLink:
-      type: object
-      properties:
-        value:
-          type: array
-          items:
-            $ref: '#/components/schemas/Owner'
-          x-cadl-name: Owner[]
-          description: The items on this page
-        nextLink:
-          type: string
-          format: uri
-          description: The link to the next page of items
-          x-cadl-name: Rest.ResourceLocation
-      description: Paged response of Owner items
       required:
         - value

--- a/packages/samples/test/output/signatures/openapi.yaml
+++ b/packages/samples/test/output/signatures/openapi.yaml
@@ -4,10 +4,33 @@ info:
   version: '0000-00-00'
 tags: []
 paths:
-  /codeSignAccounts/{name}:
+  /accountProfiles:
+    post:
+      operationId: AccountProfiles_create
+      description: Reads an instance of the AccountProfile resource.
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountProfile'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDetails'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountProfile'
+  /accountProfiles/{name}:
     get:
-      operationId: CodeSignAccounts_get
-      description: Reads an instance of the CodeSignAccount resource.
+      operationId: AccountProfiles_get
+      description: Reads an instance of the AccountProfile resource.
       parameters:
         - name: name
           in: path
@@ -20,7 +43,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CodeSignAccount'
+                $ref: '#/components/schemas/AccountProfile'
         default:
           description: An unexpected error response.
           content:
@@ -50,10 +73,10 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/CodeSignAccount'
-  /accountProfiles/{name}:
+  /codeSignAccounts/{name}:
     get:
-      operationId: AccountProfiles_get
-      description: Reads an instance of the AccountProfile resource.
+      operationId: CodeSignAccounts_get
+      description: Reads an instance of the CodeSignAccount resource.
       parameters:
         - name: name
           in: path
@@ -66,38 +89,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AccountProfile'
+                $ref: '#/components/schemas/CodeSignAccount'
         default:
           description: An unexpected error response.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorDetails'
-  /accountProfiles:
-    post:
-      operationId: AccountProfiles_create
-      description: Reads an instance of the AccountProfile resource.
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AccountProfile'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorDetails'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AccountProfile'
 components:
   schemas:
+    AccountProfile:
+      type: object
+      properties:
+        value:
+          type: integer
+          format: int32
+      required:
+        - value
     CodeSignAccount:
       type: object
       properties:
@@ -116,11 +124,3 @@ components:
       required:
         - code
         - message
-    AccountProfile:
-      type: object
-      properties:
-        value:
-          type: integer
-          format: int32
-      required:
-        - value

--- a/packages/samples/test/output/tags/openapi.yaml
+++ b/packages/samples/test/output/tags/openapi.yaml
@@ -12,6 +12,39 @@ tags:
   - name: moreInner
   - name: innerOp
 paths:
+  /bar:
+    get:
+      operationId: Bar_list
+      description: no tags
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Resp'
+                x-cadl-name: Resp[]
+  /bar/{id}:
+    post:
+      tags:
+        - tag3
+      operationId: Bar_create
+      description: one operation tag
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '204':
+          description: >-
+            There is no content to send for this request, but the headers may be
+            useful. 
   /foo/{id}:
     get:
       tags:
@@ -38,39 +71,6 @@ paths:
         - tag2
       operationId: Foo_create
       description: includes namespace tag and two operations tags
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int32
-      responses:
-        '204':
-          description: >-
-            There is no content to send for this request, but the headers may be
-            useful. 
-  /bar:
-    get:
-      operationId: Bar_list
-      description: no tags
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Resp'
-                x-cadl-name: Resp[]
-  /bar/{id}:
-    post:
-      tags:
-        - tag3
-      operationId: Bar_create
-      description: one operation tag
       parameters:
         - name: id
           in: path

--- a/packages/samples/test/output/testserver/body-boolean/openapi.yaml
+++ b/packages/samples/test/output/testserver/body-boolean/openapi.yaml
@@ -4,46 +4,6 @@ info:
   version: '0000-00-00'
 tags: []
 paths:
-  /bool/true:
-    get:
-      operationId: bool_getTrue
-      description: Get true Boolean value
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                type: boolean
-                enum:
-                  - true
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-    put:
-      operationId: bool_putTrue
-      description: Set Boolean value true
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: boolean
-              enum:
-                - true
   /bool/false:
     get:
       operationId: bool_getFalse
@@ -88,24 +48,6 @@ paths:
               type: boolean
               enum:
                 - false
-  /bool/null:
-    get:
-      operationId: bool_getNull
-      description: Get null Boolean value
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                type: boolean
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
   /bool/invalid:
     get:
       operationId: bool_getInvalid
@@ -124,6 +66,64 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /bool/null:
+    get:
+      operationId: bool_getNull
+      description: Get null Boolean value
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: boolean
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /bool/true:
+    get:
+      operationId: bool_getTrue
+      description: Get true Boolean value
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: boolean
+                enum:
+                  - true
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      operationId: bool_putTrue
+      description: Set Boolean value true
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: boolean
+              enum:
+                - true
 components:
   schemas:
     Error:

--- a/packages/samples/test/output/testserver/body-complex/openapi.yaml
+++ b/packages/samples/test/output/testserver/body-complex/openapi.yaml
@@ -4,6 +4,42 @@ info:
   version: '0000-00-00'
 tags: []
 paths:
+  /complex/array/valid:
+    get:
+      operationId: Complex_getArray
+      description: Get complex types with array properties
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArrayWrapper'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      operationId: Complex_putArray
+      description: Put complex types with array properties
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ArrayWrapper'
   /complex/basic/valid:
     get:
       operationId: Complex_getValid
@@ -40,10 +76,10 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Basic'
-  /complex/primitive/integer:
+  /complex/dictionary/typed/valid:
     get:
-      operationId: Complex_getInt
-      description: Get complex types with integer properties
+      operationId: Dictionary_getDictionary
+      description: Get complex types with dictionary property
       parameters: []
       responses:
         '200':
@@ -51,7 +87,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntWrapper'
+                $ref: '#/components/schemas/DictionaryWrapper'
         default:
           description: An unexpected error response.
           content:
@@ -59,8 +95,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
     put:
-      operationId: Complex_putInt
-      description: Put complex types with integer properties
+      operationId: Dictionary_putArray
+      description: Put complex types with dictionary property
       parameters: []
       responses:
         '200':
@@ -75,115 +111,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IntWrapper'
-  /complex/primitive/long:
-    get:
-      operationId: Complex_getLong
-      description: Get complex types with long properties
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LongWrapper'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-    put:
-      operationId: Complex_putLong
-      description: Put complex types with long properties
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LongWrapper'
-  /complex/primitive/float:
-    get:
-      operationId: Complex_getFloat
-      description: Get complex types with float properties
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FloatWrapper'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-    put:
-      operationId: Complex_putFloat
-      description: Put complex types with float properties
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FloatWrapper'
-  /complex/primitive/double:
-    get:
-      operationId: Complex_getDouble
-      description: Get complex types with double properties
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DoubleWrapper'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-    put:
-      operationId: Complex_putDouble
-      description: Put complex types with double properties
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DoubleWrapper'
+              $ref: '#/components/schemas/DictionaryWrapper'
   /complex/primitive/bool:
     get:
       operationId: Complex_getBool
@@ -220,10 +148,10 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/BooleanWrapper'
-  /complex/primitive/string:
+  /complex/primitive/bytes:
     get:
-      operationId: Complex_getString
-      description: Get complex types with string properties
+      operationId: Complex_getBytes
+      description: Get complex types with bytes properties
       parameters: []
       responses:
         '200':
@@ -231,7 +159,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/StringWrapper'
+                $ref: '#/components/schemas/BytesWrapper'
         default:
           description: An unexpected error response.
           content:
@@ -239,8 +167,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
     put:
-      operationId: Complex_putString
-      description: Put complex types with string properties
+      operationId: Complex_putBytes
+      description: Put complex types with bytes properties
       parameters: []
       responses:
         '200':
@@ -255,7 +183,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/StringWrapper'
+              $ref: '#/components/schemas/BytesWrapper'
   /complex/primitive/date:
     get:
       operationId: Complex_getPlainDate
@@ -328,6 +256,42 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/DateTimeWrapper'
+  /complex/primitive/double:
+    get:
+      operationId: Complex_getDouble
+      description: Get complex types with double properties
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DoubleWrapper'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      operationId: Complex_putDouble
+      description: Put complex types with double properties
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DoubleWrapper'
   /complex/primitive/duration:
     get:
       operationId: Complex_getZonedDuration
@@ -364,10 +328,10 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/DurationWrapper'
-  /complex/primitive/bytes:
+  /complex/primitive/float:
     get:
-      operationId: Complex_getBytes
-      description: Get complex types with bytes properties
+      operationId: Complex_getFloat
+      description: Get complex types with float properties
       parameters: []
       responses:
         '200':
@@ -375,7 +339,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BytesWrapper'
+                $ref: '#/components/schemas/FloatWrapper'
         default:
           description: An unexpected error response.
           content:
@@ -383,8 +347,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
     put:
-      operationId: Complex_putBytes
-      description: Put complex types with bytes properties
+      operationId: Complex_putFloat
+      description: Put complex types with float properties
       parameters: []
       responses:
         '200':
@@ -399,11 +363,11 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BytesWrapper'
-  /complex/array/valid:
+              $ref: '#/components/schemas/FloatWrapper'
+  /complex/primitive/integer:
     get:
-      operationId: Complex_getArray
-      description: Get complex types with array properties
+      operationId: Complex_getInt
+      description: Get complex types with integer properties
       parameters: []
       responses:
         '200':
@@ -411,7 +375,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ArrayWrapper'
+                $ref: '#/components/schemas/IntWrapper'
         default:
           description: An unexpected error response.
           content:
@@ -419,8 +383,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
     put:
-      operationId: Complex_putArray
-      description: Put complex types with array properties
+      operationId: Complex_putInt
+      description: Put complex types with integer properties
       parameters: []
       responses:
         '200':
@@ -435,11 +399,11 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ArrayWrapper'
-  /complex/dictionary/typed/valid:
+              $ref: '#/components/schemas/IntWrapper'
+  /complex/primitive/long:
     get:
-      operationId: Dictionary_getDictionary
-      description: Get complex types with dictionary property
+      operationId: Complex_getLong
+      description: Get complex types with long properties
       parameters: []
       responses:
         '200':
@@ -447,7 +411,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DictionaryWrapper'
+                $ref: '#/components/schemas/LongWrapper'
         default:
           description: An unexpected error response.
           content:
@@ -455,8 +419,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
     put:
-      operationId: Dictionary_putArray
-      description: Put complex types with dictionary property
+      operationId: Complex_putLong
+      description: Put complex types with long properties
       parameters: []
       responses:
         '200':
@@ -471,9 +435,55 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DictionaryWrapper'
+              $ref: '#/components/schemas/LongWrapper'
+  /complex/primitive/string:
+    get:
+      operationId: Complex_getString
+      description: Get complex types with string properties
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StringWrapper'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      operationId: Complex_putString
+      description: Put complex types with string properties
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StringWrapper'
 components:
   schemas:
+    ArrayWrapper:
+      type: object
+      properties:
+        field:
+          type: array
+          items:
+            type: string
+          x-cadl-name: string[]
+      required:
+        - field
     Basic:
       type: object
       properties:
@@ -494,6 +504,74 @@ components:
         - id
         - name
         - color
+    BooleanWrapper:
+      type: object
+      properties:
+        field_true:
+          type: boolean
+        field_false:
+          type: boolean
+      required:
+        - field_true
+        - field_false
+    BytesWrapper:
+      type: object
+      properties:
+        field:
+          type: string
+          format: byte
+      required:
+        - field
+    CMYKColors:
+      type: string
+      enum:
+        - cyan
+        - Magenta
+        - YELLOW
+        - blacK
+    DateTimeWrapper:
+      type: object
+      properties:
+        field:
+          type: string
+          format: date-time
+        now:
+          type: string
+          format: date-time
+      required:
+        - field
+        - now
+    DictionaryWrapper:
+      type: object
+      properties:
+        field:
+          type: object
+          additionalProperties:
+            type: string
+          x-cadl-name: Record<string>
+      required:
+        - field
+    DoubleWrapper:
+      type: object
+      properties:
+        field1:
+          type: number
+          format: double
+        field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose:
+          type: number
+          format: double
+      required:
+        - field1
+        - >-
+          field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
+    DurationWrapper:
+      type: object
+      properties:
+        field:
+          type: string
+          format: duration
+      required:
+        - field
     Error:
       type: object
       properties:
@@ -502,6 +580,18 @@ components:
       description: Error
       required:
         - message
+    FloatWrapper:
+      type: object
+      properties:
+        field1:
+          type: number
+          format: float
+        field2:
+          type: number
+          format: float
+      required:
+        - field1
+        - field2
     IntWrapper:
       type: object
       properties:
@@ -526,41 +616,43 @@ components:
       required:
         - field1
         - field2
-    FloatWrapper:
+    Pet:
       type: object
       properties:
-        field1:
-          type: number
-          format: float
-        field2:
-          type: number
-          format: float
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
       required:
-        - field1
-        - field2
-    DoubleWrapper:
+        - id
+        - name
+    PlainDateWrapper:
       type: object
       properties:
-        field1:
-          type: number
-          format: double
-        field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose:
-          type: number
-          format: double
+        field:
+          type: string
+          format: date
+        leap:
+          type: string
+          format: date
       required:
-        - field1
-        - >-
-          field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose
-    BooleanWrapper:
+        - field
+        - leap
+    ReadonlyObj:
       type: object
       properties:
-        field_true:
-          type: boolean
-        field_false:
-          type: boolean
+        id:
+          type: integer
+          format: int32
+          readOnly: true
+        size:
+          type: integer
+          format: int32
+          readOnly: true
       required:
-        - field_true
-        - field_false
+        - id
+        - size
     StringWrapper:
       type: object
       properties:
@@ -576,95 +668,3 @@ components:
         - field
         - empty
         - 'null'
-    PlainDateWrapper:
-      type: object
-      properties:
-        field:
-          type: string
-          format: date
-        leap:
-          type: string
-          format: date
-      required:
-        - field
-        - leap
-    DateTimeWrapper:
-      type: object
-      properties:
-        field:
-          type: string
-          format: date-time
-        now:
-          type: string
-          format: date-time
-      required:
-        - field
-        - now
-    DurationWrapper:
-      type: object
-      properties:
-        field:
-          type: string
-          format: duration
-      required:
-        - field
-    BytesWrapper:
-      type: object
-      properties:
-        field:
-          type: string
-          format: byte
-      required:
-        - field
-    ArrayWrapper:
-      type: object
-      properties:
-        field:
-          type: array
-          items:
-            type: string
-          x-cadl-name: string[]
-      required:
-        - field
-    DictionaryWrapper:
-      type: object
-      properties:
-        field:
-          type: object
-          additionalProperties:
-            type: string
-          x-cadl-name: Record<string>
-      required:
-        - field
-    CMYKColors:
-      type: string
-      enum:
-        - cyan
-        - Magenta
-        - YELLOW
-        - blacK
-    Pet:
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int32
-        name:
-          type: string
-      required:
-        - id
-        - name
-    ReadonlyObj:
-      type: object
-      properties:
-        id:
-          type: integer
-          format: int32
-          readOnly: true
-        size:
-          type: integer
-          format: int32
-          readOnly: true
-      required:
-        - id
-        - size

--- a/packages/samples/test/output/testserver/body-string/openapi.yaml
+++ b/packages/samples/test/output/testserver/body-string/openapi.yaml
@@ -5,12 +5,12 @@ info:
 tags:
   - name: String Operations
 paths:
-  /string/null:
+  /string/base64Encoding:
     get:
       tags:
         - String Operations
-      operationId: String_getNull
-      description: Get null string value
+      operationId: String_getBase64Encoding
+      description: Get value that is base64 encoded
       parameters: []
       responses:
         '200':
@@ -19,8 +19,7 @@ paths:
             application/json:
               schema:
                 type: string
-                nullable: true
-                x-cadl-name: string | null
+                format: byte
         default:
           description: An unexpected error response.
           content:
@@ -30,8 +29,8 @@ paths:
     put:
       tags:
         - String Operations
-      operationId: String_putNull
-      description: Put null string value
+      operationId: String_putBase64Encoding
+      description: Put value that is base64 encoded
       parameters: []
       responses:
         '200':
@@ -47,8 +46,7 @@ paths:
           application/json:
             schema:
               type: string
-              nullable: true
-              x-cadl-name: string | null
+              format: byte
   /string/empty:
     get:
       tags:
@@ -93,6 +91,86 @@ paths:
               type: string
               enum:
                 - ''
+  /string/enum/constant:
+    get:
+      tags:
+        - String Operations
+      operationId: Enums_getConstant
+      description: Gets value 'green-color' from a constant
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Colors'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      tags:
+        - String Operations
+      operationId: Enums_putConstant
+      description: Sends value 'green-color' from a constant
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Colors'
+  /string/enum/empty:
+    get:
+      tags:
+        - String Operations
+      operationId: Enums_getNotExpandable
+      description: Get non expandable string enum value
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Colors'
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      tags:
+        - String Operations
+      operationId: Enums_putNotExpandable
+      description: Put non expandable string enum value
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Colors'
   /string/mbcs:
     get:
       tags:
@@ -143,6 +221,50 @@ paths:
               enum:
                 - >-
                   啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€
+  /string/null:
+    get:
+      tags:
+        - String Operations
+      operationId: String_getNull
+      description: Get null string value
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: string
+                nullable: true
+                x-cadl-name: string | null
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+    put:
+      tags:
+        - String Operations
+      operationId: String_putNull
+      description: Put null string value
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+        default:
+          description: An unexpected error response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+              nullable: true
+              x-cadl-name: string | null
   /string/whitespace:
     get:
       tags:
@@ -193,130 +315,14 @@ paths:
               type: string
               enum:
                 - '   Now is the time for all good men to come to the aid of their country    '
-  /string/base64Encoding:
-    get:
-      tags:
-        - String Operations
-      operationId: String_getBase64Encoding
-      description: Get value that is base64 encoded
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                type: string
-                format: byte
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-    put:
-      tags:
-        - String Operations
-      operationId: String_putBase64Encoding
-      description: Put value that is base64 encoded
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: string
-              format: byte
-  /string/enum/empty:
-    get:
-      tags:
-        - String Operations
-      operationId: Enums_getNotExpandable
-      description: Get non expandable string enum value
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Colors'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-    put:
-      tags:
-        - String Operations
-      operationId: Enums_putNotExpandable
-      description: Put non expandable string enum value
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Colors'
-  /string/enum/constant:
-    get:
-      tags:
-        - String Operations
-      operationId: Enums_getConstant
-      description: Gets value 'green-color' from a constant
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Colors'
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-    put:
-      tags:
-        - String Operations
-      operationId: Enums_putConstant
-      description: Sends value 'green-color' from a constant
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-        default:
-          description: An unexpected error response.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Colors'
 components:
   schemas:
+    Colors:
+      type: string
+      enum:
+        - red color
+        - green-color
+        - blue-color
     Error:
       type: object
       properties:
@@ -329,9 +335,3 @@ components:
       required:
         - status
         - message
-    Colors:
-      type: string
-      enum:
-        - red color
-        - green-color
-        - blue-color

--- a/packages/samples/test/output/testserver/media-types/openapi.yaml
+++ b/packages/samples/test/output/testserver/media-types/openapi.yaml
@@ -56,6 +56,15 @@ paths:
               $ref: '#/components/schemas/SourcePath'
 components:
   schemas:
+    Input:
+      type: object
+      properties:
+        input:
+          allOf:
+            - $ref: '#/components/schemas/SourcePath'
+          description: Input parameter.
+      required:
+        - input
     SourcePath:
       type: object
       properties:
@@ -67,12 +76,3 @@ components:
       description: Uri or local path to source data.
       required:
         - source
-    Input:
-      type: object
-      properties:
-        input:
-          allOf:
-            - $ref: '#/components/schemas/SourcePath'
-          description: Input parameter.
-      required:
-        - input

--- a/packages/samples/test/output/testserver/multiple-inheritance/openapi.yaml
+++ b/packages/samples/test/output/testserver/multiple-inheritance/openapi.yaml
@@ -4,126 +4,6 @@ info:
   version: '0000-00-00'
 tags: []
 paths:
-  /multipleInheritance/horse:
-    get:
-      operationId: MultipleInheritance_getHorse
-      description: Get a horse with name 'Fred' and isAShowHorse true
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Horse'
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                type: string
-    put:
-      operationId: MultipleInheritance_putHorse
-      description: Put a horse with name 'General' and isAShowHorse false
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                type: string
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Horse'
-  /multipleInheritance/pet:
-    get:
-      operationId: MultipleInheritance_getPet
-      description: Get a pet with name 'Peanut'
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Pet'
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                type: string
-    put:
-      operationId: MultipleInheritance_putPet
-      description: Put a pet with name 'Butter'
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                type: string
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Pet'
-  /multipleInheritance/feline:
-    get:
-      operationId: MultipleInheritance_getFeline
-      description: Get a feline where meows and hisses are true
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Feline'
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                type: string
-    put:
-      operationId: MultipleInheritance_putFeline
-      description: Put a feline who hisses and doesn't meow
-      parameters: []
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                type: string
-        default:
-          description: Unexpected error
-          content:
-            application/json:
-              schema:
-                type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Feline'
   /multipleInheritance/cat:
     get:
       operationId: MultipleInheritance_getCat
@@ -168,6 +48,86 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Cat'
+  /multipleInheritance/feline:
+    get:
+      operationId: MultipleInheritance_getFeline
+      description: Get a feline where meows and hisses are true
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Feline'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                type: string
+    put:
+      operationId: MultipleInheritance_putFeline
+      description: Put a feline who hisses and doesn't meow
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Feline'
+  /multipleInheritance/horse:
+    get:
+      operationId: MultipleInheritance_getHorse
+      description: Get a horse with name 'Fred' and isAShowHorse true
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Horse'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                type: string
+    put:
+      operationId: MultipleInheritance_putHorse
+      description: Put a horse with name 'General' and isAShowHorse false
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Horse'
   /multipleInheritance/kitten:
     get:
       operationId: MultipleInheritance_getKitten
@@ -212,24 +172,65 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Kitten'
+  /multipleInheritance/pet:
+    get:
+      operationId: MultipleInheritance_getPet
+      description: Get a pet with name 'Peanut'
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                type: string
+    put:
+      operationId: MultipleInheritance_putPet
+      description: Put a pet with name 'Butter'
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
 components:
   schemas:
-    Horse:
+    Cat:
       type: object
       properties:
-        isAShowHorse:
+        likesMilk:
           type: boolean
       required:
-        - isAShowHorse
+        - likesMilk
       allOf:
-        - $ref: '#/components/schemas/Pet'
-    Pet:
+        - $ref: '#/components/schemas/Feline'
+    ErrorResponse:
       type: object
       properties:
-        name:
+        body:
           type: string
+      description: Unexpected error
       required:
-        - name
+        - body
     Feline:
       type: object
       properties:
@@ -242,15 +243,15 @@ components:
         - hisses
       allOf:
         - $ref: '#/components/schemas/Pet'
-    Cat:
+    Horse:
       type: object
       properties:
-        likesMilk:
+        isAShowHorse:
           type: boolean
       required:
-        - likesMilk
+        - isAShowHorse
       allOf:
-        - $ref: '#/components/schemas/Feline'
+        - $ref: '#/components/schemas/Pet'
     Kitten:
       type: object
       properties:
@@ -260,11 +261,10 @@ components:
         - eatsMiceYet
       allOf:
         - $ref: '#/components/schemas/Cat'
-    ErrorResponse:
+    Pet:
       type: object
       properties:
-        body:
+        name:
           type: string
-      description: Unexpected error
       required:
-        - body
+        - name

--- a/packages/samples/test/output/versioning/openapi.v1.yaml
+++ b/packages/samples/test/output/versioning/openapi.v1.yaml
@@ -36,34 +36,9 @@ components:
           - v1
           - v2
   schemas:
-    PetBase:
-      type: object
-      properties:
-        type:
-          type: string
-          description: Discriminator property for PetBase.
-        name:
-          type: string
-        favoriteToys:
-          type: array
-          items:
-            $ref: '#/components/schemas/Library.PetToy'
-          x-cadl-name: Library.PetToy[]
-      discriminator:
-        propertyName: type
-        mapping:
-          dog: '#/components/schemas/Dog'
-      required:
-        - name
-        - favoriteToys
     ApiVersionParam:
       type: object
       properties: {}
-    Versions:
-      type: string
-      enum:
-        - v1
-        - v2
     Dog:
       type: object
       properties:
@@ -89,3 +64,28 @@ components:
           type: string
       required:
         - name
+    PetBase:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Discriminator property for PetBase.
+        name:
+          type: string
+        favoriteToys:
+          type: array
+          items:
+            $ref: '#/components/schemas/Library.PetToy'
+          x-cadl-name: Library.PetToy[]
+      discriminator:
+        propertyName: type
+        mapping:
+          dog: '#/components/schemas/Dog'
+      required:
+        - name
+        - favoriteToys
+    Versions:
+      type: string
+      enum:
+        - v1
+        - v2

--- a/packages/samples/test/output/versioning/openapi.v2.yaml
+++ b/packages/samples/test/output/versioning/openapi.v2.yaml
@@ -36,35 +36,24 @@ components:
           - v1
           - v2
   schemas:
-    PetBase:
+    ApiVersionParam:
+      type: object
+      properties: {}
+    Cat:
       type: object
       properties:
         type:
           type: string
-          description: Discriminator property for PetBase.
-        name:
-          type: string
-        favoriteToys:
-          type: array
-          items:
-            $ref: '#/components/schemas/Library.PetToy'
-          x-cadl-name: Library.PetToy[]
-      discriminator:
-        propertyName: type
-        mapping:
-          dog: '#/components/schemas/Dog'
-          cat: '#/components/schemas/Cat'
+          enum:
+            - cat
+        catnipDose:
+          type: integer
+          format: int32
       required:
-        - name
-        - favoriteToys
-    ApiVersionParam:
-      type: object
-      properties: {}
-    Versions:
-      type: string
-      enum:
-        - v1
-        - v2
+        - type
+        - catnipDose
+      allOf:
+        - $ref: '#/components/schemas/PetBase'
     Dog:
       type: object
       properties:
@@ -88,21 +77,6 @@ components:
         - commandList
       allOf:
         - $ref: '#/components/schemas/PetBase'
-    Cat:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - cat
-        catnipDose:
-          type: integer
-          format: int32
-      required:
-        - type
-        - catnipDose
-      allOf:
-        - $ref: '#/components/schemas/PetBase'
     Library.PetToy:
       type: object
       properties:
@@ -113,3 +87,29 @@ components:
       required:
         - name
         - material
+    PetBase:
+      type: object
+      properties:
+        type:
+          type: string
+          description: Discriminator property for PetBase.
+        name:
+          type: string
+        favoriteToys:
+          type: array
+          items:
+            $ref: '#/components/schemas/Library.PetToy'
+          x-cadl-name: Library.PetToy[]
+      discriminator:
+        propertyName: type
+        mapping:
+          dog: '#/components/schemas/Dog'
+          cat: '#/components/schemas/Cat'
+      required:
+        - name
+        - favoriteToys
+    Versions:
+      type: string
+      enum:
+        - v1
+        - v2

--- a/packages/samples/test/output/visibility/openapi.yaml
+++ b/packages/samples/test/output/visibility/openapi.yaml
@@ -4,31 +4,6 @@ info:
   version: '0000-00-00'
 tags: []
 paths:
-  /hello/{id}:
-    get:
-      operationId: Hello_read
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: fieldMask
-          in: query
-          style: form
-          explode: true
-          required: true
-          schema:
-            type: array
-            items:
-              type: string
-      responses:
-        '200':
-          description: The request has succeeded.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ReadablePersonRead'
   /hello:
     post:
       operationId: Hello_create
@@ -94,37 +69,41 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PersonUpdate'
+  /hello/{id}:
+    get:
+      operationId: Hello_read
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: fieldMask
+          in: query
+          style: form
+          explode: true
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReadablePersonRead'
 components:
   schemas:
-    ReadablePersonRead:
+    OptionalPerson:
       type: object
       properties:
         id:
           type: string
           readOnly: true
-        name:
+        secret:
           type: string
-        test:
-          type: string
-        other:
-          type: string
-        relatives:
-          type: array
-          items:
-            $ref: '#/components/schemas/PersonRelativeReadItem'
-          x-cadl-name: PersonRelative[]
-      required:
-        - id
-        - name
-        - test
-        - other
-        - relatives
-    ReadablePerson:
-      type: object
-      properties:
-        id:
-          type: string
-          readOnly: true
         name:
           type: string
         test:
@@ -135,99 +114,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PersonRelative'
-          x-cadl-name: PersonRelative[]
-      required:
-        - id
-        - name
-        - test
-        - other
-        - relatives
-    WritablePersonCreate:
-      type: object
-      properties:
-        secret:
-          type: string
-        name:
-          type: string
-        test:
-          type: string
-        relatives:
-          type: array
-          items:
-            $ref: '#/components/schemas/PersonRelativeCreateItem'
-          x-cadl-name: PersonRelative[]
-      required:
-        - secret
-        - name
-        - test
-        - relatives
-    WritablePerson:
-      type: object
-      properties:
-        secret:
-          type: string
-        name:
-          type: string
-        test:
-          type: string
-        relatives:
-          type: array
-          items:
-            $ref: '#/components/schemas/PersonRelative'
-          x-cadl-name: PersonRelative[]
-      required:
-        - secret
-        - name
-        - test
-        - relatives
-    WriteableOptionalPerson:
-      type: object
-      properties:
-        secret:
-          type: string
-        name:
-          type: string
-        test:
-          type: string
-        relatives:
-          type: array
-          items:
-            $ref: '#/components/schemas/PersonRelative'
-          x-cadl-name: PersonRelative[]
-    PersonReadItem:
-      type: object
-      properties:
-        id:
-          type: string
-          readOnly: true
-        name:
-          type: string
-        test:
-          type: string
-        other:
-          type: string
-        relatives:
-          type: array
-          items:
-            $ref: '#/components/schemas/PersonRelativeReadItem'
-          x-cadl-name: PersonRelative[]
-      required:
-        - id
-        - name
-        - test
-        - other
-        - relatives
-    PersonUpdate:
-      type: object
-      properties:
-        name:
-          type: string
-        other:
-          type: string
-        relatives:
-          type: array
-          items:
-            $ref: '#/components/schemas/PersonRelativeUpdateItem'
           x-cadl-name: PersonRelative[]
     Person:
       type: object
@@ -274,6 +160,81 @@ components:
         - name
         - test
         - relatives
+    PersonReadItem:
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+        name:
+          type: string
+        test:
+          type: string
+        other:
+          type: string
+        relatives:
+          type: array
+          items:
+            $ref: '#/components/schemas/PersonRelativeReadItem'
+          x-cadl-name: PersonRelative[]
+      required:
+        - id
+        - name
+        - test
+        - other
+        - relatives
+    PersonRelative:
+      type: object
+      properties:
+        person:
+          $ref: '#/components/schemas/Person'
+        relationship:
+          type: string
+      required:
+        - person
+        - relationship
+    PersonRelativeCreateItem:
+      type: object
+      properties:
+        person:
+          $ref: '#/components/schemas/PersonCreateItem'
+        relationship:
+          type: string
+      required:
+        - person
+        - relationship
+    PersonRelativeReadItem:
+      type: object
+      properties:
+        person:
+          $ref: '#/components/schemas/PersonReadItem'
+        relationship:
+          type: string
+      required:
+        - person
+        - relationship
+    PersonRelativeUpdateItem:
+      type: object
+      properties:
+        person:
+          $ref: '#/components/schemas/PersonUpdateItem'
+        relationship:
+          type: string
+      required:
+        - person
+        - relationship
+    PersonUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+        other:
+          type: string
+        relatives:
+          type: array
+          items:
+            $ref: '#/components/schemas/PersonRelativeUpdateItem'
+          x-cadl-name: PersonRelative[]
     PersonUpdateItem:
       type: object
       properties:
@@ -290,59 +251,98 @@ components:
         - name
         - other
         - relatives
-    PersonRelative:
-      type: object
-      properties:
-        person:
-          $ref: '#/components/schemas/Person'
-        relationship:
-          type: string
-      required:
-        - person
-        - relationship
-    PersonRelativeReadItem:
-      type: object
-      properties:
-        person:
-          $ref: '#/components/schemas/PersonReadItem'
-        relationship:
-          type: string
-      required:
-        - person
-        - relationship
-    PersonRelativeCreateItem:
-      type: object
-      properties:
-        person:
-          $ref: '#/components/schemas/PersonCreateItem'
-        relationship:
-          type: string
-      required:
-        - person
-        - relationship
-    PersonRelativeUpdateItem:
-      type: object
-      properties:
-        person:
-          $ref: '#/components/schemas/PersonUpdateItem'
-        relationship:
-          type: string
-      required:
-        - person
-        - relationship
-    OptionalPerson:
+    ReadablePerson:
       type: object
       properties:
         id:
           type: string
           readOnly: true
+        name:
+          type: string
+        test:
+          type: string
+        other:
+          type: string
+        relatives:
+          type: array
+          items:
+            $ref: '#/components/schemas/PersonRelative'
+          x-cadl-name: PersonRelative[]
+      required:
+        - id
+        - name
+        - test
+        - other
+        - relatives
+    ReadablePersonRead:
+      type: object
+      properties:
+        id:
+          type: string
+          readOnly: true
+        name:
+          type: string
+        test:
+          type: string
+        other:
+          type: string
+        relatives:
+          type: array
+          items:
+            $ref: '#/components/schemas/PersonRelativeReadItem'
+          x-cadl-name: PersonRelative[]
+      required:
+        - id
+        - name
+        - test
+        - other
+        - relatives
+    WritablePerson:
+      type: object
+      properties:
         secret:
           type: string
         name:
           type: string
         test:
           type: string
-        other:
+        relatives:
+          type: array
+          items:
+            $ref: '#/components/schemas/PersonRelative'
+          x-cadl-name: PersonRelative[]
+      required:
+        - secret
+        - name
+        - test
+        - relatives
+    WritablePersonCreate:
+      type: object
+      properties:
+        secret:
+          type: string
+        name:
+          type: string
+        test:
+          type: string
+        relatives:
+          type: array
+          items:
+            $ref: '#/components/schemas/PersonRelativeCreateItem'
+          x-cadl-name: PersonRelative[]
+      required:
+        - secret
+        - name
+        - test
+        - relatives
+    WriteableOptionalPerson:
+      type: object
+      properties:
+        secret:
+          type: string
+        name:
+          type: string
+        test:
           type: string
         relatives:
           type: array


### PR DESCRIPTION
We did this already in cadl-autorest long ago but never OpenAPI 3. I am proposing we do the same for OpenAPI 3. The fix for #1355 caused a bunch of re-ordering and it will be hard to review without this. I think we want to minimally change our emit output as algorithms in the emitter evolve and sorting the output is the simplest way to ensure that.