### PR TITLE
Emitter framework updates

### DIFF
--- a/common/changes/@cadl-lang/compiler/emitter-framework-updates_2023-02-06-21-48.json
+++ b/common/changes/@cadl-lang/compiler/emitter-framework-updates_2023-02-06-21-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Add `arrayDeclaration` and `arrayLiteral` methods to emitter framework's TypeEmitter",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}

--- a/packages/compiler/core/checker.ts
+++ b/packages/compiler/core/checker.ts
@@ -240,7 +240,7 @@ const TypeInstantiationMap = class
   extends MultiKeyMap<readonly Type[], Type>
   implements TypeInstantiationMap {};
 
-type StdTypeName = IntrinsicScalarName | "Array" | "Record";
+type StdTypeName = IntrinsicScalarName | "Array" | "Record" | "object";
 type StdTypes = {
   // Models
   Array: Model;
@@ -4854,6 +4854,7 @@ export function createChecker(program: Program): Checker {
     if (type.kind === "Scalar") return stdType === undefined || stdType === type.name;
     if (stdType === "Array" && type === stdTypes["Array"]) return true;
     if (stdType === "Record" && type === stdTypes["Record"]) return true;
+    if (type.kind === "Model") return stdType === undefined || stdType === type.name;
     return false;
   }
 }

--- a/packages/compiler/core/program.ts
+++ b/packages/compiler/core/program.ts
@@ -758,7 +758,7 @@ export async function compile(
       emitterOutputDir: emitter.emitterOutputDir,
       options: emitter.options,
       getAssetEmitter(TypeEmitterClass) {
-        return createAssetEmitter(program, TypeEmitterClass);
+        return createAssetEmitter(program, TypeEmitterClass, this);
       },
     };
     try {

--- a/packages/compiler/core/types.ts
+++ b/packages/compiler/core/types.ts
@@ -1789,7 +1789,7 @@ export interface EmitContext<TOptions extends object = Record<string, never>> {
    *
    * @param TypeEmitterClass The TypeEmitter to construct your emitted output
    */
-  getAssetEmitter<T>(TypeEmitterClass: typeof TypeEmitter<T>): AssetEmitter<T>;
+  getAssetEmitter<T>(TypeEmitterClass: typeof TypeEmitter<T, TOptions>): AssetEmitter<T, TOptions>;
 }
 
 export type LogLevel = "trace" | "warning" | "error";

--- a/packages/compiler/emitter-framework/asset-emitter.ts
+++ b/packages/compiler/emitter-framework/asset-emitter.ts
@@ -1,10 +1,10 @@
-import { join as joinPath } from "path";
 import {
   compilerAssert,
   EmitContext,
   emitFile,
   IntrinsicType,
   isTemplateDeclaration,
+  joinPaths,
   Model,
   Namespace,
   Program,
@@ -170,7 +170,7 @@ export function createAssetEmitter<T, TOptions extends object>(
       const basePath = options.emitterOutputDir;
       const sourceFile = {
         globalScope: undefined as any,
-        path: joinPath(basePath, path),
+        path: joinPaths(basePath, path),
         imports: new Map(),
       };
       sourceFile.globalScope = this.createScope(sourceFile, "");

--- a/packages/compiler/emitter-framework/type-emitter.ts
+++ b/packages/compiler/emitter-framework/type-emitter.ts
@@ -144,7 +144,7 @@ export type EmitterOutput<T> = EmitEntity<T> | Placeholder<T> | T;
  * And we set reference context for the Person model, Pet will be emitted twice,
  * once without context and once with the reference context.
  */
-export class TypeEmitter<T> {
+export class TypeEmitter<T, TOptions extends object = Record<string, never>> {
   /**
    * @private
    *
@@ -152,7 +152,7 @@ export class TypeEmitter<T> {
    * call `createAssetEmitter` on the emitter context object.
    * @param emitter The asset emitter
    */
-  constructor(protected emitter: AssetEmitter<T>) {}
+  constructor(protected emitter: AssetEmitter<T, TOptions>) {}
 
   /**
    * Context shared by the entire program. In cases where you are emitting to a
@@ -370,6 +370,32 @@ export class TypeEmitter<T> {
    */
   modelPropertyReference(property: ModelProperty): EmitterOutput<T> {
     return this.emitter.emitTypeReference(property.type);
+  }
+
+  arrayDeclaration(array: Model, name: string, elementType: Type): EmitterOutput<T> {
+    this.emitter.emitType(array.indexer!.value);
+    return this.emitter.result.none();
+  }
+
+  arrayDeclarationContext(array: Model): Context {
+    return {};
+  }
+
+  arrayDeclarationReferenceContext(array: Model): Context {
+    this.emitter.emitType(array.indexer!.value);
+    return {};
+  }
+
+  arrayLiteral(array: Model, elementType: Type): EmitterOutput<T> {
+    return this.emitter.result.none();
+  }
+
+  arrayLiteralContext(array: Model): Context {
+    return {};
+  }
+
+  arrayLiteralReferenceContext(array: Model): Context {
+    return {};
   }
 
   scalarDeclaration(scalar: Scalar, name: string): EmitterOutput<T> {
@@ -660,7 +686,10 @@ export class TypeEmitter<T> {
  * by commas. It will also construct references by concatenating namespace elements together
  * with `.` which should work nicely in many object oriented languages.
  */
-export class CodeTypeEmitter extends TypeEmitter<string> {
+export class CodeTypeEmitter<TOptions extends object = Record<string, never>> extends TypeEmitter<
+  string,
+  TOptions
+> {
   modelProperties(model: Model): EmitterOutput<string> {
     const builder = new StringBuilder();
     let i = 0;

--- a/packages/compiler/emitter-framework/types.ts
+++ b/packages/compiler/emitter-framework/types.ts
@@ -11,8 +11,12 @@ import {
   Union,
 } from "../core/index.js";
 import { Placeholder } from "./placeholder.js";
+type AssetEmitterOptions<TOptions extends object> = {
+  noEmit: boolean;
+  emitterOutputDir: string;
+} & TOptions;
 
-export interface AssetEmitter<T> {
+export interface AssetEmitter<T, TOptions extends object = Record<string, unknown>> {
   /**
    * Get the current emitter context as set by the TypeEmitter's various
    * context methods.
@@ -20,7 +24,7 @@ export interface AssetEmitter<T> {
    * @returns The current emitter context
    */
   getContext(): Context;
-  getOptions(): Record<string, unknown>;
+  getOptions(): AssetEmitterOptions<TOptions>;
   getProgram(): Program;
   emitTypeReference(type: Type): EmitEntity<T>;
   emitDeclarationName(type: CadlDeclaration): string;
@@ -35,6 +39,12 @@ export interface AssetEmitter<T> {
   emitEnumMembers(en: Enum): EmitEntity<T>;
   emitUnionVariants(union: Union): EmitEntity<T>;
   emitTupleLiteralValues(tuple: Tuple): EmitEntity<T>;
+
+  /**
+   * Create a source file.
+   *
+   * @param name the path of the file, resolved relative to the emitter's output directory.
+   */
   createSourceFile(name: string): SourceFile<T>;
   createScope(sourceFile: SourceFile<T>, name: string): SourceFileScope<T>;
   createScope(namespace: any, name: string, parentScope: Scope<T>): NamespaceScope<T>;

--- a/packages/compiler/test/emitter-framework/host.ts
+++ b/packages/compiler/test/emitter-framework/host.ts
@@ -43,7 +43,10 @@ export async function emitCadl(
   validateCallCounts = true
 ) {
   const host = await getHostForCadlFile(code);
-  const emitter = createAssetEmitter(host.program, Emitter);
+  const emitter = createAssetEmitter(host.program, Emitter, {
+    emitterOutputDir: "cadl-output",
+    options: {},
+  } as any);
   const spies = emitterSpies(Emitter);
   emitter.emitProgram();
   await emitter.writeOutput();
@@ -54,7 +57,7 @@ export async function emitCadl(
 }
 
 type EmitterSpies = Record<string, SinonSpy>;
-function emitterSpies(emitter: typeof TypeEmitter) {
+function emitterSpies(emitter: typeof TypeEmitter<any, any>) {
   const spies: EmitterSpies = {};
   const methods = Object.getOwnPropertyNames(emitter.prototype);
   for (const key of methods) {

--- a/packages/compiler/test/emitter-framework/typescript-emitter.ts
+++ b/packages/compiler/test/emitter-framework/typescript-emitter.ts
@@ -78,20 +78,13 @@ export class TypeScriptInterfaceEmitter extends CodeTypeEmitter {
   }
 
   modelLiteral(model: Model): EmitterOutput<string> {
-    if (isArrayType(model)) {
-      return this.emitter.result.rawCode(
-        code`${this.emitter.emitTypeReference(model.indexer!.value!)}[]`
-      );
-    }
-
     return this.emitter.result.rawCode(code`{ ${this.emitter.emitModelProperties(model)}}`);
   }
 
   modelDeclaration(model: Model, name: string): EmitterOutput<string> {
     let extendsClause;
-    if (model.indexer && model.indexer.key!.name === "integer") {
-      extendsClause = code`extends Array<${this.emitter.emitTypeReference(model.indexer!.value!)}>`;
-    } else if (model.baseModel) {
+
+    if (model.baseModel) {
       extendsClause = code`extends ${this.emitter.emitTypeReference(model.baseModel)}`;
     } else {
       extendsClause = "";
@@ -137,6 +130,18 @@ export class TypeScriptInterfaceEmitter extends CodeTypeEmitter {
         property.type
       )}`
     );
+  }
+
+  arrayDeclaration(array: Model, name: string, elementType: Type): EmitterOutput<string> {
+    return this.emitter.result.declaration(
+      name,
+      code`interface ${name} extends Array<${this.emitter.emitTypeReference(elementType)}> { };`
+    );
+  }
+
+  arrayLiteral(array: Model, elementType: Type): EmitterOutput<string> {
+    // we always parenthesize here as prettier will remove the unneeded parens.
+    return this.emitter.result.rawCode(code`(${this.emitter.emitTypeReference(elementType)})[]`);
   }
 
   operationDeclaration(operation: Operation, name: string): EmitterOutput<string> {

--- a/rush.json
+++ b/rush.json
@@ -186,6 +186,12 @@
       "projectFolder": "packages/ref-doc",
       "reviewCategory": "production",
       "shouldPublish": false
+    },
+    {
+      "packageName": "@cadl-lang/json-schema",
+      "projectFolder": "packages/json-schema",
+      "reviewCategory": "production",
+      "shouldPublish": true
     }
   ]
 }

--- a/rush.json
+++ b/rush.json
@@ -186,12 +186,6 @@
       "projectFolder": "packages/ref-doc",
       "reviewCategory": "production",
       "shouldPublish": false
-    },
-    {
-      "packageName": "@cadl-lang/json-schema",
-      "projectFolder": "packages/json-schema",
-      "reviewCategory": "production",
-      "shouldPublish": true
     }
   ]
 }


### PR DESCRIPTION
This PR extracts the emitter framework and other core compiler updates from #1601. In particular:

* Adds `arrayLiteral` and `arrayDeclaration` methods (and their corresponding context methods) to TypeEmitter, so emitter framework users don't need to subtly prod at models to see if they are arrays.
* Strongly types emitter options by threading a new TOptions generic parameter to a bunch of places.
* Files written by framework users are scoped to the emitter's output directory by default
* Fixes the following bugs:
  * Properly initializes the emit context's asset emitter, passing along the emitter options
  * Fixed bug with handling of circular references
  * `object` is now recognized as a std type by the `isStdType` API.