### PR TITLE
Fix a typo in the playground: Open API -> OpenAPI

### DIFF
--- a/packages/playground/src/components/openapi-output.tsx
+++ b/packages/playground/src/components/openapi-output.tsx
@@ -12,7 +12,7 @@ export interface OpenAPIOutputProps {
 export const OpenAPIOutput: FunctionComponent<OpenAPIOutputProps> = (props) => {
   const [selected, setSelected] = useState<"raw" | "swagger-ui">("raw");
   const options = [
-    { label: "Open API", value: "raw" },
+    { label: "OpenAPI", value: "raw" },
     { label: "Swagger UI", value: "swagger-ui" },
   ];
 


### PR DESCRIPTION
The name of the specification/syntax is "[OpenAPI](https://github.com/OAI/OpenAPI-Specification#readme)" - one word without a space.