### PR TITLE
Fix projection of template arguments

### DIFF
--- a/common/changes/@cadl-lang/compiler/project-templates_2023-02-14-19-32.json
+++ b/common/changes/@cadl-lang/compiler/project-templates_2023-02-14-19-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@cadl-lang/compiler",
+      "comment": "Fix projection of template arguments",
+      "type": "none"
+    }
+  ],
+  "packageName": "@cadl-lang/compiler"
+}


### PR DESCRIPTION
Some template arguments were not projected, others were only stored on deprecated templateArguments that ceased to alias templateMapper.args after projection.